### PR TITLE
METRON-183 Allow the simple hbase enrichment adapter and simple threat intel adapter to use multiple column families

### DIFF
--- a/metron-platform/metron-common/README.md
+++ b/metron-platform/metron-common/README.md
@@ -68,18 +68,28 @@ The configuration is a complex JSON object with the following top level fields:
 ###The `enrichment` Configuration 
 
 
-| Field            | Description                                                                                                                                                                                                                      | Example                                                                   |
-|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| Field            | Description                                                                                                                                                                                                                   | Example                                                          |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
 | `fieldToTypeMap` | In the case of a simple HBase enrichment (i.e. a key/value lookup), the mapping between fields and the enrichment types associated with those fields must be known.  This enrichment type is used as part of the HBase key. | `"fieldToTypeMap" : { "ip_src_addr" : [ "asset_enrichment" ] }`  |
-| `fieldMap`       | The map of enrichment bolts names to fields in the JSON messages.,Each field is sent to the enrichment referenced in the key.                                                                                                    | `"fieldMap": {"hbaseEnrichment": ["ip_src_addr","ip_dst_addr"]}` |
+| `fieldMap`       | The map of enrichment bolts names to fields in the JSON messages.,Each field is sent to the enrichment referenced in the key.                                                                                                 | `"fieldMap": {"hbaseEnrichment": ["ip_src_addr","ip_dst_addr"]}` |
+| `config`         | The general configuration for the enrichment                                                                                                                                                                                  | `"config": {"typeToColumnFamily": { "asset_enrichment","cf" } }` |
+
+The `config` map is intended to house enrichment specific configuration.
+For instance, for the `hbaseEnrichment`, the mappings between the
+enrichment types to the column families is specified.
 
 ###The `threatIntel` Configuration 
 
-| Field            | Description                                                                                                                                                                                                                                      | Example                                                                  |
-|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| Field            | Description                                                                                                                                                                                                                                   | Example                                                                  |
+|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
 | `fieldToTypeMap` | In the case of a simple HBase threat intel enrichment (i.e. a key/value lookup), the mapping between fields and the enrichment types associated with those fields must be known.  This enrichment type is used as part of the HBase key. | `"fieldToTypeMap" : { "ip_src_addr" : [ "malicious_ips" ] }`             |
 | `fieldMap`       | The map of threat intel enrichment bolts names to fields in the JSON messages. Each field is sent to the threat intel enrichment bolt referenced in the key.                                                                              | `"fieldMap": {"hbaseThreatIntel": ["ip_src_addr","ip_dst_addr"]}`        |
