### PR TITLE
Metron 136 logrotate pcapservice

### DIFF
--- a/metron-deployment/roles/metron_pcapservice/defaults/main.yml
+++ b/metron-deployment/roles/metron_pcapservice/defaults/main.yml
@@ -24,3 +24,5 @@ pcapservice_port: 8081
 hbase_config_path: "/etc/hbase/conf"
 query_hdfs_path: "/tmp"
 pcap_hdfs_path: "/apps/metron/pcap"
+metron_pcapservice_logrotate_frequency: daily
+metron_pcapservice_logrotate_retention: 30

--- a/metron-deployment/roles/metron_pcapservice/defaults/main.yml
+++ b/metron-deployment/roles/metron_pcapservice/defaults/main.yml
@@ -26,3 +26,4 @@ query_hdfs_path: "/tmp"
 pcap_hdfs_path: "/apps/metron/pcap"
 metron_pcapservice_logrotate_frequency: daily
 metron_pcapservice_logrotate_retention: 30
+

--- a/metron-deployment/roles/metron_pcapservice/tasks/main.yml
+++ b/metron-deployment/roles/metron_pcapservice/tasks/main.yml
@@ -22,3 +22,4 @@
     src: "metron-pcapservice-logrotate.yml"
     dest: "/etc/logrotate.d/metron-pcapservice"
     mode: 0644
+

--- a/metron-deployment/roles/metron_pcapservice/tasks/main.yml
+++ b/metron-deployment/roles/metron_pcapservice/tasks/main.yml
@@ -16,3 +16,9 @@
 #
 ---
 - include: pcapservice.yml
+
+- name: Create Logrotate Script for metron_pcapservice
+  template:
+    src: "metron-pcapservice-logrotate.yml"
+    dest: "/etc/logrotate.d/metron-pcapservice"
+    mode: 0644

--- a/metron-deployment/roles/metron_pcapservice/templates/metron-pcapservice-logrotate.yml
+++ b/metron-deployment/roles/metron_pcapservice/templates/metron-pcapservice-logrotate.yml
@@ -1,0 +1,25 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+#Metron pcapService
+/var/log/metron_pcapservice.log {
+  {{ metron_pcapservice_logrotate_frequency }}
+  rotate {{ metron_pcapservice_logrotate_retention }}
+  missingok
+  notifempty
+  copytruncate
+}

--- a/metron-deployment/roles/metron_pcapservice/templates/metron-pcapservice-logrotate.yml
+++ b/metron-deployment/roles/metron_pcapservice/templates/metron-pcapservice-logrotate.yml
@@ -23,3 +23,4 @@
   notifempty
   copytruncate
 }
+


### PR DESCRIPTION
I tested this by starting the full-dev-platform vagrant image. The logrotate.d config file was created. I ran logrotate with the -f option (force) to test the configuration and it worked properly.

The configuration is consistent with the other logrotate configs in metron, but I have a couple of questions, which perhaps should be posted elsewhere. These questions apply to most of the default Metron logrotate configurations:

#1 - Should the pcap logs  be in their own directory like most other metron logs instead of /var/log/metron_pcapservice.log?

#2 - Should we change to compress (gzip)?

#3 - Regarding all logrotate configs, should we change them to use dateext? Currently it changes files like this:
/var/log/metron_pcapservice.log.1
/var/log/metron_pcapservice.log.2

Where, using dateext makes them:
/var/log/metron_pcapservice.log.20160507
/var/log/metron_pcapservice.log.20160508

The disadvantage to this is that even if you try to force the rotate  (-f), I don't think it will rotate because the date it would rotate to already exists. With the number, if just adds a new number.

