### PR TITLE
METRON-63 Support Provisioning Multiple, Isolated Clusters with Amazon EC2

### DIFF
--- a/deployment/amazon-ec2/README.md
+++ b/deployment/amazon-ec2/README.md
@@ -42,3 +42,12 @@ Each of the provisioned hosts will be externally accessible from the internet at
 ```
 ssh centos@ec2-52-91-215-174.compute-1.amazonaws.com
 ```
+
+Multiple Environments
+---------------------
+
+This process can support provisioning of multiple, isolated environments.  Simply change the `env` settings in `conf/defaults.yml`.  For example, you might provision separate development, test, and production environments.
+
+```
+env: metron-test
+```

--- a/deployment/amazon-ec2/conf/defaults.yml
+++ b/deployment/amazon-ec2/conf/defaults.yml
@@ -20,7 +20,7 @@ region: us-west-2
 instance_type: m4.xlarge
 image: ami-05cf2265
 volume_type: standard
-key_name: metron-test
+key_name: metron-key
 env: metron-test
 
 # ambari

--- a/deployment/amazon-ec2/tasks/create-hosts.yml
+++ b/deployment/amazon-ec2/tasks/create-hosts.yml
@@ -15,14 +15,14 @@
 #  limitations under the License.
 #
 ---
-- name: Instantiate '{{ host_count }}' host(s) as '{{ host_type }}'
+- name: "{{ env }}: Instantiate {{ host_count }} host(s) as {{ host_type }}"
   ec2:
     region: "{{ region }}"
     instance_type: "{{ instance_type }}"
     image: "{{ image }}"
-    key_name: "{{ key_name }}"
+    key_name: "{{ env }}-{{ key_name }}"
     assign_public_ip: True
-    group: [vpc-all-inbound,vpc-all-outbound]
+    group: ["{{ env }}-vpc-all-inbound","{{ env }}-vpc-all-outbound"]
     vpc_subnet_id: "{{ vpc.subnets[0].id }}"
     instance_tags:
       Name: "[{{ env }}] {{ host_type }}"
@@ -31,6 +31,7 @@
     exact_count: "{{ host_count }}"
     count_tag:
       type: "{{ host_type }}"
+      env: "{{ env }}"
     volumes:
     - device_name: /dev/sda1
       volume_type: "{{ volume_type }}"

--- a/deployment/amazon-ec2/tasks/create-keypair.yml
+++ b/deployment/amazon-ec2/tasks/create-keypair.yml
@@ -15,9 +15,15 @@
 #  limitations under the License.
 #
 ---
+- set_fact:
+    the_key_file: "{{ key_file | default('~/.ssh/id_rsa.pub') }}"
+
 - name: Define keypair
   ec2_key:
-    name: "{{ key_name }}"
+    name: "{{ env }}-{{ key_name }}"
     region: "{{ region }}"
     key_material: "{{ item }}"
-  with_file: "{{ key_file | default('~/.ssh/id_rsa.pub') }}"
+  with_file: "{{ the_key_file }}"
+
+- debug: msg="Created keypair '{{ env }}-{{ key_name }}' from '{{ the_key_file }}'"
+

--- a/deployment/amazon-ec2/tasks/create-open-inbound-security-group.yml
+++ b/deployment/amazon-ec2/tasks/create-open-inbound-security-group.yml
@@ -15,9 +15,9 @@
 #  limitations under the License.
 #
 ---
-- name: WARNING Define open inbound security group
+- name: "{{ env }}: Define open inbound security group"
   ec2_group:
-    name: vpc-all-inbound
+    name: "{{ env }}-vpc-all-inbound"
     description: WARNING allow all inbound connections from the internet
     region: "{{ region }}"
     vpc_id: "{{ vpc_id }}"

--- a/deployment/amazon-ec2/tasks/create-open-outbound-security-group.yml
+++ b/deployment/amazon-ec2/tasks/create-open-outbound-security-group.yml
@@ -15,9 +15,9 @@
 #  limitations under the License.
 #
 ---
-- name: Define outbound security group
+- name: "{{ env }}: Define open outbound security group"
   ec2_group:
-    name: vpc-all-outbound
+    name: "{{ env }}-vpc-all-outbound"
     description: allow all outbound connections to the internet
     region: "{{ region }}"
     vpc_id: "{{ vpc_id }}"

--- a/deployment/amazon-ec2/tasks/create-security-group.yml
+++ b/deployment/amazon-ec2/tasks/create-security-group.yml
@@ -15,11 +15,11 @@
 #  limitations under the License.
 #
 ---
-- name: Define "{{ name }}" security group
+- name: "{{ env }}: Define the {{ name }} security group"
   ec2_group:
-    name: "{{ name }}"
+    name: "{{ env }}-{{ name }}"
     region: "{{ region }}"
-    description: "{{ name }} - {{ proto }} - {{ port }}"
+    description: "[{{env}}] {{ name }}/{{ proto }}/{{ port }}"
     vpc_id: "{{ vpc_id }}"
     rules:
       - proto: "{{ proto }}"

--- a/deployment/amazon-ec2/tasks/create-vpc.yml
+++ b/deployment/amazon-ec2/tasks/create-vpc.yml
@@ -15,12 +15,16 @@
 #  limitations under the License.
 #
 ---
-  - name: Create vpc
+  - name: "{{ env }}:  Create virtual private cloud"
     ec2_vpc:
       region: "{{ region }}"
       internet_gateway: True
-      resource_tags: { Name: Metron }
+      resource_tags:
+        Name: "{{ env }}-virtual-private-cloud"
+        env: "{{ env }}"
       cidr_block: 10.0.0.0/16
+      dns_hostnames: yes
+      dns_support: yes
       subnets:
         - cidr: 10.0.0.0/24
           resource_tags:
@@ -41,6 +45,6 @@
             gw: igw
     register: vpc
 
-  - name: Created vpc with id='"{{ vpc.vpc_id }}"'
+  - name: "[{{ env }}] Created vpc with id='{{ vpc.vpc_id }}'"
     set_fact:
       vpc_id: "{{ vpc.vpc_id }}"


### PR DESCRIPTION
The Amazon EC2 provisioning process can now support provisioning multiple, isolated environments.  Simply change the `env` settings in `conf/defaults.yml`.  For example, you might provision separate development, test, and production environments.

The resources created, such as the host and vpc, are tagged and labelled with the environment name to make it easy to distinguish between them in the AWS management web interface.

For a test environment, in `conf/defaults.yml` set...

```
env: metron-test
```

For a dev environment, in `conf/defaults.yml` set...

```
env: metron-dev
```

- [x] Tested against Metron cluster
- [x] Integration Tests `cd metron-streaming; mvn integration-test`
- [x] License Checks `mvn apache-rat:check`
- [x]  Add environment to the keypair name