-| `triageConfig`   | The configuration of the threat triage scorer.  In the situation where a threat is detected, a score is assigned to the message and embedded in the indexed message.                                                                             | `"riskLevelRules" : { "IN_SUBNET(ip_dst_addr, '192.168.0.0/24')" : 10 }` |
+| `triageConfig`   | The configuration of the threat triage scorer.  In the situation where a threat is detected, a score is assigned to the message and embedded in the indexed message.                                                                    | `"riskLevelRules" : { "IN_SUBNET(ip_dst_addr, '192.168.0.0/24')" : 10 }` |
+| `config`         | The general configuration for the Threat Intel                                                                                                                                                                                                | `"config": {"typeToColumnFamily": { "malicious_ips","cf" } }`            |
+
+The `config` map is intended to house threat intel specific configuration.
+For instance, for the `hbaseThreatIntel` threat intel adapter, the mappings between the
+enrichment types to the column families is specified.
 
 The `triageConfig` field is also a complex field and it bears some description:
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/EnrichmentConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/EnrichmentConfig.java
@@ -25,6 +25,15 @@ import java.util.Map;
 public class EnrichmentConfig {
   private Map<String, List<String>> fieldMap = new HashMap<>();
   private Map<String, List<String>> fieldToTypeMap = new HashMap<>();
+  private Map<String, Object> config = new HashMap<>();
+
+  public Map<String, Object> getConfig() {
+    return config;
+  }
+
+  public void setConfig(Map<String, Object> config) {
+    this.config = config;
+  }
 
   public Map<String, List<String>> getFieldMap() {
     return fieldMap;
@@ -43,6 +52,15 @@ public class EnrichmentConfig {
   }
 
   @Override
+  public String toString() {
+    return "EnrichmentConfig{" +
+            "fieldMap=" + fieldMap +
+            ", fieldToTypeMap=" + fieldToTypeMap +
+            ", config=" + config +
+            '}';
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
@@ -50,7 +68,9 @@ public class EnrichmentConfig {
     EnrichmentConfig that = (EnrichmentConfig) o;
 
     if (getFieldMap() != null ? !getFieldMap().equals(that.getFieldMap()) : that.getFieldMap() != null) return false;
-    return getFieldToTypeMap() != null ? getFieldToTypeMap().equals(that.getFieldToTypeMap()) : that.getFieldToTypeMap() == null;
+    if (getFieldToTypeMap() != null ? !getFieldToTypeMap().equals(that.getFieldToTypeMap()) : that.getFieldToTypeMap() != null)
+      return false;
+    return getConfig() != null ? getConfig().equals(that.getConfig()) : that.getConfig() == null;
 
   }
 
@@ -58,14 +78,7 @@ public class EnrichmentConfig {
   public int hashCode() {
     int result = getFieldMap() != null ? getFieldMap().hashCode() : 0;
     result = 31 * result + (getFieldToTypeMap() != null ? getFieldToTypeMap().hashCode() : 0);
+    result = 31 * result + (getConfig() != null ? getConfig().hashCode() : 0);
     return result;
-  }
-
-  @Override
-  public String toString() {
-    return "EnrichmentConfig{" +
-            "fieldMap=" + fieldMap +
-            ", fieldToTypeMap=" + fieldToTypeMap +
-            '}';
   }
 }

--- a/metron-platform/metron-data-management/src/test/java/org/apache/metron/dataloads/hbase/mr/LeastRecentlyUsedPrunerIntegrationTest.java
+++ b/metron-platform/metron-data-management/src/test/java/org/apache/metron/dataloads/hbase/mr/LeastRecentlyUsedPrunerIntegrationTest.java
@@ -37,6 +37,7 @@ import org.apache.metron.enrichment.lookup.accesstracker.BloomAccessTracker;
 import org.apache.metron.enrichment.lookup.accesstracker.PersistentAccessTracker;
 import org.apache.metron.dataloads.bulk.ThreatIntelBulkLoader;
 import org.apache.metron.dataloads.nonbulk.taxii.TaxiiLoader;
+import org.apache.metron.enrichment.lookup.handler.KeyWithContext;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -118,7 +119,7 @@ public class LeastRecentlyUsedPrunerIntegrationTest {
                                                   )
                                           )
                          );
-            Assert.assertTrue(lookup.exists((EnrichmentKey)k, testTable, true));
+            Assert.assertTrue(lookup.exists((EnrichmentKey)k, new EnrichmentLookup.HBaseContext(testTable, cf), true));
         }
         pat.persist(true);
         for(LookupKey k : goodKeysOtherHalf) {
@@ -129,7 +130,7 @@ public class LeastRecentlyUsedPrunerIntegrationTest {
                                                                   )
                                          )
                          );
-            Assert.assertTrue(lookup.exists((EnrichmentKey)k, testTable, true));
+            Assert.assertTrue(lookup.exists((EnrichmentKey)k, new EnrichmentLookup.HBaseContext(testTable, cf), true));
         }
         testUtil.flush();
         Assert.assertFalse(lookup.getAccessTracker().hasSeen(goodKeysHalf.get(0)));
