### PR TITLE
Metron-126 added dfs.replication=1 for single node vm

### DIFF
--- a/metron-deployment/roles/ambari_config/vars/single_node_vm.yml
+++ b/metron-deployment/roles/ambari_config/vars/single_node_vm.yml
@@ -47,6 +47,7 @@ configurations:
       hbase_master_heapsize: 512
       hbase_regionserver_xmn_max: 512
   - hdfs-site:
+      dfs.replication: 1
       dfs.namenode.checkpoint.dir: '{{ namenode_checkpoint_dir  }}'
       dfs.namenode.name.dir: '{{ namenode_name_dir }}'
       dfs.datanode.data.dir: '{{ datanode_data_dir }}'


### PR DESCRIPTION
 Added dfs.replication=1 for single node vm in single_node_vm.yml
Tested it by running full-dev-platform.