### PR TITLE
METRON-55 Simplify Modification of Packet Replay

### DIFF
--- a/deployment/roles/pcap_replay/README.md
+++ b/deployment/roles/pcap_replay/README.md
@@ -1,27 +1,44 @@
 Pcap Replay
 ===========
 
-This will install components necessary to easily replay packet capture data to support functional performance, and load testing of Metron.
+This project enables packet capture data to be replayed through a network interface to simulate live network traffic.  This can be used to support functional, performance, and load testing of Apache Metron.
 
 Getting Started
 ---------------
 
-Pcap Replay is installed as a System V service at `/etc/init.d/pcap-replay`.  To start the service, run the following command.
+To replay packet capture data, simply start the `pcap-replay` SysV service.  To do this run the following command.
 
 ```
 service pcap-replay start
 ```
 
-An example packet capture file has been installed at `/opt/pcap-replay/example.pcap`.  By default, the network traffic contained within this file is continually replayed.  That's right, it will never, ever stop.  
+All additional options accepted by `tcpreplay` can be passed to the service script to modify how the network data is replayed.  For example, this makes it simple to control the amount and rate of data replayed during functional, performance and load testing.
 
-To replay your own packet capture data, simply add any number of files containing `libpcap` formatted packet capture data to `/opt/pcap-replay`.  The files must end with the `.pcap` file extension.  To pick up newly installed files, simply restart the service.
+Example: Replay data at a rate of 10 mbps.
 
 ```
-service pcap-replay restart
+service pcap-replay start --mbps 10
+```
+
+Example: Replay data at a rate of 10 packets per second.
+
+```
+service pcap-replay start --pps 10
 ```
 
 All nodes on the same subnet with their network interface set to promiscuous mode will then be able to capture the network traffic being replayed.  To validate, simply run something like the following.
 
 ```
 tcpdump -i eth1
+```
+
+Data
+----
+
+An example packet capture file has been installed at `/opt/pcap-replay/example.pcap`.  By default, the network traffic contained within this file is continually replayed.   
+
+To replay your own packet capture data, simply add any number of files containing `libpcap` formatted packet capture data to `/opt/pcap-replay`.  The files must end with the `.pcap` extension.  To pick up newly installed files, simply restart the service.
+
+```
+service pcap-replay restart
 ```

--- a/deployment/roles/pcap_replay/meta/main.yml
+++ b/deployment/roles/pcap_replay/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  author: Nick Allen
+  description:
+  company: Metron
+
+  license: license (Apache, CC-BY, Nick Allen)
+  min_ansible_version: 1.2
+
+  platforms:
+  - name: CentOS
+    versions:
+      - 6
+
+  categories:
+  - networking
+
+dependencies: []

--- a/deployment/roles/pcap_replay/tasks/main.yml
+++ b/deployment/roles/pcap_replay/tasks/main.yml
@@ -15,10 +15,12 @@
 #  limitations under the License.
 #
 ---
+- name: Install prerequisites
+  yum: name=libselinux-python
 
 - include: tcpreplay.yml
 
 - include: service.yml
 
 - name: Start the pcap-replay service
-  service: name=pcap-replay state=started
+  service: name=pcap-replay state=restarted

--- a/deployment/roles/pcap_replay/tasks/service.yml
+++ b/deployment/roles/pcap_replay/tasks/service.yml
@@ -16,18 +16,10 @@
 #
 ---
 - name: Create pcap directory
-  file: path={{ pcap_replay_path }} state=directory mode=0755
+  file: path={{ pcap_path }} state=directory mode=0755
 
 - name: Install init.d service script
-  template:
-    src: "../roles/pcap_replay/files/pcap-replay"
-    dest: "/etc/init.d/pcap-replay"
-    mode: 0755
-    owner: "root"
-    group: "root"
-
-- name: Set permissions on service script
-  file: path=/etc/init.d/pcap-replay mode=0755
+  template: src=pcap-replay dest=/etc/init.d/pcap-replay mode=0755
 
 - name: Install example pcap file
-  copy: src=example.pcap dest={{ pcap_replay_path }}/
+  copy: src=example.pcap dest={{ pcap_path }}/

--- a/deployment/roles/pcap_replay/tasks/tcpreplay.yml
+++ b/deployment/roles/pcap_replay/tasks/tcpreplay.yml
@@ -38,8 +38,8 @@
   shell: "{{ item }}"
   args:
     chdir: "/opt/tcpreplay-{{ tcpreplay_version }}"
-    creates: /usr/local/bin/tcpreplay
+    creates: "{{ tcpreplay_prefix }}/bin/tcpreplay"
   with_items:
-    - ./configure
+    - "./configure --prefix={{ tcpreplay_prefix }}"
     - make
     - make install

--- a/deployment/roles/pcap_replay/templates/pcap-replay
+++ b/deployment/roles/pcap_replay/templates/pcap-replay
@@ -1,34 +1,36 @@
 #!/usr/bin/env bash
 #
-#  Licensed to the Apache Software Foundation (ASF) under one or more
-#  contributor license agreements.  See the NOTICE file distributed with
-#  this work for additional information regarding copyright ownership.
-#  The ASF licenses this file to You under the Apache License, Version 2.0
-#  (the "License"); you may not use this file except in compliance with
-#  the License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # pcap replay daemon
 # chkconfig: 345 20 80
 # description: Replays packet capture data stored in libpcap format
 # processname: pcap-replay
 #
 
-DAEMON_PATH="/opt/pcap-replay"
+DAEMON_PATH="{{ pcap_path }}"
 PCAPIN=`ls $DAEMON_PATH/*.pcap 2> /dev/null`
 IFACE="{{ pcap_replay_interface | default("eth0") }}"
-DAEMON=/usr/local/bin/tcpreplay
-DAEMONOPTS="--intf1=$IFACE --loop=0 $PCAPIN"
+EXTRA_ARGS="${@:2}"
+DAEMON="{{ tcpreplay_prefix }}/bin/tcpreplay"
+DAEMONOPTS="--intf1=$IFACE --loop=0 $EXTRA_ARGS $PCAPIN"
 
 NAME=pcap-replay
-DESC="Replays packet capture data stored in libpcap format"
+DESC="Replay packet capture data"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
@@ -38,7 +40,7 @@ case "$1" in
 
     # ensure that a pcap file exists to replay
     if [ -z "$PCAPIN" ]; then
-      printf "%s: %s\n" "Fail: No pcap files found" $DAEMON_PATH
+      printf "%s: %s\n" "Fail: No pcap files found at " $DAEMON_PATH
     else
       # kick-off the daemon
       cd $DAEMON_PATH

--- a/deployment/roles/pcap_replay/vars/main.yml
+++ b/deployment/roles/pcap_replay/vars/main.yml
@@ -15,5 +15,7 @@
 #  limitations under the License.
 #
 ---
+pcap_replay_interface: eth0
+pcap_path: /opt/pcap-replay
 tcpreplay_version: 4.1.1
-pcap_replay_path: /opt/pcap-replay
+tcpreplay_prefix: /opt


### PR DESCRIPTION
All additional options accepted by `tcpreplay` can be passed to the service script to modify how the network data is replayed. This makes it simple to control the amount and rate of data replayed during functional, performance and load testing.

Example: Replay data at a rate of 10 mbps.
`service pcap-replay start --mbps 10`

Example: Replay data at a rate of 10 packets per second.
`service pcap-replay start --pps 10`