### PR TITLE
METRON-114 Created Ansible role to automate deployment of OpenTAXII services

### DIFF
--- a/deployment/roles/opentaxii/README.md
+++ b/deployment/roles/opentaxii/README.md
@@ -1,0 +1,62 @@
+# OpenTAXII
+
+Installs [OpenTAXII](https://github.com/EclecticIQ/OpenTAXII) as a deamon that can be launched via a SysV service script.  The complementary client implementation, [Cabby](https://github.com/EclecticIQ/cabby) is also installed.
+
+OpenTAXII is a robust Python implementation of TAXII Services that delivers a rich feature set and friendly pythonic API.  [TAXII](https://stixproject.github.io/) (Trusted Automated eXchange of Indicator Information) is a collection of specifications defining a set of services and message exchanges used for sharing cyber threat intelligence information between parties.
+
+## Usage
+
+### Service
+
+A standard SysV script has been installed to manage OpenTAXII.  The following functions are available.
+
+- `start` Start the opentaxii service
+- `stop` Stop the opentaxii service
+- `restart` Restart the opentaxii service
+- `status` Current status of the opentaxii service
+- `setup` Creates a set of collections and services to mirror the threat data made available at [Hail a TAXII](http://hailataxii.com/).  Running this will destroy all existing data.
+
+### Troubleshooting
+
+Should you need to explore the installation, here are instructions on doing so.
+
+OpenTAXII is installed in a virtual environment.  Before exploring the environment run the following commands to perform the necessary setup.  The specific paths may change depending on your Ansible settings.
+
+```
+export LD_LIBRARY_PATH=/opt/rh/python27/root/usr/lib64
+cd /usr/local/opentaxii
+. opentaxii-venv/bin/activate
+```
+
+Explore the available collections.
+
+```
+taxii-collections --path http://hailataxii.com/taxii-data
+taxii-collections --path http://localhost:9000/services/hailataxii/collection
+```
+
+Read data from a collection.
+
+```
+taxii-poll --host hailataxii.com --discovery taxii-data -c guest.phishtank_com
+taxii-poll --host localhost:9000 --discovery services/hailataxii/collection -c hailataxii-phishtank
+```
+
+Discover available services.
+
+```
+taxii-discovery --discovery http://hailataxii.com/taxii-data
+taxii-discovery --discovery http://localhost:9000/services/hailataxii/discovery
+```
+
+Fetch data from a remote service and mirror it locally.
+
+```
+taxii-proxy --poll-path http://hailataxii.com/taxii-data \
+                     --poll-collection guest.phishtank_com \
+                     --inbox-path http://localhost:9000/services/inbox \
+                     --inbox-collection hailataxii-phishtank \
+                     --begin 2016-04-17 \
+                     --binding urn:stix.mitre.org:xml:1.1.1 \
+                     --inbox-username guest --inbox-password guest
+```

--- a/deployment/roles/opentaxii/defaults/main.yml
+++ b/deployment/roles/opentaxii/defaults/main.yml
@@ -1,0 +1,30 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+---
+opentaxii_home: /usr/local/opentaxii
+opentaxii_venv: opentaxii-venv
+opentaxii_bin: "{{ opentaxii_home }}/{{ opentaxii_venv }}/bin"
+opentaxii_user: guest
+opentaxii_pass: guest
+opentaxii_workers: 2
+opentaxii_loglevel: info
+opentaxii_timeout: 300
+opentaxii_bind: localhost:9000
+opentaxii_auth_db: "{{ opentaxii_home }}/auth.db"
+opentaxii_data_db: "{{ opentaxii_home }}/data.db"
+opentaxii_salt: "@#L:KJDASLKJASD@"
+python27_home: /opt/rh/python27/root

--- a/deployment/roles/opentaxii/meta/main.yml
+++ b/deployment/roles/opentaxii/meta/main.yml
@@ -1,0 +1,17 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+---

--- a/deployment/roles/opentaxii/tasks/dependencies.yml
+++ b/deployment/roles/opentaxii/tasks/dependencies.yml
@@ -1,0 +1,37 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+---
+- name: Install yum repositories
+  yum: name={{ item }} update_cache=yes
+  with_items:
+    - epel-release
+    - centos-release-scl
+
+- name: Install dependencies
+  yum: name={{ item }}
+  with_items:
+    - "@Development tools"
+    - python27
+    - python27-scldevel
+    - python27-python-virtualenv
+    - libxml2-devel
+    - libxslt-devel
+    - libselinux-python
+  register: result
+  until: result.rc == 0
+  retries: 5
+  delay: 10

--- a/deployment/roles/opentaxii/tasks/main.yml
+++ b/deployment/roles/opentaxii/tasks/main.yml
@@ -1,0 +1,19 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+---
+- include: dependencies.yml
+- include: opentaxii.yml

--- a/deployment/roles/opentaxii/tasks/opentaxii.yml
+++ b/deployment/roles/opentaxii/tasks/opentaxii.yml
@@ -1,0 +1,61 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+---
+- name: Create install directory
+  file: path={{ opentaxii_home }} state=directory mode=0755
+
+- name: Create virtual environment
+  shell: "{{ python27_home }}/usr/bin/virtualenv {{ opentaxii_venv }}"
+  args:
+    chdir: "{{ opentaxii_home }}"
+    creates: "{{ opentaxii_home }}/{{ opentaxii_venv }}"
+  environment:
+    LD_LIBRARY_PATH: "{{ python27_home }}/usr/lib64"
+
+- name: Install opentaxii, cabby, and gunicorn
+  shell: "{{ opentaxii_bin }}/pip install {{ item }}"
+  environment:
+    LD_LIBRARY_PATH: "{{ python27_home }}/usr/lib64"
+  with_items:
+    - opentaxii
+    - cabby
+    - gunicorn
+
+- name: Deploy opentaxii configs
+  template: src={{ item }} dest={{ opentaxii_home }} mode=0400
+  with_items:
+    - opentaxii-conf.yml
+    - hailataxii-services.yml
+    - hailataxii-collections.yml
+
+- name: Deploy opentaxii service script
+  template: src=opentaxii dest=/etc/init.d/opentaxii mode=0755
+
+- name: Setup opentaxii
+  shell: echo "y" | /etc/init.d/opentaxii setup
+
+- name: Start opentaxii
+  service: name=opentaxii state=restarted
+
+# TODO
+# taxii-proxy --poll-path http://hailataxii.com/taxii-data \
+#                      --poll-collection guest.phishtank_com \
+#                      --inbox-path http://localhost:9000/services/inbox \
+#                      --inbox-collection hailataxii-phishtank \
+#                      --begin 2016-04-17 \
+#                      --binding urn:stix.mitre.org:xml:1.1.1 \
+#                      --inbox-username guest --inbox-password guest

--- a/deployment/roles/opentaxii/templates/hailataxii-collections.yml
+++ b/deployment/roles/opentaxii/templates/hailataxii-collections.yml
@@ -1,0 +1,38 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+---
+- name: hailataxii-phishtank
+  available: true
+  accept_all_content: false
+  supported_content:
+    - urn:stix.mitre.org:xml:1.1.1
+  service_ids:
+    - hailataxii-discovery
+    - hailataxii-inbox
+    - hailataxii-collection
+    - hailataxii-poll
+
+# - name: hailataxii-cybercrime
+#   available: true
+#   accept_all_content: false
+#   supported_content:
+#     - urn:stix.mitre.org:xml:1.1.1
+#   service_ids:
+#     - hailataxii-discovery
+#     - hailataxii-inbox
+#     - hailataxii-collection
+#     - hailataxii-poll

--- a/deployment/roles/opentaxii/templates/hailataxii-services.yml
+++ b/deployment/roles/opentaxii/templates/hailataxii-services.yml
@@ -1,0 +1,66 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+---
+#
+# discovery: used by a TAXII Client to discover available TAXII Service
+#
+- id: hailataxii-discovery
+  type: discovery
+  address: /services/hailataxii/discovery
+  description: example discovery service
+  advertised_services:
+    - collection
+    - inbox
+    - poll
+  protocol_bindings:
+    - urn:taxii.mitre.org:protocol:http:1.0
+
+#
+# inbox: used by a TAXII Client to push information to a TAXII Server
+#
+- id: hailataxii-inbox
+  type: inbox
+  address: /services/hailataxii/inbox
+  description: example inbox service
+  destination_collection_required: yes
+  accept_all_content: yes
+  authentication_required: no
+  protocol_bindings:
+    - urn:taxii.mitre.org:protocol:http:1.0
+
+#
+# collection_management: used by a TAXII Client to request information about
+# available data collections or request a subscription.
+#
+- id: hailataxii-collection
+  type: collection_management
+  address: /services/hailataxii/collection
+  description: example collection service
+  protocol_bindings:
+    - urn:taxii.mitre.org:protocol:https:1.0
+
+#
+# poll: used by a TAXII Client to request information from a TAXII Server
+#
+- id: hailataxii-poll
+  type: poll
+  address: /services/hailataxii/poll
+  description: example poll service
+  subscription_required: no
+  authentication_required: yes
+  protocol_bindings:
+    - urn:taxii.mitre.org:protocol:http:1.0

--- a/deployment/roles/opentaxii/templates/opentaxii
+++ b/deployment/roles/opentaxii/templates/opentaxii
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# opentaxii daemon
+# chkconfig: 345 20 80
+# description: OpenTAXII is a robust Python implementation of TAXII Service
+# processname: opentaxii
+#
+export LD_LIBRARY_PATH="{{ python27_home }}/usr/lib64"
+export OPENTAXII_CONFIG="{{ opentaxii_home }}/opentaxii-conf.yml"
+
+NAME=opentaxii
+DESC="OpenTAXII is a robust Python implementation of a TAXII service"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+LOGFILE="/var/log/$NAME.log"
+DAEMON_PATH="{{ opentaxii_home }}"
+DAEMON="{{ opentaxii_bin }}/gunicorn"
+DAEMONOPTS="opentaxii.http:app"
+DAEMONOPTS+=" --workers {{ opentaxii_workers }}"
+DAEMONOPTS+=" --log-level {{ opentaxii_loglevel }}"
+DAEMONOPTS+=" --log-file $LOGFILE"
+DAEMONOPTS+=" --timeout {{ opentaxii_timeout }}"
+DAEMONOPTS+=" --bind {{ opentaxii_bind }}"
+DAEMONOPTS+=" --env OPENTAXII_CONFIG={{ opentaxii_home }}/opentaxii-conf.yml"
+
+case "$1" in
+
+  #
+  # start
+  #
+  start)
+    printf "%-50s" "Starting $NAME..."
+
+    # kick-off the daemon
+    cd $DAEMON_PATH
+    . {{ opentaxii_bin }}/activate
+    PID=`$DAEMON $DAEMONOPTS >> $LOGFILE 2>&1 & echo $!`
+    if [ -z $PID ]; then
+        printf "%s\n" "Fail"
+    else
+        echo $PID > $PIDFILE
+        printf "%s\n" "Ok"
+    fi
+  ;;
+
+  #
+  # status
+  #
+  status)
+    printf "%-50s" "Checking $NAME..."
+    if [ -f $PIDFILE ]; then
+      PID=`cat $PIDFILE`
+      if [ -z "`ps axf | grep ${PID} | grep -v grep`" ]; then
+        printf "%s\n" "Process dead but pidfile exists"
+      else
+        echo "Running"
+      fi
+    else
+      printf "%s\n" "Service not running"
+    fi
+  ;;
+
+  #
+  # stop
+  #
+  stop)
+    printf "%-50s" "Stopping $NAME"
+    PID=`cat $PIDFILE`
+    cd $DAEMON_PATH
+    if [ -f $PIDFILE ]; then
+        kill -HUP $PID
+        printf "%s\n" "Ok"
+        rm -f $PIDFILE
+    else
+        printf "%s\n" "pidfile not found"
+    fi
+  ;;
+
+  #
+  # restart
+  #
+  restart)
+    $0 stop
+    $0 start
+  ;;
+
+  #
+  # setup
+  #
+  setup)
+    read -p "WARNING: force reset and destroy all opentaxii data? [Ny]: " REPLY
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      cd $DAEMON_PATH
+      rm -f {{ opentaxii_auth_db }}
+      rm -f {{ opentaxii_data_db }}
+      {{ opentaxii_bin }}/opentaxii-create-services -c {{ opentaxii_home}}/hailataxii-services.yml
+      {{ opentaxii_bin }}/opentaxii-create-collections -c {{ opentaxii_home}}/hailataxii-collections.yml
+      echo "opentaxii successfull reset"
+    fi
+  ;;
+
+  *)
+    echo "Usage: $0 {status|start|stop|restart|setup}"
+    exit 1
+esac

