### PR TITLE
Configure Cobertura plugin to produce html only and aggregate coverage reports.

### DIFF
--- a/metron-streaming/pom.xml
+++ b/metron-streaming/pom.xml
@@ -76,6 +76,22 @@
 	</dependencies>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>cobertura-maven-plugin</artifactId>
+					<version>2.7</version>
+					<configuration>
+						<check/>
+						<formats>
+							<format>html</format>
+						</formats>
+						<aggregate>true</aggregate>
+						</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 
 	<reporting>


### PR DESCRIPTION
Automatic report creation is not currently configured- reports are generated with:
mvn cobertura:cobertura