### PR TITLE
METRON-184 Fixed 'creates' path to avoid re-downloading GeoIP data

### DIFF
--- a/metron-deployment/roles/mysql_server/tasks/geoip.yml
+++ b/metron-deployment/roles/mysql_server/tasks/geoip.yml
@@ -20,7 +20,7 @@
     src:  http://geolite.maxmind.com/download/geoip/database/GeoLiteCity_CSV/GeoLiteCity-latest.tar.xz
     dest: /tmp/geoip
     copy: no
-    creates: /tmp/geopip/*/GeoLiteCity-Blocks.csv
+    creates: /tmp/geoip/*/GeoLiteCity-Blocks.csv
 
 - name: Copy to MySQL import directory
   shell: "cp /tmp/geoip/*/*.csv /var/lib/mysql-files/"


### PR DESCRIPTION
Prevents the GeoIP data from being re-downloaded when it already exists.  The 'creates' path was specifying the wrong file.