### PR TITLE
METRON-128 - Create Platform Launch and Troubleshooting Scripts

### DIFF
--- a/metron-deployment/amazon-ec2/.gitignore
+++ b/metron-deployment/amazon-ec2/.gitignore
@@ -2,3 +2,4 @@
 *.secret
 *.log
 *.retry
+.metron-env

--- a/metron-deployment/amazon-ec2/README.md
+++ b/metron-deployment/amazon-ec2/README.md
@@ -3,18 +3,40 @@ Apache Metron on Amazon EC2
 
 This project fully automates the provisioning of Apache Metron on Amazon EC2 infrastructure.  Starting with only your Amazon EC2 credentials, this project will create a fully-functioning, end-to-end, multi-node cluster running Apache Metron.
 
+Warning: Amazon will charge for the use of their resources when running Apache Metron.  The amount will vary based on the number and size of hosts, along with current Amazon pricing structure.  Be sure to stop or terminate all of the hosts instantiated by Apache Metron when not in use to avoid unnecessary charges.
+
 Getting Started
 ---------------
 
 ### Prerequisites
 
-The host that will drive the provisioning process will need to have [Ansible](https://github.com/ansible/ansible), Python and PIP installed.  In most cases, a development laptop serves this purpose just fine.  Also, install the Python library `boto` and its dependencies.  
+The computer used to deploy Apache Metron will need to have [Ansible](https://github.com/ansible/ansible), Python, Maven, SSH, and Git installed.  Any platform that supports these tools is suitable, but the following instructions cover only Mac OS X.  The easiest means of installing these tools on a Mac is to use the excellent [Homebrew](http://brew.sh/) project.
 
-```
-pip install boto six
-```
+1. Install Homebrew by running the following command in a terminal.  Refer to the  [Homebrew](http://brew.sh/) home page for the latest installation instructions.
 
-Ensure that an SSH key has been generated and stored at `~/.ssh/id_rsa.pub`.  In most cases this key will already exist and no further action will be needed.
+  ```
+  /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  ```
+
+2. With Homebrew installed, run the following command in a terminal to install all of the required tools.
+
+  ```  
+  brew install ansible brew-pip maven git
+  ```
+
+3. Ensure that a public SSH key is located at `~/.ssh/id_rsa.pub`.  
+
+  ```
+  $ cat ~/.ssh/id_rsa.pub
+  ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQChv5GJxPjR39UJV7VY17ivbLVlxFrH7UHwh1Jsjem4d1eYiAtde5N2y65/HRNxWbhYli9ED8k0/MRP92ejewucEbrPNq5mytPqdC4IvZ98Ln2GbqTDwvlP3T7xa/wYFOpFsOmXXql8216wSrnrS4f3XK7ze34S6/VmY+lsBYnr3dzyj8sG/mexpJgFS/w83mWJV0e/ryf4Hd7P6DZ5fO+nmTXfKNK22ga4ctcnbZ+toYcPL+ODCh8598XCKVo97XjwF5OxN3vl1p1HHguo3cHB4H1OIaqX5mUt59gFIZcAXUME89PO6NUiZDd3RTstpf125nQVkQAHu2fvW96/f037 nick@localhost
+  ```
+
+  If this file does not exist, run the following command at a terminal and accept all defaults.  Only the public key, not the private key, will be uploaded to Amazon and configured on each host to enable SSH connectivity.  While it is possible to create and use an alternative key those details will not be covered.  
+
+  ```
+  ssh-keygen -t rsa
+  ```
+
 
 ### Create User
 
@@ -29,28 +51,26 @@ Ensure that an SSH key has been generated and stored at `~/.ssh/id_rsa.pub`.  In
 
 3. Create an access key for the user by clicking on `Security Credentials > Create Access Key`.  Save the provided access key values in a safe place.  These values cannot be retrieved from the web console at a later time.
 
-4. Use the access key by exporting its values to the shell's environment.  This allows Ansible to authenticate with Amazon EC2.  For example:
+### Deploy Metron
+
+1. Use the Amazon access key by exporting its values via the shell's environment.  This allows Ansible to authenticate with Amazon EC2.  For example:
 
   ```
   export AWS_ACCESS_KEY_ID="AKIAI6NRFEO27E5FFELQ"
   export AWS_SECRET_ACCESS_KEY="vTDydWJQnAer7OWauUS150i+9Np7hfCXrrVVP6ed"
   ```
 
-### Deploy Metron
+  Notice: You must replace the access key values above with values from your own access key.
 
-1. Ensure that Metron's streaming topology uber-jar has been built.
-
-  ```
-  cd ../../metron-platform
-  mvn clean package -DskipTests
-  ```
-
-2. Start the Metron playbook.  A full Metron deployment can consume up to 60 minutes.  Grab a coffee, relax and practice mindfulness meditation.  If the playbook fails mid-stream for any reason, simply re-run it.  
+2. Start the Apache Metron deployment process.  When prompted provide a unique name for your Metron environment or accept the default.  
 
   ```
-  export EC2_INI_PATH=conf/ec2.ini
-  ansible-playbook -i ec2.py playbook.yml
+  $ ./run.sh
+  Metron Environment [metron-test]: my-metron-env
+  ...
   ```
+
+  The process is likely to take between 70-90 minutes.  Fortunately, everything is fully automated and you should feel free to grab a coffee.
 
 ### Explore Metron
 

--- a/metron-deployment/amazon-ec2/run.sh
+++ b/metron-deployment/amazon-ec2/run.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+#
+# Builds Metron platform jars, instantiates hosts, and deploys Metron to those
+# hosts on Amazon EC2
+#
+
+LOGFILE="./ansible.log"
+DEPLOYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+EXTRA_VARS="-v"
+NOW=`date`
+DEFAULT_ENV="metron-test"
+DEFAULT_ENV_FILE="./.metron-env"
+
+# ensure aws access key is defined
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+  echo "Error: missing AWS_ACCESS_KEY_ID"
+  exit 1
+fi
+
+# ensure aws access key is defined
+if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+  echo "Error: missing AWS_SECRET_ACCESS_KEY"
+  exit 1
+fi
+
+# retrieve environment name from previous run
+if [ -f $DEFAULT_ENV_FILE ]; then
+  ENV=`cat $DEFAULT_ENV_FILE`
+else
+  ENV=$DEFAULT_ENV
+fi
+
+# prompt the user for an environment name
+read -p "Metron Environment [$ENV]: " INPUT
+[ -n "$INPUT" ] && ENV=$INPUT
+
+# store the environment name for the next run
+echo "$ENV" > $DEFAULT_ENV_FILE
+
+# log information about the host platform
+echo "=============================================================" >> $LOGFILE
+echo "Launching Metron @ $NOW"... >> $LOGFILE
+echo "Metron Environment: $ENV" >> $LOGFILE
+$DEPLOYDIR/../scripts/platform-info.sh >> $LOGFILE
+
+# build metron
+cd ../../metron-platform
+mvn package -DskipTests
+
+# deploy metron
+cd $DEPLOYDIR
+export EC2_INI_PATH=conf/ec2.ini
+ansible-playbook -i ec2.py playbook.yml --extra-vars="env=$ENV" $EXTRA_VARS

--- a/metron-deployment/scripts/platform-info.sh
+++ b/metron-deployment/scripts/platform-info.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+#
+# extracts information from the host environment that is useful for
+# troubleshooting Apache Metron deployments
+#
+CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# extract metron version from the pom
+METRON_VERSION=`cat $CWD/../../pom.xml | grep "<version>" | head -1 | sed -ne '/version/{s/.*<version>\(.*\)<\/version>.*/\1/p;q;}'`
+echo "Metron $METRON_VERSION"
+
+# is this a git repo?
+IS_GIT_REPO=`git rev-parse --is-inside-work-tree`
+if [ "$IS_GIT_REPO" == "true" ]; then
+
+  # current branch
+  echo "--"
+  git branch | grep "*"
+
+  # last commit
+  echo "--"
+  git log -n 1
+
+  # local changes since last commit
+  echo "--"
+  git diff --stat
+fi
+
+# ansible
+echo "--"
+ansible --version
+
+# vagrant
+echo "--"
+vagrant --version
+
+# python
+echo "--"
+python --version 2>&1
+
+# maven
+echo "--"
+mvn --version
+
+# operating system
+echo "--"
+uname -a


### PR DESCRIPTION
Changes
------------
- `metron-deployment/scripts/platform-info.sh`
  - A means of extracting useful host information that can be used for troubleshooting.
-  `metron-deployment/amazon-ec2/run.sh`
  - Simplifies the deployment process and checks for common user errors.
  - Adds host/platform information to `ansible.log` to aid in troubleshooting.
- `metron-deployment/amazon-ec2/README.md`
  - Updated to show use of `run.sh`
  - Added warning about AWS costs

Usage
--------

```
$ metron-deployment/scripts/platform-info.sh
Metron 0.1BETA
--
* METRON-128
--
commit c8a8f8f06b89cbb4b365e3b6633ccbb0e3d98fba
Author: Nick Allen <nick@nickallen.org>
Date:   Fri Apr 29 08:46:35 2016 -0400

    METRON-128 - Create Platform Launch and Troubleshooting Scripts
--
--
ansible 2.0.1.0
  config file = /Users/nallen/Development/incubator-metron/metron-deployment/ansible.cfg
  configured module search path = extra_modules
--
Vagrant 1.8.1
--
Python 2.7.11
--
Apache Maven 3.3.9 (bb52d8502b132ec0a5a3f4c09453c07478323dc5; 2015-11-10T11:41:47-05:00)
Maven home: /usr/local/Cellar/maven/3.3.9/libexec
Java version: 1.8.0_66, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_66.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.11.4", arch: "x86_64", family: "mac"
--
Darwin HW12402.local 15.4.0 Darwin Kernel Version 15.4.0: Fri Feb 26 22:08:05 PST 2016; root:xnu-3248.40.184~3/RELEASE_X86_64 x86_64
```

```
$ metron-deployment/amazon-ec2/run.sh
Metron Environment [metron-test]: my-custom-env
...
```

Validation
-------------
- Deployment to Amazon EC2