### PR TITLE
Updating document to have the correct script name, instructions on in…

### DIFF
--- a/metron-deployment/vagrant/codelab-platform/README.md
+++ b/metron-deployment/vagrant/codelab-platform/README.md
@@ -16,6 +16,24 @@ As with the Singlenode Full Image, the computer used to deploy Apache Metron wil
  - Python 2.7.11
  - Maven 3.3.9
 
+### Ensure vagrant hostmanager is installed
+
+To check and make sure you have the plugin installed execute the following:
+
+ ```
+ vagrant plugin list
+ ```
+
+If you have it installed you should see the following listed in the output:
+
+  ```
+  vagrant-hostmanager (1.8.1)
+  ```
+If it is not installed, you can install it with the following command:
+
+  ```
+  vagrant plugin install vagrant-hostmanager
+  ```
 
 ### Launch the Metron Development Image
 
@@ -23,7 +41,7 @@ Start the image with the following commands:
 
   ```
   cd metron-deployment/vagrant/codelab-platform
-  ./launch_dev_image.sh
+  ./launch_image.sh
   ```
 
 ### Work with Metron
@@ -36,8 +54,8 @@ As you build out new capabilities for Metron, you will need to re-deploy the Sto
 
 Remember Navigate to the following resources to explore your newly minted Apache Metron environment.
 
- - [Metron](http://node1:8080)
- - [Ambari](http://node1:5000)
+ - [Metron](http://node1:5000)
+ - [Ambari](http://node1:8080)
 
 Connecting to the host through SSH is as simple as running the following command.
 


### PR DESCRIPTION
Updated the README to correct the following:

1. The script name in the directory is launch_image.sh not launch_dev_image.sh
2. The ports for the Ambari and Metron UI were flipped

Also added instructions for installing vagrant hostmanager, if the user does a fresh vagrant install this is not installed by default and they will get errors when they run the launch_image script.
