### PR TITLE
METRON-84 Update license/notices with appropriate 3rd party bundled notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,23 @@ Apache License
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+This product bundles filesaver 2013-01-23, which is available under a "MIT" license.
+This product bundles angular-dragdrop 1.0.4, which is available under a "MIT" license.
+This product bundles modernizr 2.6.1, which is available under a "MIT" license.
+This product bundles bindonce 0.2.1, which is available under a "MIT" license.
+This product bundles moment 2.1.0, which is available under a "MIT" license.
+This product bundles jquery-ui 1.10.3, which is available under a "MIT" license.
+This product bundles angular 1.1.5, which is available under a "MIT" license.
+This product bundles jquery 1.8.0, which is available under a "MIT" license.
+This product bundles elasticjs 1.1.1, which is available under a "MIT" license.
+This product bundles angular-strap 0.7.5, which is available under a "MIT" license.
+This product bundles lodash 2.4.1, which is available under a "MIT" license.
+This product bundles require 2.1.8, which is available under a "MIT" license.
+This product bundles flot 0.8.1, which is available under a "MIT" license.
+This product bundles leaflet 0.6, which is available under a "2-Clause BSD" license.
+This product bundles jvectormap 1.2.2, which is available under a "MIT" license.
+This product bundles timepicker 0.2.6, which is available under a "MIT" license.
+This product bundles blob 2013-06-20, which is available under a "MIT" license.
+This product bundles numeral 1.5.2, which is available under a "MIT" license.
+This product bundles chromath 0.0.5, which is available under a "MIT" license.

--- a/metron-ui/lib/public/vendor/LICENSE.json
+++ b/metron-ui/lib/public/vendor/LICENSE.json
@@ -77,11 +77,11 @@
   },
   "lodash": {
     "version":"2.4.1",
-    "license":"https://github.com/lodash/lodash/blob/2.4.1/LICENSE.txt"
+    "license":"MIT"
   },
   "leaflet": {
     "version":"0.6",
-    "license":"https://github.com/Leaflet/Leaflet/blob/v0.6/LICENSE"
+    "license":"2-Clause BSD"
   },
   "jvectormap": {
     "version":"1.2.2",

--- a/notices_dumper.py
+++ b/notices_dumper.py
@@ -1,3 +1,20 @@
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import json
 import sys
 

--- a/notices_dumper.py
+++ b/notices_dumper.py
@@ -1,0 +1,25 @@
+import json
+import sys
+
+def merge_dicts(*dict_args):
+    result = {}
+    for dictionary in dict_args:
+        result.update(dictionary)
+    return result
+
+def get_statement(component, version, license):
+    #This product bundles SuperWidget 1.2.3, which is available under a
+    #"3-clause BSD" license.
+    s = "This product bundles " + component + " " + version \
+      + ", which is available under a \"" + license + "\" license."
+    return s
+
+licenses = {}
+for i in xrange(1, len(sys.argv)):
+    with open(sys.argv[i]) as f:
+        license_summary = f.read()
+        licenses = merge_dicts(licenses, json.loads(license_summary))
+for component, value in licenses.iteritems():
+    if not(value['license'].startswith("Apache")):
+        print get_statement(component, value['version'], value['license'])
+


### PR DESCRIPTION
As part of the apache release, we have to provide pointers at the end of the license file for bundled dependencies.  Because our UI does indeed bundle some of these dependencies, we must provide the appropriate pointers.

I added a utility which can be run against metron-ui/lib/public/vendor/LICENSE.json and generate the snippets to append to the LICENSE.