--- a/deployment/roles/opentaxii/templates/opentaxii-conf.yml
+++ b/deployment/roles/opentaxii/templates/opentaxii-conf.yml
@@ -1,0 +1,38 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+---
+domain: "localhost:9000"
+support_basic_auth: no
+
+persistence_api:
+  class: opentaxii.persistence.sqldb.SQLDatabaseAPI
+  parameters:
+    db_connection: "sqlite:///{{ opentaxii_auth_db }}"
+    create_tables: yes
+
+auth_api:
+  class: opentaxii.auth.sqldb.SQLDatabaseAPI
+  parameters:
+    db_connection: "sqlite:///{{ opentaxii_data_db }}"
+    create_tables: yes
+    secret: "{{ opentaxii_salt }}"
+
+logging:
+  opentaxii: info
+  root: info
+
+hooks:


### PR DESCRIPTION
Created an Ansible role that performs automated deployment and setup of OpenTAXII services.  This role has not been integrated into any of the deployments; Amazon or Vagrant.  The integration will occur once all work related to the "pcap ingest refresh" is complete.

Other things to keep in mind...

- Python 2.7 is needed to support OpenTAXII, but CentOS 6 comes with Python 2.6.  The `centos-release-scl` repository is used to install Python 2.7 without impacting the existing Python 2.6.

