### PR TITLE
METRON-42 Replace GPL license language with ASF for custom ansible module

### DIFF
--- a/deployment/extra_modules/ambari_cluster_state.py
+++ b/deployment/extra_modules/ambari_cluster_state.py
@@ -1,21 +1,20 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 #
-# Author: Mark Bittmann (https://github.com/mbittmann)
-# This file is part of Ansible
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
 #
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 #
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 DOCUMENTATION = '''
 ---


### PR DESCRIPTION
This code is not part of ansible and therefore not subject to GPL. As
the original author, I am including the Apache license as part of the
Metron project.