### PR TITLE
METRON-135: Ambari Start needs to set state to 'restarted'

### DIFF
--- a/metron-deployment/roles/ambari_master/tasks/main.yml
+++ b/metron-deployment/roles/ambari_master/tasks/main.yml
@@ -41,5 +41,5 @@
 - name: start ambari server
   service:
     name: ambari-server
-    state: started
+    state: restarted
 


### PR DESCRIPTION
Set state to restarted and tested on single node vagrant.