### PR TITLE
METRON-91 Expose tags and skip tags to Vagrant

### DIFF
--- a/metron-deployment/vagrant/singlenode-vagrant/README.md
+++ b/metron-deployment/vagrant/singlenode-vagrant/README.md
@@ -61,7 +61,33 @@ Now that the hard part is done, start the Metron deployment process.
   ```
   vagrant provision
   ```
-
+  
+  In addition to re-running the entire provisioning play book, you may now re-run an individual Ansible tag or a collection of tags in the following ways.
+  
+  ```
+  ./run_ansible_role.sh web
+  ```
+  or
+  ```
+  vagrant --ansible-tags="web" provision
+  ```
+  Will re-run the web role on the Vagrant image. This will re-install (if necessary) and start the UI.
+   
+  A collection of tags is specified as a comma separated list.
+  
+  ```
+  ./run_ansbile_role.sh "sensors,enrichment"
+  
+  ```
+  
+  Tags are listed in the playbooks, some frequently used tags:
+  + hdp-install - Install HDP
+  + hdp-deploy - Deploy and Start HDP Services (will start all Hadoop Services)
+  + sensors - Deploy and Start Sensors.
+  + enrichment - Deploy and Start Enrichment Topology.
+  
+  Note: there is a convienence script, ```./run_enrichment_role.sh```,  which runs the enrichment tag.
+  
 ### Explore Metron
 
 Navigate to the following resources to explore your newly minted Apache Metron environment.

--- a/metron-deployment/vagrant/singlenode-vagrant/Vagrantfile
+++ b/metron-deployment/vagrant/singlenode-vagrant/Vagrantfile
@@ -14,6 +14,33 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+require 'getoptlong'
+
+ansibleTags=''
+ansibleSkipTags=''
+
+begin
+   opts = GetoptLong.new(
+     [ '--ansible-tags', GetoptLong::OPTIONAL_ARGUMENT ],
+     [ '--ansible-skip-tags', GetoptLong::OPTIONAL_ARGUMENT ]
+   )
+
+   opts.quiet = TRUE
+
+   opts.each do |opt, arg|
+     case opt
+       when '--ansible-tags'
+         ansibleTags=arg
+       when '--ansible-skip-tags'
+         ansibleSkipTags=arg
+     end
+   end
+rescue Exception => ignored
+#Ignore to allow other opts to be passed to Vagrant
+end
+
+puts " Running with ansible-tags: " + ansibleTags.split(",").to_s if ansibleTags != ''
+puts " Running with ansible-skip-tags: " + ansibleSkipTags.split(",").to_s if ansibleSkipTags != ''
 
 hosts = [{
     hostname: "node1",
@@ -27,7 +54,7 @@ Vagrant.configure(2) do |config|
 
   # all hosts built on centos 6
   config.vm.box = "bento/centos-6.7"
-  config.ssh.insert_key = "true"
+  config.ssh.insert_key = true
 
   # enable the hostmanager plugin
   config.hostmanager.enabled = true
@@ -58,6 +85,8 @@ Vagrant.configure(2) do |config|
   config.vm.provision :ansible do |ansible|
     ansible.playbook = "../../playbooks/metron_full_install.yml"
     ansible.sudo = true
+    ansible.tags = ansibleTags.split(",") if ansibleTags != ''
+    ansible.skip_tags = ansibleSkipTags.split(",") if ansibleSkipTags != ''
     ansible.inventory_path = "../../inventory/singlenode-vagrant"
   end
 end

--- a/metron-deployment/vagrant/singlenode-vagrant/ansible.cfg
+++ b/metron-deployment/vagrant/singlenode-vagrant/ansible.cfg
@@ -20,3 +20,8 @@ library = ../../extra_modules
 roles_path = ../../roles
 pipelining = True
 log_path = ./ansible.log
+
+
+# fix for "ssh throws 'unix domain socket too long' " problem
+[ssh_connection]
+control_path = %(directory)s/%%h-%%p-%%r

--- a/metron-deployment/vagrant/singlenode-vagrant/run_ansible_role.sh
+++ b/metron-deployment/vagrant/singlenode-vagrant/run_ansible_role.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+vagrant --ansible-tags="$@" provision

--- a/metron-deployment/vagrant/singlenode-vagrant/run_enrichment_role.sh
+++ b/metron-deployment/vagrant/singlenode-vagrant/run_enrichment_role.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+./run_ansible_role.sh enrichment


### PR DESCRIPTION
Tested with the following:
- [x] Clean run "vagrant up"
- [x] Skip tags "vagrant --ansible-skip-tags="ambari" up
- [x] Tags "vagrant --ansible-tags="ambari,metron" up
- [x] ./run_enrichment_role.sh 

Edit - AND
- [x] vagrant destroy -f (sorry, forgot to mention that)
