### PR TITLE
METRON-180 Granular Control of Component Installation with Tags

### DIFF
--- a/metron-deployment/amazon-ec2/run.sh
+++ b/metron-deployment/amazon-ec2/run.sh
@@ -65,4 +65,7 @@ mvn package -DskipTests
 # deploy metron
 cd $DEPLOYDIR
 export EC2_INI_PATH=conf/ec2.ini
-ansible-playbook -i ec2.py playbook.yml --extra-vars="env=$ENV" $EXTRA_ARGS
+ansible-playbook -i ec2.py playbook.yml \
+  --skip-tags="solr" \
+  --extra-vars="env=$ENV" \
+  $EXTRA_ARGS

--- a/metron-deployment/playbooks/metron_install.yml
+++ b/metron-deployment/playbooks/metron_install.yml
@@ -116,66 +116,17 @@
 - hosts: sensors
   become: true
   roles:
-    - role: ambari_gather_facts
-    - role: tap_interface
+    - { role: ambari_gather_facts, tags: [ 'always'] }
+    - { role: tap_interface, tags: ['tap'] }
+    - { role: pycapa, tags: ['pycapa'] }
+    - { role: bro, tags: ['bro'] }
+    - { role: flume,  tags: ['snort','flume'] }
+    - { role: snort, tags: ['snort'] }
+    - { role: yaf, tags: ['yaf'] }
+    - { role: pcap_replay, tags: ['pcap-replay'] }
+    - { role: sensor-test-mode, tags: ['sensor-test-mode'] }
   tags:
-    - tap
-
-- hosts: sensors
-  become: true
-  roles:
-    - role: ambari_gather_facts
-    - role: pycapa
-  tags:
-    - pycapa
-
-- hosts: sensors
-  become: true
-  roles:
-    - role: ambari_gather_facts
-    - role: bro
-  tags:
-    - bro
-
-- hosts: sensors
-  become: true
-  roles:
-    - role: ambari_gather_facts
-    - role: flume
-  tags:
-    - flume
-
-- hosts: sensors
-  become: true
-  roles:
-    - role: ambari_gather_facts
-    - role: snort
-  tags:
-    - snort
-
-- hosts: sensors
-  become: true
-  roles:
-    - role: ambari_gather_facts
-    - role: yaf
-  tags:
-    - yaf
-
-- hosts: sensors
-  become: true
-  roles:
-    - role: ambari_gather_facts
-    - role: pcap_replay
-  tags:
-    - pcap-replay
-
-- hosts: sensors
-  become: true
-  roles:
-    - role: ambari_gather_facts
-    - role: sensor-test-mode
-  tags:
-    - sensor-test-mode
+    - sensors
 
 #
 # monit

--- a/metron-deployment/playbooks/metron_install.yml
+++ b/metron-deployment/playbooks/metron_install.yml
@@ -29,6 +29,9 @@
   tags:
     - packer
 
+#
+# prerequisites
+#
 - hosts: metron
   become: true
   roles:
@@ -44,22 +47,28 @@
     - metron-prereqs
     - hadoop-setup
 
+#
+# search
+#
 - hosts: search
   become: true
   vars:
     es_hosts: "{% set comma = joiner(',') %}{% for host in groups['search'] -%}{{ comma() }}{{ host }}{%- endfor %}"
   roles:
-    - { role: elasticsearch, when: install_elasticsearch | default(True) == True }
+    - role: elasticsearch
   tags:
-    - search
+    - elasticsearch
 
 - hosts: search
   become: true
   roles:
-    - { role: solr, when: install_solr | default(False) == True  }
+    - role: solr
   tags:
-    - search
+    - solr
 
+#
+# mysql
+#
 - hosts: mysql
   become: true
   roles:
@@ -74,21 +83,9 @@
   tags:
     - mysql-client
 
