### PR TITLE
METRON-111 "Start Metron UI" Fails When Already Started

### DIFF
--- a/deployment/roles/metron_ui/tasks/main.yml
+++ b/deployment/roles/metron_ui/tasks/main.yml
@@ -53,4 +53,4 @@
     production: no
 
 - name: Start Metron UI
-  shell: "pm2 start {{ metron_ui_directory }}/lib/metron-ui.js --name metron"
+  shell: "pm2 restart {{ metron_ui_directory }}/lib/metron-ui.js --name metron"


### PR DESCRIPTION
Deployment fails if the Metron UI is already running.  Using 'restart' instead of 'start' works whether its is running or not.

```
TASK [metron_ui : Install Node dependencies] ***********************************
ok: [ec2-52-38-107-175.us-west-2.compute.amazonaws.com]

TASK [metron_ui : Install Metron UI] *******************************************
ok: [ec2-52-38-107-175.us-west-2.compute.amazonaws.com]

TASK [metron_ui : Start Metron UI] *********************************************
fatal: [ec2-52-38-107-175.us-west-2.compute.amazonaws.com]: FAILED! => {"changed": true, 
"cmd": "pm2 start /usr/metron/0.1BETA/metron-ui/lib/metron-ui.js --name metron", 
"delta": "0:00:00.234542", "end": "2016-04-15 18:31:19.971101", "failed": true, "rc": 1, 
"start": "2016-04-15 18:31:19.736559", 
"stderr": "[PM2][ERROR] Script already launched, add -f option to force re-execution", 
"stdout":
"┌──────────┬────┬──────┬───────┬────────┬─────────┬────────┬──────────────┬──────────┐\n
│ App name │ id │ mode │ pid   │ status │ restart │ uptime │ memory       │ watching │\n
├──────────┼────┼──────┼───────┼────────┼─────────┼────────┼──────────────┼──────────┤\n
│ metron   │ 0  │ fork │ 16884 │ online │ 0       │ 47h    │ 105.633 MB   │ disabled │\n
└──────────┴────┴──────┴───────┴────────┴─────────┴────────┴──────────────┴──────────┘\n
 Use `pm2 show <id|name>` to get more details about an app",... , "warnings": []}

```