### PR TITLE
Specify shorter control_path to avoid 'unix domain socket too long' problem

### DIFF
--- a/metron-deployment/amazon-ec2/ansible.cfg
+++ b/metron-deployment/amazon-ec2/ansible.cfg
@@ -25,4 +25,4 @@ log_path = ./ansible.log
 
 # fix for "ssh throws 'unix domain socket too long' " problem
 [ssh_connection]
-control_path = %(directory)s/%%h-%%p-%%r
+control_path = /tmp/%%h-%%p-%%r

--- a/metron-deployment/amazon-ec2/ansible.cfg
+++ b/metron-deployment/amazon-ec2/ansible.cfg
@@ -25,4 +25,4 @@ log_path = ./ansible.log
 
 # fix for "ssh throws 'unix domain socket too long' " problem
 [ssh_connection]
-control_path = /tmp/%%h-%%p-%%r
+control_path = ~/.ssh/ansible-ssh-%%C


### PR DESCRIPTION
Paired with Ryan Merriman on this fix.  This issue is reported in the following Jira:  https://issues.apache.org/jira/browse/METRON-168