-- hosts: sensors
-  become: true
-  roles:
-    - ambari_gather_facts
-    - { role: tap_interface, when: install_tap | default(False) == True }
-    - { role: pycapa, when: install_pycapa | default(True) == True }
-    - { role: bro, when: install_bro | default(True) == True }
-    - { role: flume,  when: install_snort | default(True) == True }
-    - { role: snort , when: install_snort | default(True) == True }
-    - { role: yaf, when: install_yaf | default(True) == True }
-    - { role: pcap_replay, when: install_pcap_replay | default(False) == True }
-    - { role: sensor-test-mode, when: sensor_test_mode | default(False) == True }
-  tags:
-      - sensors
-
+#
+# parsers, enrichment, and indexing topologies
+#
 - hosts: enrichment
   become: true
   roles:
@@ -96,25 +93,105 @@
   tags:
     - enrichment
 
+#
+# user interface
+#
 - hosts: pcap_server
   become: true
   roles:
-    - { role: metron_pcapservice, when: install_elasticsearch | default(True) == True }
+    - role: metron_pcapservice
   tags:
-    - pcap_service
+    - pcap-service
 
 - hosts: web
   become: true
   roles:
-    - { role: kibana, when: install_elasticsearch | default(True) == True }
+    - role: kibana
   tags:
-    - web
+    - kibana
 
+#
+# sensors
+#
+- hosts: sensors
+  become: true
+  roles:
+    - role: ambari_gather_facts
+    - role: tap_interface
+  tags:
+    - tap
+
+- hosts: sensors
+  become: true
+  roles:
+    - role: ambari_gather_facts
+    - role: pycapa
+  tags:
+    - pycapa
+
+- hosts: sensors
+  become: true
+  roles:
+    - role: ambari_gather_facts
+    - role: bro
+  tags:
+    - bro
+
+- hosts: sensors
+  become: true
+  roles:
+    - role: ambari_gather_facts
+    - role: flume
+  tags:
+    - flume
+
+- hosts: sensors
+  become: true
+  roles:
+    - role: ambari_gather_facts
+    - role: snort
+  tags:
+    - snort
+
+- hosts: sensors
+  become: true
+  roles:
+    - role: ambari_gather_facts
+    - role: yaf
+  tags:
+    - yaf
+
+- hosts: sensors
+  become: true
+  roles:
+    - role: ambari_gather_facts
+    - role: pcap_replay
+  tags:
+    - pcap-replay
+
+- hosts: sensors
+  become: true
+  roles:
+    - role: ambari_gather_facts
+    - role: sensor-test-mode
+  tags:
+    - sensor-test-mode
+
+#
+# monit
+#
 - hosts: metron
   become: true
   roles:
     - role: ambari_gather_facts
     - role: monit
+  tags:
+    - monit
+
+- hosts: metron
+  become: true
+  roles:
+    - role: ambari_gather_facts
     - role: monit-start
   tags:
     - start

--- a/metron-deployment/roles/kafka-client/defaults/main.yml
+++ b/metron-deployment/roles/kafka-client/defaults/main.yml
@@ -15,10 +15,4 @@
 #  limitations under the License.
 #
 ---
-- include: ambari_install.yml
-  tags:
-    - ambari
-    
-- include: metron_install.yml
-  tags:
-    - metron
+hdp_repo_def: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.3.2.0/hdp.repo

--- a/metron-deployment/vagrant/full-dev-platform/run.sh
+++ b/metron-deployment/vagrant/full-dev-platform/run.sh
@@ -17,5 +17,4 @@
 # limitations under the License.
 #
 
-vagrant up
-
+vagrant --ansible-skip-tags="solr" up

--- a/metron-deployment/vagrant/quick-dev-platform/run.sh
+++ b/metron-deployment/vagrant/quick-dev-platform/run.sh
@@ -17,5 +17,7 @@
 # limitations under the License.
 #
 
-vagrant --ansible-tags="hdp-deploy,metron" up
-
+vagrant \
+  --ansible-tags="hdp-deploy,metron" \
+  --ansible-skip-tags="solr" \
+  up


### PR DESCRIPTION
To allow users to make the most use of the deployment scripts, they should be able to choose whether each component is installed or not.  This is important very highly customized environments where Metron will be installed.  This is currently possible in most cases, but there are a few scenarios that are exceptions.

For example, the PCAP service will only be installed if `install_elasticsearch` is set to `true`. This was a good coupling back when PCAP searches were hosted in the index. Now that PCAP searches come from HDFS, we need to be able to install PCAP service separately.