### PR TITLE
METRON-137: Improve output on ignored errors.

### DIFF
--- a/metron-deployment/roles/hadoop_setup/tasks/main.yml
+++ b/metron-deployment/roles/hadoop_setup/tasks/main.yml
@@ -18,20 +18,24 @@
 #must run on hadoop host
 - name: Create HBase tables
   shell: echo "create '{{ item }}','t'" | hbase shell -n
-  ignore_errors: yes
   with_items:
     - "{{ pcap_hbase_table }}"
     - "{{ tracker_hbase_table }}"
     - "{{ threatintel_hbase_table }}"
     - "{{ enrichment_hbase_table }}"
+  register: hbase_result
+  failed_when: hbase_result.rc != 0 and ("Table already exists" not in hbase_result.stdout)
+  changed_when: ("Table already exists" not in hbase_result.stdout)
 
-#if kafka topic
 - name: Create Kafka topics
   shell: "{{ kafka_home }}/bin/kafka-topics.sh --zookeeper {{ zookeeper_url }} --create --topic {{ item }} --partitions {{ num_partitions }} --replication-factor 1 --config retention.bytes={{ retention_in_gb * 1024 * 1024 * 1024}}"
-  ignore_errors: yes
   with_items:
     - "{{ pycapa_topic }}"
     - "{{ bro_topic }}"
     - "{{ yaf_topic }}"
     - "{{ snort_topic }}"
     - "{{ enrichments_topic }}"
+  register: kafka_result
+  failed_when: kafka_result.rc != 0 and ("already exists" not in kafka_result.stderr)
+  changed_when: ("already exists" not in kafka_result.stderr)
+

--- a/metron-deployment/roles/metron_ui/tasks/metron-ui.yml
+++ b/metron-deployment/roles/metron_ui/tasks/metron-ui.yml
@@ -40,7 +40,8 @@
   shell: pm2 stop all
   args:
     creates: /etc/init.d/pm2-init.sh
-  ignore_errors: True
+  register: pm2_result
+  failed_when: pm2_result.rc != 0 and ("No process found" not in pm2_result.stderr)
 
 - name: Configure Metron UI as a service
   shell: "{{ item }}"


### PR DESCRIPTION
HBase table creation, Kafka topic creation and UI stop will no longer output error text when there is no error.

Tested with:
 + full-dev-platform (vagrant up followed by vagrant provision)
 + quick-dev-platform (./launch_dev_image.sh followed by ./run_ansbile_role.sh "metron-prereqs,web")

