### PR TITLE
[METRON-19] Enable Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,13 @@ install:
   - |
     cd metron-streaming
     mvn install -DskipTests=true
+before_script:
+  - pip install --user codecov
 script:
   - |
     cd metron-streaming
     mvn test
+after_success:
+  - codecov
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
     - $HOME/.m2
 language: java
 jdk:
+  - oraclejdk7
   - oraclejdk8
 install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+cache:
+  directories:
+    - $HOME/.m2
+language: java
+jdk:
+  - oraclejdk8
+install:
+  - |
+    cd metron-streaming
+    mvn install -DskipTests=true
+script:
+  - |
+    cd metron-streaming
+    mvn test
+notifications:
+  email: false

--- a/metron-streaming/pom.xml
+++ b/metron-streaming/pom.xml
@@ -70,7 +70,27 @@
 		</dependency>
 	</dependencies>
 	<build>
-
+		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.7.5.201505241946</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
 	<reporting>
 		<plugins>


### PR DESCRIPTION
This, combined with enabling the apache/incubator-metron repo with Travis (which must be done by someone from the apache github org), will enable testing of the `metron-streaming` code via Travis. You can see how this will look with the PR on my fork: https://github.com/reaperhulk/incubator-metron/pull/1

PRs submitted to this repo after this is enabled will be automatically tested and status will be reported back.