@@ -153,10 +154,10 @@ public class LeastRecentlyUsedPrunerIntegrationTest {
         Job job = LeastRecentlyUsedPruner.createJob(config, tableName, cf, atTableName, atCF, ts);
         Assert.assertTrue(job.waitForCompletion(true));
         for(LookupKey k : goodKeys) {
-            Assert.assertTrue(lookup.exists((EnrichmentKey)k, testTable, true));
+            Assert.assertTrue(lookup.exists((EnrichmentKey)k, new EnrichmentLookup.HBaseContext(testTable, cf), true));
         }
         for(LookupKey k : badKey) {
-            Assert.assertFalse(lookup.exists((EnrichmentKey)k, testTable, true));
+            Assert.assertFalse(lookup.exists((EnrichmentKey)k, new EnrichmentLookup.HBaseContext(testTable, cf), true));
         }
 
     }

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/simplehbase/SimpleHBaseAdapter.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/simplehbase/SimpleHBaseAdapter.java
@@ -70,9 +70,11 @@ public class SimpleHBaseAdapter implements EnrichmentAdapter<CacheKey>,Serializa
       try {
         for (LookupKV<EnrichmentKey, EnrichmentValue> kv :
                 lookup.get(Iterables.transform(enrichmentTypes
-                                              , new EnrichmentUtils.TypeToKey(value.getValue())
+                                              , new EnrichmentUtils.TypeToKey( value.getValue()
+                                                                             , lookup.getTable()
+                                                                             , value.getConfig().getEnrichment()
+                                                                             )
                                               )
-                          , lookup.getTable()
                           , false
                           )
             )

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/threatintel/ThreatIntelAdapter.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/threatintel/ThreatIntelAdapter.java
@@ -74,9 +74,11 @@ public class ThreatIntelAdapter implements EnrichmentAdapter<CacheKey>,Serializa
       try {
         for (Boolean isThreat :
                 lookup.exists(Iterables.transform(enrichmentTypes
-                                                 , new EnrichmentUtils.TypeToKey(value.getValue())
+                                                 , new EnrichmentUtils.TypeToKey(value.getValue()
+                                                                                , lookup.getTable()
+                                                                                , value.getConfig().getThreatIntel()
+                                                                                )
                                                  )
-                             , lookup.getTable()
                              , false
                              )
             )

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/lookup/Lookup.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/lookup/Lookup.java
@@ -19,6 +19,7 @@ package org.apache.metron.enrichment.lookup;
 
 import org.apache.metron.enrichment.lookup.accesstracker.AccessTracker;
 import org.apache.metron.enrichment.lookup.handler.Handler;
+import org.apache.metron.enrichment.lookup.handler.KeyWithContext;
 
 import java.io.IOException;
 
@@ -68,24 +69,24 @@ public class Lookup<CONTEXT_T, KEY_T extends LookupKey, RESULT_T> implements Han
   }
 
   @Override
-  public Iterable<Boolean> exists(Iterable<KEY_T> key, CONTEXT_T context, boolean logAccess) throws IOException {
+  public Iterable<Boolean> exists(Iterable<KeyWithContext<KEY_T, CONTEXT_T>> key, boolean logAccess) throws IOException {
     if(logAccess) {
-      for (KEY_T k : key) {
-        accessTracker.logAccess(k);
+      for (KeyWithContext<KEY_T, CONTEXT_T> k : key) {
+        accessTracker.logAccess(k.getKey());
       }
     }
-    return lookupHandler.exists(key, context, logAccess);
+    return lookupHandler.exists(key, logAccess);
   }
 
 
   @Override
-  public Iterable<RESULT_T> get(Iterable<KEY_T> key, CONTEXT_T context, boolean logAccess) throws IOException {
+  public Iterable<RESULT_T> get(Iterable<KeyWithContext<KEY_T, CONTEXT_T>> key, boolean logAccess) throws IOException {
     if(logAccess) {
-      for (KEY_T k : key) {
-        accessTracker.logAccess(k);
+      for (KeyWithContext<KEY_T, CONTEXT_T> k : key) {
+        accessTracker.logAccess(k.getKey());
       }
     }
-    return lookupHandler.get(key, context, logAccess);
+    return lookupHandler.get(key, logAccess);
   }
 
   @Override

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/lookup/handler/KeyWithContext.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/lookup/handler/KeyWithContext.java
@@ -15,15 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.metron.enrichment.lookup.handler;
 
-import org.apache.metron.enrichment.lookup.LookupKey;
-
-import java.io.IOException;
-
-public interface Handler<CONTEXT_T, KEY_T extends LookupKey, RESULT_T> extends AutoCloseable{
-  boolean exists(KEY_T key, CONTEXT_T context, boolean logAccess) throws IOException;
-  RESULT_T get(KEY_T key, CONTEXT_T context, boolean logAccess) throws IOException;
-  Iterable<Boolean> exists(Iterable<KeyWithContext<KEY_T, CONTEXT_T>> key, boolean logAccess) throws IOException;
-  Iterable<RESULT_T> get(Iterable<KeyWithContext<KEY_T, CONTEXT_T>> key, boolean logAccess) throws IOException;
+public class KeyWithContext<KEY_T, CONTEXT_T> {
+  private KEY_T key;
+  private CONTEXT_T context;
+  public KeyWithContext(KEY_T key, CONTEXT_T context) {
+    this.key = key;
+    this.context = context;
+  }
+  public KEY_T getKey() { return key; }
+  public CONTEXT_T getContext() { return context; }
 }


### PR DESCRIPTION
Allow the simple hbase enrichment adapter and simple threat intel adapter to use multiple column families. As it stands, the table and column family used are configured at topology submission time rather than via zookeeper. It makes sense to allow different enrichment types to be associated with different column families so that column family specific configuration, such as retention policies, can be used per enrichment type.