### PR TITLE
METRON-100 GeoIP errors out silently in vagrant

### DIFF
--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/geo/GeoAdapter.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/geo/GeoAdapter.java
@@ -24,6 +24,7 @@ import org.json.simple.JSONObject;
 
 import java.net.InetAddress;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 
 public class GeoAdapter extends JdbcAdapter {
 
@@ -34,10 +35,15 @@ public class GeoAdapter extends JdbcAdapter {
 
   }
 
+
   @SuppressWarnings("unchecked")
   @Override
   public JSONObject enrich(CacheKey value) {
     JSONObject enriched = new JSONObject();
+    if(!resetConnectionIfNecessary()) {
+      _LOG.error("Enrichment failure, cannot maintain a connection to JDBC.  Please check connection.  In the meantime, I'm not enriching.");
+      return enriched;
+    }
     try {
       InetAddress addr = InetAddress.getByName(value.getValue());
       if (addr.isAnyLocalAddress() || addr.isLoopbackAddress()

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/geo/GeoAdapter.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/geo/GeoAdapter.java
@@ -51,7 +51,7 @@ public class GeoAdapter extends JdbcAdapter {
               || !ipvalidator.isValidInet4Address(value.getValue())) {
         return new JSONObject();
       }
-      String locidQuery = "select IPTOLOCID(\"" + value
+      String locidQuery = "select IPTOLOCID(\"" + value.getValue()
               + "\") as ANS";
       ResultSet resultSet = statement.executeQuery(locidQuery);
       String locid = null;

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/jdbc/JdbcAdapter.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/jdbc/JdbcAdapter.java
@@ -53,8 +53,7 @@ public abstract class JdbcAdapter implements EnrichmentAdapter<CacheKey>,
   }
 
   protected boolean resetConnectionIfNecessary() {
-    if(isConnectionClosed())
-    {
+    if(isConnectionClosed()) {
       this.cleanup();
       return this.initializeAdapter();
     }
@@ -80,8 +79,9 @@ public abstract class JdbcAdapter implements EnrichmentAdapter<CacheKey>,
       Class.forName(this.config.getClassName());
       connection = DriverManager.getConnection(this.config.getJdbcUrl());
       connection.setReadOnly(true);
-      if (!connection.isValid(0))
+      if (!connection.isValid(0)) {
         throw new Exception("Invalid connection string....");
+      }
       statement = connection.createStatement(
               ResultSet.TYPE_SCROLL_INSENSITIVE,
               ResultSet.CONCUR_READ_ONLY);

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/jdbc/JdbcAdapter.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/jdbc/JdbcAdapter.java
@@ -19,7 +19,6 @@ package org.apache.metron.enrichment.adapters.jdbc;
 
 import org.apache.metron.enrichment.bolt.CacheKey;
 import org.apache.metron.enrichment.interfaces.EnrichmentAdapter;
-import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,8 +26,7 @@ import java.io.Serializable;
 import java.net.InetAddress;
 import java.sql.*;
 
-public abstract class JdbcAdapter implements EnrichmentAdapter<CacheKey>,
-        Serializable {
+public abstract class JdbcAdapter implements EnrichmentAdapter<CacheKey>, Serializable {
 
   protected static final Logger _LOG = LoggerFactory
           .getLogger(JdbcAdapter.class);

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/simplehbase/SimpleHBaseAdapter.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/simplehbase/SimpleHBaseAdapter.java
@@ -60,13 +60,19 @@ public class SimpleHBaseAdapter implements EnrichmentAdapter<CacheKey>,Serializa
   }
 
 
+  public boolean isInitialized() {
+    return lookup != null && lookup.getTable() != null;
+  }
   @Override
   public JSONObject enrich(CacheKey value) {
     JSONObject enriched = new JSONObject();
+    if(!isInitialized()) {
+      initializeAdapter();
+    }
     List<String> enrichmentTypes = value.getConfig()
                                         .getEnrichment().getFieldToTypeMap()
                                         .get(EnrichmentUtils.toTopLevelField(value.getField()));
-    if(enrichmentTypes != null && value.getValue() != null) {
+    if(isInitialized() && enrichmentTypes != null && value.getValue() != null) {
       try {
         for (LookupKV<EnrichmentKey, EnrichmentValue> kv :
                 lookup.get(Iterables.transform(enrichmentTypes
@@ -87,6 +93,7 @@ public class SimpleHBaseAdapter implements EnrichmentAdapter<CacheKey>,Serializa
       }
       catch (IOException e) {
         _LOG.error("Unable to retrieve value: " + e.getMessage(), e);
+        initializeAdapter();
         throw new RuntimeException("Unable to retrieve value: " + e.getMessage(), e);
       }
     }
@@ -103,7 +110,8 @@ public class SimpleHBaseAdapter implements EnrichmentAdapter<CacheKey>,Serializa
                                    , new NoopAccessTracker()
                                    );
     } catch (IOException e) {
-      throw new RuntimeException("Unable to initialize adapter: " + e.getMessage(), e);
+      _LOG.error("Unable to initialize adapter: " + e.getMessage(), e);
+      return false;
     }
     return true;
   }
@@ -113,7 +121,7 @@ public class SimpleHBaseAdapter implements EnrichmentAdapter<CacheKey>,Serializa
     try {
       lookup.close();
     } catch (Exception e) {
-      throw new RuntimeException("Unable to cleanup access tracker", e);
+      _LOG.error("Unable to cleanup access tracker", e);
     }
   }
 }

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/threatintel/ThreatIntelAdapter.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/threatintel/ThreatIntelAdapter.java
@@ -65,11 +65,14 @@ public class ThreatIntelAdapter implements EnrichmentAdapter<CacheKey>,Serializa
 
   @Override
   public JSONObject enrich(CacheKey value) {
+    if(!isInitialized()) {
+      initializeAdapter();
+    }
     JSONObject enriched = new JSONObject();
     List<String> enrichmentTypes = value.getConfig()
                                         .getThreatIntel().getFieldToTypeMap()
                                         .get(EnrichmentUtils.toTopLevelField(value.getField()));
-    if(enrichmentTypes != null) {
+    if(isInitialized() && enrichmentTypes != null) {
       int i = 0;
       try {
         for (Boolean isThreat :
@@ -89,11 +92,16 @@ public class ThreatIntelAdapter implements EnrichmentAdapter<CacheKey>,Serializa
         }
       }
       catch(IOException e) {
+        _LOG.error("Unable to retrieve value: " + e.getMessage(), e);
+        initializeAdapter();
         throw new RuntimeException("Unable to retrieve value", e);
       }
     }
-    //throw new RuntimeException("Unable to retrieve value " + value);
     return enriched;
+  }
+
+  public boolean isInitialized() {
+    return lookup != null && lookup.getTable() != null;
   }
 
   @Override
@@ -117,7 +125,8 @@ public class ThreatIntelAdapter implements EnrichmentAdapter<CacheKey>,Serializa
       );
       lookup = new EnrichmentLookup(config.getProvider().getTable(hbaseConfig, hbaseTable), config.getHBaseCF(), accessTracker);
     } catch (IOException e) {
-      throw new IllegalStateException("Unable to initialize ThreatIntelAdapter", e);
+      _LOG.error("Unable to initialize ThreatIntelAdapter", e);
+      return false;
     }
 
     return true;

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/geo/GeoAdapterTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/geo/GeoAdapterTest.java
@@ -83,7 +83,12 @@ public class GeoAdapterTest {
 
   @Test
   public void testEnrich() throws Exception {
-    GeoAdapter geo = new GeoAdapter();
+    GeoAdapter geo = new GeoAdapter() {
+      @Override
+      public boolean initializeAdapter() {
+        return true;
+      }
+    };
     geo.setStatement(statetment);
     JSONObject actualMessage = geo.enrich(new CacheKey("dummy", ip, null));
     Assert.assertNotNull(actualMessage.get("locID"));

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/geo/GeoAdapterTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/geo/GeoAdapterTest.java
@@ -66,7 +66,7 @@ public class GeoAdapterTest {
     JSONParser jsonParser = new JSONParser();
     expectedMessage = (JSONObject) jsonParser.parse(expectedMessageString);
     MockitoAnnotations.initMocks(this);
-    when(statetment.executeQuery("select IPTOLOCID(\"CacheKey{field='dummy', value='72.163.4.161'}\") as ANS")).thenReturn(resultSet);
+    when(statetment.executeQuery("select IPTOLOCID(\"" + ip + "\") as ANS")).thenReturn(resultSet);
     when(statetment.executeQuery("select * from location where locID = 1")).thenReturn(resultSet1);
     when(resultSet.next()).thenReturn(Boolean.TRUE, Boolean.FALSE);
     when(resultSet.getString("ANS")).thenReturn("1");

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/threatintel/ThreatIntelAdapterTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/threatintel/ThreatIntelAdapterTest.java
@@ -122,7 +122,7 @@ public class ThreatIntelAdapterTest {
     Assert.assertEquals(expectedMessage, actualMessage);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testInitializeAdapter() {
 
     String cf = "cf";
@@ -145,7 +145,7 @@ public class ThreatIntelAdapterTest {
 
     ThreatIntelAdapter tia = new ThreatIntelAdapter(config);
     tia.initializeAdapter();
-
+    Assert.assertFalse(tia.isInitialized());
   }
 
 

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/bolt/GenericEnrichmentBoltTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/bolt/GenericEnrichmentBoltTest.java
@@ -18,6 +18,7 @@
 package org.apache.metron.enrichment.bolt;
 
 import backtype.storm.tuple.Values;
+import com.google.common.collect.ImmutableMap;
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.metron.TestConstants;
 import org.apache.metron.test.bolt.BaseEnrichmentBoltTest;
@@ -177,7 +178,7 @@ public class GenericEnrichmentBoltTest extends BaseEnrichmentBoltTest {
     when(tuple.getStringByField("key")).thenReturn(key);
     when(tuple.getValueByField("message")).thenReturn(originalMessage);
     genericEnrichmentBolt.execute(tuple);
-    verify(outputCollector, times(1)).emit(eq(enrichmentType), argThat(new EnrichedMessageMatcher(key, new JSONObject())));
+    verify(outputCollector, times(1)).emit(eq(enrichmentType), argThat(new EnrichedMessageMatcher(key, new JSONObject(ImmutableMap.of("source.type", "test")))));
     reset(enrichmentAdapter);
 
     SensorEnrichmentConfig sensorEnrichmentConfig = SensorEnrichmentConfig.


### PR DESCRIPTION
When we transitioned from passing the value to the adapters to passing a CacheKey object, we never adjusted the SQL statements.  Also, this error may cause downstream issues whereby messages error out because enrichments are short circuited if one fails and the source.type never gets properly set.

The JIRA is wrong, this bug is actually present in every environment and prevents GeoIP enrichment from working.