### PR TITLE
METRON-67 YAF Probe Not Landing Data in Kafka

### DIFF
--- a/deployment/amazon-ec2/README.md
+++ b/deployment/amazon-ec2/README.md
@@ -6,42 +6,67 @@ This project fully automates the provisioning of Apache Metron on Amazon EC2 inf
 Getting Started
 ---------------
 
-The host that will be used to drive the provisioning process will need to have [Ansible](https://github.com/ansible/ansible), Python and PIP installed.  In most cases, a development laptop serves this purpose just fine.  For better performance, run this playbook on a pre-provisioned EC2 host.
+### Prerequisites
 
-Ensure that an SSH key has been generated.  The playbook will attempt to register `~/.ssh/id_rsa.pub` with each provisioned host so that an SSH connection can be established.  If one does not exist, use `ssh-keygen` to create one.
+The host that will drive the provisioning process will need to have [Ansible](https://github.com/ansible/ansible), Python and PIP installed.  In most cases, a development laptop serves this purpose just fine.  Also, install the Python library `boto` and its dependencies.  
 
-1. Install the Python library `boto` and its dependencies.  This enables Ansible to communicate with Amazon EC2.
+```
+pip install boto six
+```
+
+Ensure that an SSH key has been generated using `ssh-keygen`.  By default, the playbook will attempt to register `~/.ssh/id_rsa` with each provisioned host so that an SSH connection can be established.  If this key does not exist or you would prefer to use another, provide the path to the private key in `conf/defaults.yml`.
+
+```
+key_file: ~/.ssh/metron-private-key
+```
+
+### Create User
+
+1. Use Amazon's [Identity and Access Management](https://console.aws.amazon.com/iam/) tool to create a user account by clicking on `Users > Create New User`.  
+
+2. Grant the user permission by clicking on `Permissions > Attach Policy` and adding the following policies.
 
   ```
-  pip install boto six
+  AmazonEC2FullAccess
+  AmazonVPCFullAccess
   ```
 
-2. Use Amazon's [IAM](https://console.aws.amazon.com/iam/) tool to generate an access key.  Export these access keys in an environment variable so that Ansible can authenticate with Amazon EC2.
+3. Create an access key for the user by clicking on `Security Credentials > Create Access Key`.  Save the provided access key values in a safe place for use later.
+
+4. Use the access key by exporting it in an environment variable.  This allows Ansible to authenticate with Amazon EC2.  For example:
 
   ```
-  export AWS_ACCESS_KEY_ID="..."
-  export AWS_SECRET_ACCESS_KEY="..."
+  export AWS_ACCESS_KEY_ID="AKIAI6NRFEO27E5FFELQ"
+  export AWS_SECRET_ACCESS_KEY="vTDydWJQnAer7OWauUS150i+9Np7hfCXrrVVP6ed"
   ```
 
-3. Build Metron's streaming topology uber-jar.
+### Deploy Metron
+
+1. Ensure that Metron's streaming topology uber-jar has been built.
 
   ```
   cd ../../metron-streaming
   mvn clean package -DskipTests
   ```
 
-4. Kick-off the provisioning playbook.  If the playbook fails mid-stream for any reason, simply re-run it.  This will attempt to re-provision on the previously instantiated EC2 hosts.
+2. Start the Metron playbook.  A full Metron deployment can consume up to 60 minutes.  Grab a coffee, relax and practice mindfulness meditation.  If the playbook fails mid-stream for any reason, simply re-run it.  
 
   ```
   export EC2_INI_PATH=conf/ec2.ini
   ansible-playbook -i ec2.py playbook.yml
   ```
 
-Each of the provisioned hosts will be externally accessible from the internet at-large. Connecting to one over SSH as the user `centos` will not require a password as it will authenticate with the pre-defined SSH key.  
+### Explore Metron
 
-```
-ssh centos@ec2-52-91-215-174.compute-1.amazonaws.com
-```
+1. Go to the [EC2 Management Console](https://aws.amazon.com/console) and find the running instances.  Look at the `Name` column which is populated with both the host group and environment name.  The Metron Web Console runs on the host in the `web` host group.  Once you have found the host, point your web browser at it.  For example:
+
+  http://ec2-52-38-14-241.us-west-2.compute.amazonaws.com:5000
+
+2. Each of the provisioned hosts will be accessible from the internet. Connecting to one over SSH as the user `centos` will not require a password as it will authenticate with the pre-defined SSH key.  
+
+  ```
+  ssh centos@ec2-52-91-215-174.compute-1.amazonaws.com
+  ```
 
 Usage
 -----

--- a/deployment/amazon-ec2/playbook.yml
+++ b/deployment/amazon-ec2/playbook.yml
@@ -51,3 +51,14 @@
 # build the metron cluster
 #
 - include: ../playbooks/metron_full_install.yml
+
+#
+# provisioning report
+#
+- hosts: localhost
+  vars_files:
+    - conf/defaults.yml
+  tasks:
+    - include: tasks/provisioning-report.yml
+  tags:
+    - ec2

--- a/deployment/amazon-ec2/tasks/provisioning-report.yml
+++ b/deployment/amazon-ec2/tasks/provisioning-report.yml
@@ -3,20 +3,24 @@
 #  contributor license agreements.  See the NOTICE file distributed with
 #  this work for additional information regarding copyright ownership.
 #  The ASF licenses this file to You under the Apache License, Version 2.0
-#  (the "License"); you may not use this file except in compliance with
+#  (the 'License'); you may not use this file except in compliance with
 #  the License.  You may obtain a copy of the License at
 #
 #      http://www.apache.org/licenses/LICENSE-2.0
 #
 #  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
+#  distributed under the License is distributed on an 'AS IS' BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
 ---
-- include: dependencies.yml
-- include: librdkafka.yml
-- include: bro.yml
-- include: bro-plugin-kafka.yml
-- include: start-bro.yml
+- set_fact:
+    Success:
+      - "Apache Metron deployed successfully"
+      - "   Metron  @  http://{{ groups.web[0] }}:5000"
+      - "   Ambari  @  http://{{ groups.ambari_master[0] }}:{{ ambari_port }}"
+      - "   Sensors @  {{ groups.sensors[0] }} on {{ sniff_interface }}"
+      - For additional information, see https://metron.incubator.apache.org/'
+
+- debug: var=Success

--- a/deployment/playbooks/metron_install.yml
+++ b/deployment/playbooks/metron_install.yml
@@ -21,7 +21,7 @@
     - include_vars: ../amazon-ec2/conf/defaults.yml
   tags:
     - ec2
-    
+
 - hosts: metron
   become: true
   roles:
@@ -59,7 +59,6 @@
     - role: mysql_client
   tags:
     - mysql-client
-
 
 - hosts: sensors
   become: true

--- a/deployment/roles/ambari_config/tasks/main.yml
+++ b/deployment/roles/ambari_config/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Install python-requests
   yum: name=python-requests
 
-- name: Create the ambari cluster
+- name: Deploy cluster with Ambari; http://{{ groups.ambari_master[0] }}:{{ ambari_port }}
   ambari_cluster_state:
     host: "{{ groups.ambari_master[0] }}"
     port: "{{ ambari_port }}"

--- a/deployment/roles/bro/tasks/bro-plugin-kafka.yml
+++ b/deployment/roles/bro/tasks/bro-plugin-kafka.yml
@@ -16,13 +16,13 @@
 #
 ---
 - name: Distribute bro-kafka plugin
-  copy: src=../../../bro-plugin-kafka dest=/tmp mode=0755
+  copy: src=../../../bro-plugin-kafka dest=/tmp/ mode=0755
 
 - name: Compile and install the plugin
   shell: "{{ item }}"
   args:
     chdir: "/tmp/bro-plugin-kafka"
-    creates: /usr/local/bro/lib/bro/plugins/METRON_KAFKA
+    creates: /usr/local/bro/lib/bro/plugins/BRO_KAFKA
   with_items:
     - rm -rf build/
     - "./configure --bro-dist=/tmp/bro-{{ bro_version }}"

--- a/deployment/roles/bro/tasks/dependencies.yml
+++ b/deployment/roles/bro/tasks/dependencies.yml
@@ -15,8 +15,20 @@
 #  limitations under the License.
 #
 ---
-- include: dependencies.yml
-- include: librdkafka.yml
-- include: bro.yml
-- include: bro-plugin-kafka.yml
-- include: start-bro.yml
+- name: Install prerequisites
+  yum: name={{ item }}
+  with_items:
+    - libselinux-python
+    - cmake
+    - make
+    - gcc
+    - gcc-c++
+    - flex
+    - bison
+    - libpcap
+    - libpcap-devel
+    - openssl-devel
+    - python-devel
+    - swig
+    - zlib-devel
+    - perl

--- a/deployment/roles/bro/tasks/start-bro.yml
+++ b/deployment/roles/bro/tasks/start-bro.yml
@@ -15,8 +15,20 @@
 #  limitations under the License.
 #
 ---
-- include: dependencies.yml
-- include: librdkafka.yml
-- include: bro.yml
-- include: bro-plugin-kafka.yml
-- include: start-bro.yml
+- name: Turn on promiscuous mode for {{ sniff_interface }}
+  shell: "ip link set {{ sniff_interface }} promisc on"
+
+- name: Update bro configuration
+  shell: /usr/local/bro/bin/broctl install
+
+- name: Start bro
+  shell: /usr/local/bro/bin/broctl start
+
+- name: Bro Cronjob
+  cron:
+    name: Bro Cron
+    minute: "{{ bro_crontab_minutes }}"
+    job: "{{ item }}"
+  with_items:
+    - "{{ bro_crontab_job }}"
+    - "{{ bro_clean_job }}"

--- a/deployment/roles/mysql_client/tasks/main.yml
+++ b/deployment/roles/mysql_client/tasks/main.yml
@@ -31,4 +31,5 @@
     name: "all"
     state: "import"
     target: "/tmp/{{ansible_fqdn}}.sql"
+  ignore_errors: True
   delegate_to: "{{ groups.mysql[0] }}"

--- a/deployment/roles/yaf/defaults/main.yml
+++ b/deployment/roles/yaf/defaults/main.yml
@@ -26,3 +26,5 @@ yafscii_bin: /usr/local/bin/yafscii
 yaf_log: /var/log/yaf.log
 kafka_prod: /usr/hdp/current/kafka-broker/bin/kafka-console-producer.sh
 daemon_bin: /usr/local/bin/airdaemon
+yaf_start: /opt/yaf/start-yaf.sh
+yaf_args:

--- a/deployment/roles/yaf/tasks/yaf.yml
+++ b/deployment/roles/yaf/tasks/yaf.yml
@@ -43,6 +43,9 @@
     state: directory
     mode: 0755
 
+- name: Install yaf start script
+  template: src=start-yaf.sh dest={{ yaf_home }}/start-yaf.sh mode=0755
+
 - name: Install init.d service script
   template: src=yaf dest=/etc/init.d/yaf mode=0755
 
@@ -54,4 +57,4 @@
   shell: "ip link set {{ sniff_interface }} promisc on"
 
 - name: Start yaf
-  service: name=yaf state=restarted
+  service: name=yaf state=restarted args="{{ yaf_args }}"

--- a/deployment/roles/yaf/templates/start-yaf.sh
+++ b/deployment/roles/yaf/templates/start-yaf.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# a very simply metron probe that captures the output of yaf - yet another
+# flowmeter - and sends the output to kafka so that it can be consumed
+# by metron
+#
+{{ yaf_bin }} --in {{ sniff_interface }} --live pcap ${@:2} | {{ yafscii_bin }} --tabular | {{ kafka_prod }} --broker-list {{ kafka_broker_url }} --topic {{ yaf_topic }}

--- a/deployment/roles/yaf/templates/yaf
+++ b/deployment/roles/yaf/templates/yaf
@@ -25,10 +25,9 @@ NAME=yaf
 DESC="Executes yaf - yet another flowmeter"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-EXTRA_ARGS="${@:2}"
 DAEMON_PATH="{{ yaf_home }}"
-DAEMON="{{ daemon_bin }} --airdaemon-pidfile $PIDFILE --log {{ yaf_log }} --retry 15 --retry-max 300 --"
-DAEMONOPTS="{{ yaf_bin }} --in {{ sniff_interface }} --live pcap $EXTRA_ARGS | {{ yafscii_bin }} --tabular | {{ kafka_prod }} --broker-list {{ kafka_broker_url }} --topic {{ yaf_topic }}"
+DAEMON="{{ yaf_start }}"
+DAEMONOPTS="${@:2}"
 
 case "$1" in
   start)


### PR DESCRIPTION
### Changes
- METRON-67 YAF Probe Not Landing Data in Kafka
- METRON-68 Create Post-Provisioning Report

```
TASK [debug] *******************************************************************
ok: [localhost] => {
    "Success": [
        "Apache Metron deployed successfully",
        "   Metron  @  http://ec2-52-37-255-142.us-west-2.compute.amazonaws.com:5000",
        "   Ambari  @  http://ec2-52-37-225-202.us-west-2.compute.amazonaws.com:8080",
        "   Sensors @  ec2-52-37-225-202.us-west-2.compute.amazonaws.com on tap0",
        "For additional information, see https://metron.incubator.apache.org/'"
    ]
}
```

### Validation
- [x] Validated with full and partial Metron deployment to EC2.
- [x] License Check
- [x] Integration Tests
   