### PR TITLE
METRON-89: Rerunning playbook halts due to hdfs put.

### DIFF
--- a/deployment/roles/metron_streaming/tasks/grok_upload.yml
+++ b/deployment/roles/metron_streaming/tasks/grok_upload.yml
@@ -31,8 +31,7 @@
   become_user: hdfs
 
 - name: Upload Grok Patterns to hdfs://{{ metron_hdfs_output_dir }}
-  command: hdfs dfs -put {{ metron_directory }}/config/patterns  {{ metron_hdfs_output_dir }}
+  command: hdfs dfs -put -f {{ metron_directory }}/config/patterns  {{ metron_hdfs_output_dir }}
   become: yes
   become_user: hdfs
-  ignore_errors: yes
 

--- a/deployment/roles/metron_streaming/tasks/grok_upload.yml
+++ b/deployment/roles/metron_streaming/tasks/grok_upload.yml
@@ -34,4 +34,5 @@
   command: hdfs dfs -put {{ metron_directory }}/config/patterns  {{ metron_hdfs_output_dir }}
   become: yes
   become_user: hdfs
+  ignore_errors: yes
 


### PR DESCRIPTION
The playbook for AWS fails to rerun due to a hdfs put throwing “File exists” errors. Not seeing a hdfs put with override capabilities, so using the “ignore_errors” flag pattern seen elsewhere just so the playbook will complete on subsequent runs...

![ignore_error](https://cloud.githubusercontent.com/assets/373458/14070117/7129990c-f470-11e5-8d90-5ab1006fa98b.png)

(Other than that, due to having to restart the playbook a couple of times, I was able to get an AWS environment up and running with one command -- which is awesome!)