### PR TITLE
METRON-92: Snort has moved their release artifacts, breaking deployment

### DIFF
--- a/deployment/roles/snort/defaults/main.yml
+++ b/deployment/roles/snort/defaults/main.yml
@@ -19,3 +19,7 @@ snort_version: 2.9.8.0-1
 daq_version: 2.0.6-1
 snort_topic: snort
 snort_alert_csv_path: /var/log/snort/alert.csv
+snort_src_url: "https://snort.org/downloads/archive/snort/snort-{{ snort_version }}.src.rpm"
+snort_community_rules_url: "https://www.snort.org/downloads/community/community-rules.tar.gz"
+dag_src_url: "https://snort.org/downloads/snort/daq-{{ daq_version }}.src.rpm"
+

--- a/deployment/roles/snort/tasks/daq.yml
+++ b/deployment/roles/snort/tasks/daq.yml
@@ -17,7 +17,7 @@
 ---
 - name: Download daq
   get_url:
-    url: "https://snort.org/downloads/snort/daq-{{ daq_version }}.src.rpm"
+    url: "{{ dag_src_url }}"
     dest: "/tmp/daq-{{ daq_version }}.src.rpm"
 
 - name: Build daq

--- a/deployment/roles/snort/tasks/snort.yml
+++ b/deployment/roles/snort/tasks/snort.yml
@@ -15,28 +15,9 @@
 #  limitations under the License.
 #
 ---
-- name: Download daq
-  get_url:
-    url: "https://snort.org/downloads/snort/daq-{{ daq_version }}.src.rpm"
-    dest: "/tmp/daq-{{ daq_version }}.src.rpm"
-
-- name: Build daq
-  shell: "rpmbuild --rebuild daq-{{ daq_version }}.src.rpm"
-  args:
-    chdir: /tmp
-    creates: /root/rpmbuild/RPMS/x86_64/daq-{{ daq_version }}.x86_64.rpm
-
-- name: Install daq
-  yum:
-    name: /root/rpmbuild/RPMS/x86_64/daq-{{ daq_version }}.x86_64.rpm
-  register: result
-  until: result.rc == 0
-  retries: 5
-  delay: 10
-
 - name: Download snort
   get_url:
-    url: "https://snort.org/downloads/snort/snort-{{ snort_version }}.src.rpm"
+    url: "{{ snort_src_url }}"
     dest: "/tmp/snort-{{ snort_version }}.src.rpm"
 
 - name: Build snort
@@ -55,7 +36,7 @@
 
 - name: Download snort community rules
   get_url:
-    url: "https://www.snort.org/downloads/community/community-rules.tar.gz"
+    url: "{{ snort_community_rules_url }}"
     dest: "/tmp/community-rules.tar.gz"
 
 - name: Extract tarball


### PR DESCRIPTION
  Make snort and dag url a variable and move to defaults.

[X] Tested on Singlenode Vargrant
[X] Tested on EC2
[X] Travis CI tests pass (on fork)