### PR TITLE
METRON-123 Pycapa requires 'kafka_broker_url'

### DIFF
--- a/metron-deployment/roles/ambari_gather_facts/tasks/main.yml
+++ b/metron-deployment/roles/ambari_gather_facts/tasks/main.yml
@@ -15,7 +15,10 @@
 #  limitations under the License.
 #
 ---
-- name: Ambari rest get cluster name
+#
+# cluster_name
+#
+- name: "Ask Ambari: cluster_name"
   uri:
     url: "http://{{ groups.ambari_master[0] }}:{{ ambari_port }}/api/v1/clusters"
     user: "{{ ambari_user }}"
@@ -23,11 +26,16 @@
     force_basic_auth: yes
     return_content: yes
   register: cluster_name_response
+  when: cluster_name is undefined
 
 - set_fact:
     cluster_name: "{{ (cluster_name_response.content | from_json)['items'][0].Clusters.cluster_name }}"
+  when: cluster_name is undefined
 
-- name: Ambari rest get namenode hosts
+#
+# namenode_host
+#
+- name: "Ask Ambari: namenode_host"
   uri:
     url: "http://{{ groups.ambari_master[0] }}:{{ ambari_port }}/api/v1/clusters/{{ cluster_name }}/services/HDFS/components/NAMENODE"
     user: "{{ ambari_user }}"
@@ -35,11 +43,16 @@
     force_basic_auth: yes
     return_content: yes
   register: namenode_hosts_response
+  when: namenode_host is undefined
 
 - set_fact:
     namenode_host: "{{ (namenode_hosts_response.content | from_json).host_components[0].HostRoles.host_name }}"
+  when: namenode_host is undefined
 
-- name: Ambari rest get namenode core-site tag
+#
+# core_site_tag
+#
+- name: "Ask Ambari: core_site_tag"
   uri:
     url: "http://{{ groups.ambari_master[0] }}:{{ ambari_port }}/api/v1/clusters/{{ cluster_name }}/hosts/{{ namenode_host }}/host_components/NAMENODE"
     user: "{{ ambari_user }}"
@@ -47,11 +60,16 @@
     force_basic_auth: yes
     return_content: yes
   register: core_site_tag_response
+  when: core_site_tag is undefined
 
 - set_fact:
     core_site_tag: "{{ (core_site_tag_response.content | from_json).HostRoles.actual_configs['core-site'].default }}"
+  when: core_site_tag is undefined
 
-- name: Ambari rest get namenode core-site properties
+#
+# hdfs_url
+#
+- name: "Ask Ambari: hdfs_url"
   uri:
     url: "http://{{ groups.ambari_master[0] }}:{{ ambari_port }}/api/v1/clusters/{{ cluster_name }}/configurations?type=core-site&tag={{ core_site_tag }}"
     user: "{{ ambari_user }}"
@@ -59,11 +77,16 @@
     force_basic_auth: yes
     return_content: yes
   register: core_site_response
+  when: hdfs_url is undefined
 
 - set_fact:
     hdfs_url: "{{ (core_site_response.content | from_json)['items'][0].properties['fs.defaultFS'] }}"
+  when: hdfs_url is undefined
 
-- name: Ambari rest get kafka broker hosts
+#
+# kafka_broker_hosts
+#
+- name: "Ask Ambari: kafka_broker_hosts"
   uri:
     url: "http://{{ groups.ambari_master[0] }}:{{ ambari_port }}/api/v1/clusters/{{ cluster_name }}/services/KAFKA/components/KAFKA_BROKER"
     user: "{{ ambari_user }}"
@@ -71,11 +94,16 @@
     force_basic_auth: yes
     return_content: yes
   register: kafka_broker_hosts_response
+  when: kafka_broker_hosts is undefined
 
 - set_fact:
     kafka_broker_hosts: "{{ (kafka_broker_hosts_response.content | from_json).host_components | map(attribute='HostRoles.host_name') | list }}"
+  when: kafka_broker_hosts is undefined
 
-- name: Ambari rest get kafka kafka-broker tag
+#
+# kafka_broker_tag
+#
+- name: "Ask Ambari: kafka_broker_tag"
   uri:
     url: "http://{{ groups.ambari_master[0] }}:{{ ambari_port }}/api/v1/clusters/{{ cluster_name }}/hosts/{{ kafka_broker_hosts[0] }}/host_components/KAFKA_BROKER"
     user: "{{ ambari_user }}"
@@ -83,11 +111,16 @@
     force_basic_auth: yes
     return_content: yes
   register: kafka_broker_tag_response
+  when: kafka_broker_tag is undefined
 
 - set_fact:
     kafka_broker_tag: "{{ (kafka_broker_tag_response.content | from_json).HostRoles.actual_configs['kafka-broker'].default }}"
