### PR TITLE
METRON-29: Remediate Metron-Alerts unit tests for JUnit 4

### DIFF
--- a/metron-streaming/Metron-Alerts/pom.xml
+++ b/metron-streaming/Metron-Alerts/pom.xml
@@ -22,7 +22,7 @@
 	<description>Taggers for alerts</description>
 	<properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>		
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<commons.validator.version>1.4.0</commons.validator.version>
 	</properties>
 	<dependencies>
@@ -30,6 +30,16 @@
 			<groupId>org.apache.metron</groupId>
 			<artifactId>Metron-Common</artifactId>
 			<version>${project.parent.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.json-simple</groupId>
@@ -46,7 +56,15 @@
 				   <artifactId>servlet-api</artifactId>
 				   <groupId>javax.servlet</groupId>
 				  </exclusion>
-		    </exclusions>					
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
@@ -66,6 +84,14 @@
 					<groupId>javax.jms</groupId>
 					<artifactId>jms</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -79,11 +105,11 @@
 			<version>${commons.validator.version}</version>
 			<exclusions>
 				<exclusion>
-				
+
 				<groupId>commons-beanutils</groupId>
-				
+
 				<artifactId>commons-beanutils</artifactId>
-				
+
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -102,7 +128,7 @@
 						</property>
 					</systemProperties>
 				</configuration>
-			</plugin>		
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -125,7 +151,7 @@
 				<artifactId>emma-maven-plugin</artifactId>
 				<version>1.0-alpha-3</version>
 				<inherited>true</inherited>
-			</plugin>			
+			</plugin>
 		</plugins>
 		<resources>
 			<resource>

--- a/metron-streaming/Metron-Alerts/src/test/java/org/apache/metron/alerts/adapters/AllAlertAdapterTest.java
+++ b/metron-streaming/Metron-Alerts/src/test/java/org/apache/metron/alerts/adapters/AllAlertAdapterTest.java
@@ -1,4 +1,4 @@
- /*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -16,152 +16,49 @@
  */
 package org.apache.metron.alerts.adapters;
 
-import java.lang.reflect.Constructor;
 import java.util.Map;
 import java.util.Properties;
 
 import org.apache.metron.test.AbstractConfigTest;
-import org.apache.metron.alerts.adapters.AllAlertAdapter;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
- /**
- * <ul>
- * <li>Title: AllAlertAdapterTest</li>
- * <li>Description: Tests for AllAlertAdapter</li>
- * <li>Created: Oct 8, 2014</li>
- * </ul>
- * @version $Revision: 1.1 $
- */
 public class AllAlertAdapterTest extends AbstractConfigTest {
 
      /**
      * The allAlertAdapter.
      */
-    private static AllAlertAdapter allAlertAdapter=null;
-    
-     /**
-     * The connected.
-     */
-    private static boolean connected=false;
+    private AllAlertAdapter allAlertAdapter=null;
 
-    /**
-     * Constructs a new <code>AllAlertAdapterTest</code> instance.
-     * @param name
-     */
-    public AllAlertAdapterTest(String name) {
-        super(name);
+    public AllAlertAdapterTest() throws Exception {
+        super.setUp("org.apache.metron.alerts.adapters.AllAlertAdapter");
+        Properties prop = super.getTestProperties();
+        Assert.assertNotNull(prop);
+
+        Map<String, String> settings = super.getSettings();
+
+        allAlertAdapter = new AllAlertAdapter(settings);
     }
 
     /**
-     * @throws java.lang.Exception
+     * Test method for {@link org.apache.metron.alerts.adapters.AllAlertAdapter#initialize()}.
      */
-    protected static void setUpBeforeClass() throws Exception {
-    }
-
-    /**
-     * @throws java.lang.Exception
-     */
-    protected static void tearDownAfterClass() throws Exception {
-    }
-
-    /* 
-     * (non-Javadoc)
-     * @see junit.framework.TestCase#setUp()
-     */
-
-    @SuppressWarnings("unchecked")
-    protected void setUp() throws Exception {
-          super.setUp("org.apache.metron.alerts.adapters.AllAlertAdapter");
-          Properties prop = super.getTestProperties();
-          Assert.assertNotNull(prop);
-       // this.setMode("global");
-        if(skipTests(this.getMode())){
-            System.out.println(getClass().getName()+" Skipping Tests !!Local Mode");
-            return;//skip tests
-       }else{      
-           Map<String, String> settings = super.getSettings();
-           @SuppressWarnings("rawtypes")
-        Class loaded_class = Class.forName("org.apache.metron.alerts.adapters.AllAlertAdapter");
-           @SuppressWarnings("rawtypes")
-        Constructor constructor = loaded_class.getConstructor(new Class[] { Map.class});
-           
-           AllAlertAdapterTest.allAlertAdapter = (AllAlertAdapter) constructor.newInstance(settings);
-            // AllAlertAdapterTest.allAlertAdapter = new AllAlertAdapter(settings)
-      }
-    }
-
-    /* 
-     * (non-Javadoc)
-     * @see junit.framework.TestCase#tearDown()
-     */
-
-    protected void tearDown() throws Exception {
-        super.tearDown();
-    }
-
-
-    /**
-     * Test method for {@link org.apache.metron.alerts.adapters.AlllterAdapter#initialize()}.
-     */
+    @Ignore //FIXME - This is really an integration test, e.g. requires a running ZK cluster
+    @Test
     public void testInitializeAdapter() {
-        if(skipTests(this.getMode())){
-            return;//skip tests
-       }else{        
-           
-        boolean initialized =AllAlertAdapterTest.getAllAlertAdapter().initialize();
+        boolean initialized = this.allAlertAdapter.initialize();
         Assert.assertTrue(initialized);
-       }
     }
     
     /**
      * Test method for containsAlertId(@link  org.apache.metron.alerts.adapters.AlllterAdapter#containsAlertId()}.
      */
-    public void testContainsAlertId(){
-        if(skipTests(this.getMode())){
-            return;//skip tests
-       }else{          
-            boolean containsAlert =AllAlertAdapterTest.getAllAlertAdapter().containsAlertId("test");
-            Assert.assertFalse(containsAlert);
-       }
+    @Test
+    public void testContainsAlertId() {
+        boolean containsAlert = this.allAlertAdapter.containsAlertId("test");
+        Assert.assertFalse(containsAlert);
     }
- 
-   
-
-    /**
-     * Returns the allAlertAdapter.
-     * @return the allAlertAdapter.
-     */
-    
-    public static AllAlertAdapter getAllAlertAdapter() {
-        return allAlertAdapter;
-    }
-
-    /**
-     * Sets the allAlertAdapter.
-     * @param allAlertAdapter the allAlertAdapter.
-     */
-    
-    public static void setAllAlertAdapter(AllAlertAdapter allAlertAdapter) {
-    
-        AllAlertAdapterTest.allAlertAdapter = allAlertAdapter;
-    }
-    /**
-     * Returns the connected.
-     * @return the connected.
-     */
-    
-    public static boolean isConnected() {
-        return connected;
-    }
-
-    /**
-     * Sets the connected.
-     * @param connected the connected.
-     */
-    
-    public static void setConnected(boolean connected) {
-    
-        AllAlertAdapterTest.connected = connected;
-    }    
 }
 


### PR DESCRIPTION
The main unit test here had to be marked `@Ignore` because it is really an integration test, which assumes a zookeeper cluster is available.  However, the main test is class is remediated and ready for JUnit 4 style unit tests to be added.