- OpenTAXII is installed in a virtual environment to maintain isolation.

- The installation is currently backed by a sqlite database.  OpenTAXII can be configured with a proper database like MySQL, but that work has not been done.

---

# OpenTAXII

Installs [OpenTAXII](https://github.com/EclecticIQ/OpenTAXII) as a deamon that can be launched via a SysV service script.  The complementary client implementation, [Cabby](https://github.com/EclecticIQ/cabby) is also installed.

OpenTAXII is a robust Python implementation of TAXII Services that delivers a rich feature set and friendly pythonic API.  [TAXII](https://stixproject.github.io/) (Trusted Automated eXchange of Indicator Information) is a collection of specifications defining a set of services and message exchanges used for sharing cyber threat intelligence information between parties.

## Usage

### Service

A standard SysV script has been installed to manage OpenTAXII.  The following functions are available.

- `start` Start the opentaxii service
- `stop` Stop the opentaxii service
- `restart` Restart the opentaxii service
- `status` Current status of the opentaxii service
- `setup` Creates a set of collections and services to mirror the threat data made available at [Hail a TAXII](http://hailataxii.com/).  Running this will destroy all existing data.

### Troubleshooting

Should you need to explore the installation, here are instructions on doing so.

OpenTAXII is installed in a virtual environment.  Before exploring the environment run the following commands to perform the necessary setup.  The specific paths may change depending on your Ansible settings.

```
export LD_LIBRARY_PATH=/opt/rh/python27/root/usr/lib64
cd /usr/local/opentaxii
. opentaxii-venv/bin/activate
```

Explore the available collections.

```
taxii-collections --path http://hailataxii.com/taxii-data
taxii-collections --path http://localhost:9000/services/hailataxii/collection
```

Read data from a collection.

```
taxii-poll --host hailataxii.com --discovery taxii-data -c guest.phishtank_com
taxii-poll --host localhost:9000 --discovery services/hailataxii/collection -c hailataxii-phishtank
```

Discover available services.

```
taxii-discovery --discovery http://hailataxii.com/taxii-data
taxii-discovery --discovery http://localhost:9000/services/hailataxii/discovery
```

Fetch data from a remote service and mirror it locally.

```
taxii-proxy --poll-path http://hailataxii.com/taxii-data \
                     --poll-collection guest.phishtank_com \
                     --inbox-path http://localhost:9000/services/inbox \
                     --inbox-collection hailataxii-phishtank \
                     --begin 2016-04-17 \
                     --binding urn:stix.mitre.org:xml:1.1.1 \
                     --inbox-username guest --inbox-password guest
```