+  when: kafka_broker_tag is undefined
 
-- name: Ambari rest get kafka kafka-broker properties
+#
+# kafka_broker_url, kafka_broker_port
+#
+- name: "Ask Ambari: kafka_broker_port, kafka_broker_url"
   uri:
     url: "http://{{ groups.ambari_master[0] }}:{{ ambari_port }}/api/v1/clusters/{{ cluster_name }}/configurations?type=kafka-broker&tag={{ kafka_broker_tag }}"
     user: "{{ ambari_user }}"
@@ -95,14 +128,20 @@
     force_basic_auth: yes
     return_content: yes
   register: kafka_broker_properties_response
+  when: (kafka_broker_url is undefined) or (kafka_broker_port is undefined)
 
 - set_fact:
     kafka_broker_port: "{{ (kafka_broker_properties_response.content | from_json)['items'][0].properties['listeners'] | replace('PLAINTEXT://localhost:', '')}}"
+  when: kafka_broker_port is undefined
 
 - set_fact:
     kafka_broker_url: "{% for host in kafka_broker_hosts %}{% if loop.index != 1 %},{% endif %}{{ host }}:{{ kafka_broker_port }}{% endfor %}"
+  when: kafka_broker_url is undefined
 
-- name: Ambari rest get zookeeper hosts
+#
+# zookeeper_hosts
+#
+- name: "Ask Ambari: zookeeper_hosts"
   uri:
     url: "http://{{ groups.ambari_master[0] }}:{{ ambari_port }}/api/v1/clusters/{{ cluster_name }}/services/ZOOKEEPER/components/ZOOKEEPER_SERVER"
     user: "{{ ambari_user }}"
@@ -110,11 +149,16 @@
     force_basic_auth: yes
     return_content: yes
   register: zookeeper_hosts_response
+  when: zookeeper_hosts is undefined
 
 - set_fact:
     zookeeper_hosts: "{{ (zookeeper_hosts_response.content | from_json).host_components | map(attribute='HostRoles.host_name') | list }}"
+  when: zookeeper_hosts is undefined
 
-- name: Ambari rest get zookeeper zoo.cfg tag
+#
+# zookeeper_tag
+#
+- name: "Ask Ambari: zookeeper_tag"
   uri:
     url: "http://{{ groups.ambari_master[0] }}:{{ ambari_port }}/api/v1/clusters/{{ cluster_name }}/hosts/{{ zookeeper_hosts[0] }}/host_components/ZOOKEEPER_SERVER"
     user: "{{ ambari_user }}"
@@ -122,11 +166,16 @@
     force_basic_auth: yes
     return_content: yes
   register: zookeeper_tag_response
+  when: zookeeper_tag is undefined
 
 - set_fact:
     zookeeper_tag: "{{ (zookeeper_tag_response.content | from_json).HostRoles.actual_configs['zoo.cfg'].default }}"
+  when: zookeeper_tag is undefined
 
-- name: Ambari rest get kafka kafka-broker properties
+#
+# zookeeper_url, zookeeper_port
+#
+- name: "Ask Ambari: zookeeper_url, zookeeper_port"
   uri:
     url: "http://{{ groups.ambari_master[0] }}:{{ ambari_port }}/api/v1/clusters/{{ cluster_name }}/configurations?type=zoo.cfg&tag={{ zookeeper_tag }}"
     user: "{{ ambari_user }}"
@@ -134,13 +183,19 @@
     force_basic_auth: yes
     return_content: yes
   register: zookeeper_properties_response
+  when: zookeeper_url is undefined or zookeeper_port is undefined
 
 - set_fact:
     zookeeper_port: "{{ (zookeeper_properties_response.content | from_json)['items'][0].properties['clientPort'] }}"
+  when: zookeeper_port is undefined
 
 - set_fact:
     zookeeper_url: "{% for host in zookeeper_hosts %}{% if loop.index != 1 %},{% endif %}{{ host }}:{{ zookeeper_port }}{% endfor %}"
+  when: zookeeper_url is undefined
 
+#
+# debug output
+#
 - name: debug
   debug:
     msg: "zookeeper_port = {{ zookeeper_port }},

--- a/metron-deployment/roles/pycapa/defaults/main.yml
+++ b/metron-deployment/roles/pycapa/defaults/main.yml
@@ -22,3 +22,5 @@ pycapa_log: /var/log/pycapa.log
 pycapa_topic: pcap
 pycapa_sniff_interface: "{{ sniff_interface }}"
 python27_home: /opt/rh/python27/root
+
+install_pycapa_service: True

--- a/metron-deployment/roles/pycapa/meta/main.yml
+++ b/metron-deployment/roles/pycapa/meta/main.yml
@@ -15,3 +15,5 @@
 #  limitations under the License.
 #
 ---
