### PR TITLE
METRON-81: Metron-UI Deployment should exclude node_modules

### DIFF
--- a/deployment/roles/metron_ui/tasks/copy-source.yml
+++ b/deployment/roles/metron_ui/tasks/copy-source.yml
@@ -24,7 +24,7 @@
     group: root
 
 - name: Archive metron-ui on localhost
-  shell: tar -czf {{ metron_temp_archive }} .
+  shell: tar --exclude='./node_modules' -czf {{ metron_temp_archive }} .
   args:
     chdir: "{{ playbook_dir }}/../../metron-ui"
     creates: "{{ metron_temp_archive }}"


### PR DESCRIPTION
Excluded node_modules from the metron-ui tar call.