+dependencies:
+  - ambari_gather_facts

--- a/metron-deployment/roles/pycapa/tasks/main.yml
+++ b/metron-deployment/roles/pycapa/tasks/main.yml
@@ -17,3 +17,5 @@
 ---
 - include: dependencies.yml
 - include: pycapa.yml
+- include: pycapa-service.yml
+  when: install_pycapa_service

--- a/metron-deployment/roles/pycapa/tasks/pycapa-service.yml
+++ b/metron-deployment/roles/pycapa/tasks/pycapa-service.yml
@@ -15,37 +15,11 @@
 #  limitations under the License.
 #
 ---
-#
-# the 'source' produces network traffic
-#
-- hosts: source
-  become: yes
-  vars_files:
-    - vars/main.yml
-  roles:
-    - role: kafka-broker
-    - role: pcap_replay
-    - { role: pycapa, install_pycapa_service: False }
-    - { role: sensor-test-mode, pcap_replay: True, install_yaf: False, install_snort: False }
+- name: Turn on promiscuous mode for {{ pycapa_sniff_interface }}
+  shell: "ip link set {{ pycapa_sniff_interface }} promisc on"
 
-#
-# the 'sink' consumes network traffic
-#
-- hosts: sink
-  become: yes
-  vars_files:
-    - vars/main.yml
-  roles:
-    - role: librdkafka
-    - role: fastcapa
+- name: Install service script
+  template: src=pycapa dest=/etc/init.d/pycapa mode=0755
 
-#
-# validate the environment - needs to run on `source` node
-#
-- hosts: source
-  become: yes
-  vars_files:
-    - vars/main.yml
-  tasks:
-    - include: tasks/validate-packets-sent.yml
-    - include: tasks/validate-messages-received.yml
+- name: Start pycapa
+  service: name=pycapa state=restarted

--- a/metron-deployment/roles/pycapa/tasks/pycapa.yml
+++ b/metron-deployment/roles/pycapa/tasks/pycapa.yml
@@ -38,12 +38,3 @@
   with_items:
     - "{{ pycapa_bin }}/pip install -r requirements.txt"
     - "{{ pycapa_bin }}/python setup.py install"
-
-- name: Turn on promiscuous mode for {{ pycapa_sniff_interface }}
-  shell: "ip link set {{ pycapa_sniff_interface }} promisc on"
-
-- name: Install service script
-  template: src=pycapa dest=/etc/init.d/pycapa mode=0755
-
-- name: Start pycapa
-  service: name=pycapa state=restarted

--- a/metron-deployment/vagrant/fastcapa-vagrant/vars/main.yml
+++ b/metron-deployment/vagrant/fastcapa-vagrant/vars/main.yml
@@ -24,3 +24,15 @@ kafka_broker_url: source:9092
 zookeeper_url: source:2181
 pcap_replay_interface: eth1
 kafka_broker_home: /usr/hdp/current/kafka-broker/
+
+# dummy variables for pycapa's dependence on ambari_gather_facts
+cluster_name: dummy
+namenode_host: dummy
+core_site_tag: dummy
+hdfs_url: dummy
+kafka_broker_hosts: dummy
+kafka_broker_tag: dummy
+kafka_broker_port: dummy
+zookeeper_hosts: dummy
+zookeeper_tag: dummy
+zookeeper_port: dummy


### PR DESCRIPTION
Pycapa needs to know the URL of the Kafka Broker to send packet data to. During a standard deployment, such as single node vagrant or amazon-ec2, this URL needs to be retrieved from Ambari.  When using Pycapa to test other functionality, like fastcapa, Ambari is not used.  In these cases the URL need to be specified by the user instead of being retrieved from Ambari.

The Pycapa role at `metron-deployment/roles/pycapa` previously had a dependency on `ambari_gather_facts` through which it retrieved the Kafka Broker URL. This dependency was removed in METRON-110 which introduced this bug.

### Changes
- Changed the `ambari_gather_facts` Ansible role so that it only retrieves information from Ambari if the information is not already known.
- Updated Pycapa so that the service start script can be installed or not depending on a variable.  As a sensor, we need the start script installed.  As a testing tool, we do not need the start script installed.
- Update Fastcapa test environment so extra dummy variables are provided instead of having the process reach out to a nonexistent Ambari server.

### Validation
Running Pycapa in Single Node Vagant provided the "positive" test, using Ambari to retrieve value, and using the Fastcapa Test Environment provided the "negative" test, using a user-provided value.
- Single Node Vagrant Environment `cd metron-deploymet/vagrant/singlenode-vagrant; vagrant up`
- Fastcapa Test Environment `cd metron-deployment/vagrant/fastcapa-vagrant; vagrant up`