### PR TITLE
METRON-190: Make start_parser_topology.sh more adaptable regarding storm topology configuration

### DIFF
--- a/metron-platform/metron-parsers/README.md
+++ b/metron-platform/metron-parsers/README.md
@@ -201,21 +201,23 @@ The usage for `start_parser_topology.sh` is as follows:
 
 ```
 usage: start_parser_topology.sh
- -e,--extra_options <JSON_FILE>            Extra options in the form of a
-                                           JSON file with a map for
-                                           content.
- -h,--help                                 This screen
- -k,--kafka <BROKER_URL>                   Kafka Broker URL
- -mt,--message_timeout <TIMEOUT_IN_SECS>   Message Timeout in Seconds
- -mtp,--max_task_parallelism <MAX_TASK>    Max task parallelism
- -na,--num_ackers <NUM_ACKERS>             Number of Ackers
- -nw,--num_workers <NUM_WORKERS>           Number of Workers
- -pp,--parser_p <PARSER_PARALLELISM>       Parser Parallelism
- -s,--sensor <SENSOR_TYPE>                 Sensor Type
- -sp,--spout_p <SPOUT_PARALLELISM>         Spout Parallelism
- -t,--test <TEST>                          Run in Test Mode
- -z,--zk <ZK_QUORUM>                       Zookeeper Quroum URL
-                                           (zk1:2181,zk2:2181,...
+ -e,--extra_options <JSON_FILE>               Extra options in the form of
+                                              a JSON file with a map for
+                                              content.
+ -h,--help                                    This screen
+ -k,--kafka <BROKER_URL>                      Kafka Broker URL
+ -mt,--message_timeout <TIMEOUT_IN_SECS>      Message Timeout in Seconds
+ -mtp,--max_task_parallelism <MAX_TASK>       Max task parallelism
+ -na,--num_ackers <NUM_ACKERS>                Number of Ackers
+ -nw,--num_workers <NUM_WORKERS>              Number of Workers
+ -pnt,--parser_num_tasks <PARSER_NUM_TASKS>   Parser Num Tasks
+ -pp,--parser_p <PARSER_PARALLELISM_HINT>     Parser Parallelism Hint
+ -s,--sensor <SENSOR_TYPE>                    Sensor Type
+ -snt,--spout_num_tasks <NUM_TASKS>           Spout Num Tasks
+ -sp,--spout_p <SPOUT_PARALLELISM_HINT>       Spout Parallelism Hint
+ -t,--test <TEST>                             Run in Test Mode
+ -z,--zk <ZK_QUORUM>                          Zookeeper Quroum URL
+                                              (zk1:2181,zk2:2181,...
 ```
 
 A small note on the extra options.  These options are intended to be Storm configuration options and will live in

--- a/metron-platform/metron-parsers/README.md
+++ b/metron-platform/metron-parsers/README.md
@@ -188,3 +188,44 @@ Grok parser adapters are designed primarly for someone who is not a Java coder f
 For more information on the Grok project please refer to the following link:
 
 https://github.com/thekrakken/java-grok
+
+#Starting the Parser Topology
+
+Starting a particular parser topology on a running Metron deployment is
+as easy as running the `start_parser_topology.sh` script located in
+`$METRON_HOME/bin`.  This utility will allow you to configure and start
+the running topology assuming that the sensor specific parser configuration
+exists within zookeeper.
+
+The usage for `start_parser_topology.sh` is as follows:
+
+```
+usage: start_parser_topology.sh
+ -e,--extra_options <JSON_FILE>            Extra options in the form of a
+                                           JSON file with a map for
+                                           content.
+ -h,--help                                 This screen
+ -k,--kafka <BROKER_URL>                   Kafka Broker URL
+ -mt,--message_timeout <TIMEOUT_IN_SECS>   Message Timeout in Seconds
+ -mtp,--max_task_parallelism <MAX_TASK>    Max task parallelism
+ -na,--num_ackers <NUM_ACKERS>             Number of Ackers
+ -nw,--num_workers <NUM_WORKERS>           Number of Workers
+ -pp,--parser_p <PARSER_PARALLELISM>       Parser Parallelism
+ -s,--sensor <SENSOR_TYPE>                 Sensor Type
+ -sp,--spout_p <SPOUT_PARALLELISM>         Spout Parallelism
+ -t,--test <TEST>                          Run in Test Mode
+ -z,--zk <ZK_QUORUM>                       Zookeeper Quroum URL
+                                           (zk1:2181,zk2:2181,...
+```
+
+A small note on the extra options.  These options are intended to be Storm configuration options and will live in
+a JSON file which will be loaded into the Storm config.  For instance, if you wanted to set some storm property on
+the config called `topology.ticks.tuple.freq.secs` to 1000 and `storm.local.dir` to `/opt/my/path`
+you could create a file called `custom_config.json` containing 
+```
+{ 
+  "topology.ticks.tuple.freq.secs" : 1000,
+  "storm.local.dir" : "/opt/my/path"
+}
+```
+and pass `--extra_options custom_config.json` to `start_parser_topology.sh`.

--- a/metron-platform/metron-parsers/pom.xml
+++ b/metron-platform/metron-parsers/pom.xml
@@ -165,8 +165,8 @@
                 <version>3.1</version>
                 <inherited>true</inherited>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyBuilder.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyBuilder.java
@@ -39,7 +39,10 @@ public class ParserTopologyBuilder {
                          String sensorType,
                          SpoutConfig.Offset offset,
                          int spoutParallelism,
-                         int parserParallelism) throws Exception {
+                         int spoutNumTasks,
+                         int parserParallelism,
+                         int parserNumTasks
+                                     ) throws Exception {
     CuratorFramework client = ConfigurationsUtils.getClient(zookeeperUrl);
     client.start();
     SensorParserConfig sensorParserConfig = ConfigurationsUtils.readSensorParserConfigFromZookeeper(sensorType, client);
@@ -49,12 +52,15 @@ public class ParserTopologyBuilder {
     ZkHosts zkHosts = new ZkHosts(zookeeperUrl);
     SpoutConfig spoutConfig = new SpoutConfig(zkHosts, sensorTopic, "", sensorTopic).from(offset);
     KafkaSpout kafkaSpout = new KafkaSpout(spoutConfig);
-    builder.setSpout("kafkaSpout", kafkaSpout, spoutParallelism);
+    builder.setSpout("kafkaSpout", kafkaSpout, spoutParallelism)
+           .setNumTasks(parserNumTasks);
     MessageParser<JSONObject> parser = ReflectionUtils.createInstance(sensorParserConfig.getParserClassName());
     parser.configure(sensorParserConfig.getParserConfig());
     KafkaWriter writer = new KafkaWriter(brokerUrl);
     ParserBolt parserBolt = new ParserBolt(zookeeperUrl, sensorType, parser, writer);
-    builder.setBolt("parserBolt", parserBolt, parserParallelism).shuffleGrouping("kafkaSpout");
+    builder.setBolt("parserBolt", parserBolt, parserParallelism)
+           .setNumTasks(spoutNumTasks)
+           .shuffleGrouping("kafkaSpout");
     return builder;
   }
 }

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyBuilder.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyBuilder.java
@@ -30,6 +30,8 @@ import org.json.simple.JSONObject;
 import storm.kafka.KafkaSpout;
 import storm.kafka.ZkHosts;
 
+import java.util.Map;
+
 public class ParserTopologyBuilder {
 
   public static TopologyBuilder build(String zookeeperUrl,

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
@@ -61,15 +61,15 @@ public class ParserTopologyCLI {
       return o;
     }),
     SPOUT_PARALLELISM("sp", code -> {
-      Option o = new Option(code, "spout_p", true, "Spout Parallelism");
-      o.setArgName("SPOUT_PARALLELISM");
+      Option o = new Option(code, "spout_p", true, "Spout Parallelism Hint");
+      o.setArgName("SPOUT_PARALLELISM_HINT");
       o.setRequired(false);
       o.setType(Number.class);
       return o;
     }),
     PARSER_PARALLISM("pp", code -> {
-      Option o = new Option(code, "parser_p", true, "Parser Parallelism");
-      o.setArgName("PARSER_PARALLELISM");
+      Option o = new Option(code, "parser_p", true, "Parser Parallelism Hint");
+      o.setArgName("PARSER_PARALLELISM_HINT");
       o.setRequired(false);
       o.setType(Number.class);
       return o;

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
@@ -195,7 +195,7 @@ public class ParserTopologyCLI {
       CommandLineParser parser = new PosixParser();
       CommandLine cmd = null;
       try {
-        cmd = ParserOptions.parse(parser, args)
+        cmd = ParserOptions.parse(parser, args);
       } catch (ParseException pe) {
         pe.printStackTrace();
         final HelpFormatter usageFormatter = new HelpFormatter();

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
@@ -18,69 +18,179 @@
 package org.apache.metron.parsers.topology;
 
 import backtype.storm.Config;
+import backtype.storm.ConfigValidation;
 import backtype.storm.LocalCluster;
 import backtype.storm.StormSubmitter;
 import backtype.storm.topology.TopologyBuilder;
 import backtype.storm.utils.Utils;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
+import com.google.common.base.Joiner;
+import org.apache.commons.cli.*;
 import org.apache.metron.common.spout.kafka.SpoutConfig;
+import org.apache.metron.parsers.topology.config.Arg;
+import org.apache.metron.parsers.topology.config.ConfigHandlers;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
+import java.util.function.Function;
 
 public class ParserTopologyCLI {
 
-  public static void main(String[] args) {
-    Options options = new Options();
-    {
-      Option o = new Option("h", "help", false, "This screen");
+  public enum ParserOptions {
+    HELP("h", code -> {
+      Option o = new Option(code, "help", false, "This screen");
       o.setRequired(false);
-      options.addOption(o);
-    }
-    {
-      Option o = new Option("z", "zk", true, "Zookeeper Quroum URL (zk1:2181,zk2:2181,...");
+      return o;
+    }),
+    ZK_QUORUM("z", code -> {
+      Option o = new Option(code, "zk", true, "Zookeeper Quroum URL (zk1:2181,zk2:2181,...");
       o.setArgName("ZK_QUORUM");
       o.setRequired(true);
-      options.addOption(o);
-    }
-    {
-      Option o = new Option("k", "kafka", true, "Kafka Broker URL");
+      return o;
+    }),
+    BROKER_URL("k", code -> {
+      Option o = new Option(code, "kafka", true, "Kafka Broker URL");
       o.setArgName("BROKER_URL");
       o.setRequired(true);
-      options.addOption(o);
-    }
-    {
-      Option o = new Option("s", "sensor", true, "Sensor Type");
+      return o;
+    }),
+    SENSOR_TYPE("s", code -> {
+      Option o = new Option(code, "sensor", true, "Sensor Type");
       o.setArgName("SENSOR_TYPE");
       o.setRequired(true);
-      options.addOption(o);
-    }
-    {
-      Option o = new Option("sp", "spout_p", true, "Spout Parallelism");
+      return o;
+    }),
+    SPOUT_PARALLELISM("sp", code -> {
+      Option o = new Option(code, "spout_p", true, "Spout Parallelism");
       o.setArgName("SPOUT_PARALLELISM");
       o.setRequired(false);
       o.setType(Number.class);
-      options.addOption(o);
-    }
-    {
-      Option o = new Option("pp", "parser_p", true, "Parser Parallelism");
+      return o;
+    }),
+    PARSER_PARALLISM("pp", code -> {
+      Option o = new Option(code, "parser_p", true, "Parser Parallelism");
       o.setArgName("PARSER_PARALLELISM");
       o.setRequired(false);
       o.setType(Number.class);
-      options.addOption(o);
-    }
+      return o;
+    }),
+    NUM_WORKERS("nw", code -> {
+      Option o = new Option(code, "num_workers", true, "Number of Workers");
+      o.setArgName("NUM_WORKERS");
+      o.setRequired(false);
+      o.setType(Number.class);
+      return o;
+      }, new ConfigHandlers.SetNumWorkersHandler()
+    )
+    ,NUM_ACKERS("na", code -> {
+      Option o = new Option(code, "num_ackers", true, "Number of Ackers");
+      o.setArgName("NUM_ACKERS");
+      o.setRequired(false);
+      o.setType(Number.class);
+      return o;
+    }, new ConfigHandlers.SetNumAckersHandler()
+    )
+    ,NUM_MAX_TASK_PARALLELISM("mtp", code -> {
+      Option o = new Option(code, "max_task_parallelism", true, "Max task parallelism");
+      o.setArgName("MAX_TASK");
+      o.setRequired(false);
+      o.setType(Number.class);
+      return o;
+    }, new ConfigHandlers.SetMaxTaskParallelismHandler()
+    )
+    ,MESSAGE_TIMEOUT("mt", code -> {
+      Option o = new Option(code, "message_timeout", true, "Message Timeout in Seconds");
+      o.setArgName("TIMEOUT_IN_SECS");
+      o.setRequired(false);
+      o.setType(Number.class);
+      return o;
+    }, new ConfigHandlers.SetMessageTimeoutHandler()
+    )
+    ,EXTRA_OPTIONS("e", code -> {
+      Option o = new Option(code, "extra_options", true, "Extra options in the form of a JSON file with a map for content.");
+      o.setArgName("JSON_FILE");
+      o.setRequired(false);
+      o.setType(String.class);
+      return o;
+    }, new ConfigHandlers.LoadJSONHandler()
+    )
+    ,TEST("t", code ->
     {
       Option o = new Option("t", "test", true, "Run in Test Mode");
       o.setArgName("TEST");
       o.setRequired(false);
-      options.addOption(o);
+      return o;
+    })
+    ;
+    Option option;
+    String shortCode;
+    Function<Arg, Config> configHandler;
+    ParserOptions(String shortCode
+                 , Function<String, Option> optionHandler
+                 ) {
+      this(shortCode, optionHandler, arg -> arg.getConfig());
+                 }
+    ParserOptions(String shortCode
+                 , Function<String, Option> optionHandler
+                 , Function<Arg, Config> configHandler
+                 ) {
+      this.shortCode = shortCode;
+      this.option = optionHandler.apply(shortCode);
+      this.configHandler = configHandler;
     }
+
+    public boolean has(CommandLine cli) {
+      return cli.hasOption(shortCode);
+    }
+
+    public String get(CommandLine cli) {
+      return cli.getOptionValue(shortCode);
+    }
+    public String get(CommandLine cli, String def) {
+      return has(cli)?cli.getOptionValue(shortCode):def;
+    }
+
+    public static Config getConfig(CommandLine cli) {
+      Config config = new Config();
+      for(ParserOptions option : ParserOptions.values()) {
+        config = option.configHandler.apply(new Arg(config, option.get(cli)));
+      }
+      return config;
+    }
+
+    public static CommandLine parse(CommandLineParser parser, String[] args) throws ParseException {
+      try {
+        CommandLine cli = parser.parse(getOptions(), args);
+        if(HELP.has(cli)) {
+          printHelp();
+          System.exit(0);
+        }
+        return cli;
+      } catch (ParseException e) {
+        System.err.println("Unable to parse args: " + Joiner.on(' ').join(args));
+        e.printStackTrace(System.err);
+        printHelp();
+        throw e;
+      }
+    }
+
+    public static void printHelp() {
+      HelpFormatter formatter = new HelpFormatter();
+      formatter.printHelp( "ParserTopologyCLI", getOptions());
+    }
+
+    public static Options getOptions() {
+      Options ret = new Options();
+      for(ParserOptions o : ParserOptions.values()) {
+        ret.addOption(o.option);
+      }
+      return ret;
+    }
+  }
+
+  public static void main(String[] args) {
+    Options options = new Options();
+
     try {
       CommandLineParser parser = new PosixParser();
       CommandLine cmd = null;
@@ -97,27 +207,28 @@ public class ParserTopologyCLI {
         usageFormatter.printHelp("ParserTopologyCLI", null, options, null, true);
         System.exit(0);
       }
-      String zookeeperUrl = cmd.getOptionValue("z");
-      String brokerUrl = cmd.getOptionValue("k");
-      String sensoryType = cmd.getOptionValue("s");
-      int spoutParallelism = Integer.parseInt(cmd.getOptionValue("sp", "1"));
-      int parserParallelism = Integer.parseInt(cmd.getOptionValue("pp", "1"));
+      String zookeeperUrl = ParserOptions.ZK_QUORUM.get(cmd);;
+      String brokerUrl = ParserOptions.BROKER_URL.get(cmd);
+      String sensorType= ParserOptions.SENSOR_TYPE.get(cmd);
+      int spoutParallelism = Integer.parseInt(ParserOptions.SPOUT_PARALLELISM.get(cmd, "1"));
+      int parserParallelism = Integer.parseInt(ParserOptions.PARSER_PARALLISM.get(cmd, "1"));
       SpoutConfig.Offset offset = cmd.hasOption("t") ? SpoutConfig.Offset.BEGINNING : SpoutConfig.Offset.WHERE_I_LEFT_OFF;
       TopologyBuilder builder = ParserTopologyBuilder.build(zookeeperUrl,
               brokerUrl,
-              sensoryType,
+              sensorType,
               offset,
               spoutParallelism,
               parserParallelism);
-      if (cmd.hasOption("t")) {
-        Map<String, Object> stormConf = new HashMap<>();
+      Config stormConf = ParserOptions.getConfig(cmd);
+
+      if (ParserOptions.TEST.has(cmd)) {
         stormConf.put(Config.TOPOLOGY_DEBUG, true);
         LocalCluster cluster = new LocalCluster();
-        cluster.submitTopology(sensoryType, stormConf, builder.createTopology());
+        cluster.submitTopology(sensorType, stormConf, builder.createTopology());
         Utils.sleep(300000);
         cluster.shutdown();
       } else {
-        StormSubmitter.submitTopology(sensoryType, new HashMap<>(), builder.createTopology());
+        StormSubmitter.submitTopology(sensorType, stormConf, builder.createTopology());
       }
     } catch (Exception e) {
       e.printStackTrace();

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
@@ -74,6 +74,20 @@ public class ParserTopologyCLI {
       o.setType(Number.class);
       return o;
     }),
+    SPOUT_NUM_TASKS("snt", code -> {
+      Option o = new Option(code, "spout_num_tasks", true, "Spout Num Tasks");
+      o.setArgName("NUM_TASKS");
+      o.setRequired(false);
+      o.setType(Number.class);
+      return o;
+    }),
+    PARSER_NUM_TASKS("pnt", code -> {
+      Option o = new Option(code, "parser_num_tasks", true, "Parser Num Tasks");
+      o.setArgName("PARSER_NUM_TASKS");
+      o.setRequired(false);
+      o.setType(Number.class);
+      return o;
+    }),
     NUM_WORKERS("nw", code -> {
       Option o = new Option(code, "num_workers", true, "Number of Workers");
       o.setArgName("NUM_WORKERS");
@@ -211,14 +225,18 @@ public class ParserTopologyCLI {
       String brokerUrl = ParserOptions.BROKER_URL.get(cmd);
       String sensorType= ParserOptions.SENSOR_TYPE.get(cmd);
       int spoutParallelism = Integer.parseInt(ParserOptions.SPOUT_PARALLELISM.get(cmd, "1"));
+      int spoutNumTasks = Integer.parseInt(ParserOptions.SPOUT_NUM_TASKS.get(cmd, "1"));
       int parserParallelism = Integer.parseInt(ParserOptions.PARSER_PARALLISM.get(cmd, "1"));
+      int parserNumTasks= Integer.parseInt(ParserOptions.PARSER_NUM_TASKS.get(cmd, "1"));
       SpoutConfig.Offset offset = cmd.hasOption("t") ? SpoutConfig.Offset.BEGINNING : SpoutConfig.Offset.WHERE_I_LEFT_OFF;
       TopologyBuilder builder = ParserTopologyBuilder.build(zookeeperUrl,
               brokerUrl,
               sensorType,
               offset,
               spoutParallelism,
-              parserParallelism);
+              spoutNumTasks,
+              parserParallelism,
+              parserNumTasks);
       Config stormConf = ParserOptions.getConfig(cmd);
 
       if (ParserOptions.TEST.has(cmd)) {

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
@@ -195,7 +195,7 @@ public class ParserTopologyCLI {
       CommandLineParser parser = new PosixParser();
       CommandLine cmd = null;
       try {
-        cmd = parser.parse(options, args);
+        cmd = ParserOptions.parse(parser, args)
       } catch (ParseException pe) {
         pe.printStackTrace();
         final HelpFormatter usageFormatter = new HelpFormatter();

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/config/Arg.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/config/Arg.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.parsers.topology.config;
+
+import backtype.storm.Config;
+
+public class Arg {
+  private Config config;
+  private String arg;
+
+  public Arg(Config config, String arg) {
+    this.config = config;
+    this.arg = arg;
+  }
+
+  public Config getConfig() {
+    return config;
+  }
+
+  public String getArg() {
+    return arg;
+  }
+}

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/config/ConfigHandlers.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/config/ConfigHandlers.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.parsers.topology.config;
+
+import backtype.storm.Config;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.commons.io.FileUtils;
+import org.apache.metron.common.utils.JSONUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Function;
+
+public class ConfigHandlers {
+  public static class SetNumWorkersHandler implements Function<Arg, Config> {
+    @Override
+    public Config apply(Arg arg) {
+      if(arg.getArg() != null) {
+        arg.getConfig().setNumWorkers(Integer.parseInt(arg.getArg()));
+      }
+      return arg.getConfig();
+    }
+  }
+  public static class SetNumAckersHandler implements Function<Arg, Config> {
+    @Override
+    public Config apply(Arg arg) {
+      if(arg.getArg() != null) {
+        arg.getConfig().setNumAckers(Integer.parseInt(arg.getArg()));
+      }
+      return arg.getConfig();
+    }
+  }
+  public static class SetMaxTaskParallelismHandler implements Function<Arg, Config> {
+    @Override
+    public Config apply(Arg arg) {
+      if(arg.getArg() != null) {
+        arg.getConfig().setMaxTaskParallelism(Integer.parseInt(arg.getArg()));
+      }
+      return arg.getConfig();
+    }
+  }
+  public static class SetMessageTimeoutHandler implements Function<Arg, Config> {
+    @Override
+    public Config apply(Arg arg) {
+      if(arg.getArg() != null) {
+        arg.getConfig().setMessageTimeoutSecs(Integer.parseInt(arg.getArg()));
+      }
+      return arg.getConfig();
+    }
+  }
+  public static class LoadJSONHandler implements Function<Arg, Config> {
+    @Override
+    public Config apply(Arg arg) {
+      if(arg.getArg() != null) {
+        File inputFile = new File(arg.getArg());
+        String json = null;
+        if (inputFile.exists()) {
+          try {
+            json = FileUtils.readFileToString(inputFile);
+          } catch (IOException e) {
+            throw new IllegalStateException("Unable to process JSON file " + inputFile, e);
+          }
+        } else {
+          json = arg.getArg();
+        }
+        try {
+          arg.getConfig().putAll(JSONUtils.INSTANCE.load(json, new TypeReference<Map<String, Object>>() {
+          }));
+        } catch (IOException e) {
+          throw new IllegalStateException("Unable to process JSON snippet.", e);
+        }
+      }
+      return arg.getConfig();
+    }
+  }
+}

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/components/ParserTopologyComponent.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/components/ParserTopologyComponent.java
@@ -67,7 +67,15 @@ public class ParserTopologyComponent implements InMemoryComponent {
   @Override
   public void start() throws UnableToStartException {
     try {
-      TopologyBuilder topologyBuilder = ParserTopologyBuilder.build(topologyProperties.getProperty("kafka.zk"), brokerUrl, sensorType, SpoutConfig.Offset.BEGINNING, 1, 1);
+      TopologyBuilder topologyBuilder = ParserTopologyBuilder.build(topologyProperties.getProperty("kafka.zk")
+                                                                   , brokerUrl
+                                                                   , sensorType
+                                                                   , SpoutConfig.Offset.BEGINNING
+                                                                   , 1
+                                                                   , 1
+                                                                   , 1
+                                                                   , 1
+                                                                   );
       Map<String, Object> stormConf = new HashMap<>();
       stormConf.put(Config.TOPOLOGY_DEBUG, true);
       stormCluster = new LocalCluster();

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/topology/ParserTopologyCLITest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/topology/ParserTopologyCLITest.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.parsers.topology;
+
+import backtype.storm.Config;
+import com.google.common.collect.ImmutableMap;
+import org.adrianwalker.multilinestring.Multiline;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.PosixParser;
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.Map;
+
+public class ParserTopologyCLITest {
+
+
+  public static class CLIBuilder {
+    EnumMap<ParserTopologyCLI.ParserOptions, String> map = new EnumMap<>(ParserTopologyCLI.ParserOptions.class);
+
+    public CLIBuilder with(ParserTopologyCLI.ParserOptions option, String val) {
+      map.put(option, val);
+      return this;
+    }
+    public CLIBuilder with(ParserTopologyCLI.ParserOptions option) {
+      map.put(option, null);
+      return this;
+    }
+    public CommandLine build(boolean longOpt) throws ParseException {
+      return getCLI(map, longOpt);
+    }
+    private CommandLine getCLI(EnumMap<ParserTopologyCLI.ParserOptions, String> options, boolean longOpt) throws ParseException {
+      ArrayList<String> args = new ArrayList<>();
+      for (Map.Entry<ParserTopologyCLI.ParserOptions, String> option : options.entrySet()) {
+        boolean hasLongOpt = option.getKey().option.hasLongOpt();
+        if (hasLongOpt && longOpt) {
+          args.add("--" + option.getKey().option.getLongOpt());
+          if (option.getKey().option.hasArg() && option.getValue() != null) {
+            args.add(option.getValue());
+          }
+        } else if (hasLongOpt && !longOpt) {
+          args.add("-" + option.getKey().shortCode);
+          if (option.getKey().option.hasArg() && option.getValue() != null) {
+            args.add(option.getValue());
+          }
+        }
+      }
+      return ParserTopologyCLI.ParserOptions.parse(new PosixParser(), args.toArray(new String[args.size()]));
+    }
+  }
+
+
+  @Test
+  public void testCLI_happyPath() throws ParseException {
+    happyPath(true);
+    happyPath(false);
+  }
+
+  @Test(expected=ParseException.class)
+  public void testCLI_insufficientArg() throws ParseException {
+    CommandLine cli = new CLIBuilder().with(ParserTopologyCLI.ParserOptions.BROKER_URL, "mybroker")
+                                      .with(ParserTopologyCLI.ParserOptions.ZK_QUORUM, "myzk")
+                                      .build(true);
+  }
+  public void happyPath(boolean longOpt) throws ParseException {
+    CommandLine cli = new CLIBuilder().with(ParserTopologyCLI.ParserOptions.BROKER_URL, "mybroker")
+                                      .with(ParserTopologyCLI.ParserOptions.ZK_QUORUM, "myzk")
+                                      .with(ParserTopologyCLI.ParserOptions.SENSOR_TYPE, "mysensor")
+                                      .build(longOpt);
+    Assert.assertEquals("myzk", ParserTopologyCLI.ParserOptions.ZK_QUORUM.get(cli));
+    Assert.assertEquals("mybroker", ParserTopologyCLI.ParserOptions.BROKER_URL.get(cli));
+    Assert.assertEquals("mysensor", ParserTopologyCLI.ParserOptions.SENSOR_TYPE.get(cli));
+  }
+
+  @Test
+  public void testConfig_noExtra() throws ParseException {
+    testConfig_noExtra(true);
+    testConfig_noExtra(false);
+  }
+
+  public void testConfig_noExtra(boolean longOpt) throws ParseException {
+   CommandLine cli = new CLIBuilder().with(ParserTopologyCLI.ParserOptions.BROKER_URL, "mybroker")
+                                     .with(ParserTopologyCLI.ParserOptions.ZK_QUORUM, "myzk")
+                                     .with(ParserTopologyCLI.ParserOptions.SENSOR_TYPE, "mysensor")
+                                     .with(ParserTopologyCLI.ParserOptions.NUM_WORKERS, "1")
+                                     .with(ParserTopologyCLI.ParserOptions.NUM_ACKERS, "2")
+                                     .with(ParserTopologyCLI.ParserOptions.NUM_MAX_TASK_PARALLELISM, "3")
+                                     .with(ParserTopologyCLI.ParserOptions.MESSAGE_TIMEOUT, "4")
+                                     .build(longOpt);
+    Config config = ParserTopologyCLI.ParserOptions.getConfig(cli);
+    Assert.assertEquals(1, config.get(Config.TOPOLOGY_WORKERS));
+    Assert.assertEquals(2, config.get(Config.TOPOLOGY_ACKER_EXECUTORS));
+    Assert.assertEquals(3, config.get(Config.TOPOLOGY_MAX_TASK_PARALLELISM));
+    Assert.assertEquals(4, config.get(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS));
+  }
+  /**
+    {
+      "string" : "foo"
+     ,"integer" : 1
+    }
+   */
+  @Multiline
+  public static String extraConfig;
+
+  @Test
+  public void testConfig_extra() throws Exception {
+    testConfig_extra(true);
+    testConfig_extra(false);
+  }
+
+  public void testConfig_extra(boolean longOpt) throws IOException, ParseException {
+    File extraFile = File.createTempFile("extra", "json");
+    try {
+      FileUtils.write(extraFile, extraConfig);
+      CommandLine cli = new CLIBuilder().with(ParserTopologyCLI.ParserOptions.BROKER_URL, "mybroker")
+              .with(ParserTopologyCLI.ParserOptions.ZK_QUORUM, "myzk")
+              .with(ParserTopologyCLI.ParserOptions.SENSOR_TYPE, "mysensor")
+              .with(ParserTopologyCLI.ParserOptions.MESSAGE_TIMEOUT, "4")
+              .with(ParserTopologyCLI.ParserOptions.EXTRA_OPTIONS, extraFile.getAbsolutePath())
+              .build(longOpt);
+      Config config = ParserTopologyCLI.ParserOptions.getConfig(cli);
+      Assert.assertEquals(4, config.get(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS));
+      Assert.assertEquals("foo", config.get("string"));
+      Assert.assertEquals(1, config.get("integer"));
+    } finally{
+      extraFile.deleteOnExit();
+    }
+  }
+}


### PR DESCRIPTION
Add the ability to specify the message timeout, the max task parallelism, the number of ackers, the number of workers. Also allow the user to pass in JSON file containing a map of extra storm configs.

I added the following extra options to `start_parser_topology.sh`:
```
 -e,--extra_options <JSON_FILE>            Extra options in the form of a
                                           JSON file with a map for
                                           content.
 -mt,--message_timeout <TIMEOUT_IN_SECS>   Message Timeout in Seconds
 -mtp,--max_task_parallelism <MAX_TASK>    Max task parallelism
 -na,--num_ackers <NUM_ACKERS>             Number of Ackers
 -nw,--num_workers <NUM_WORKERS>           Number of Workers
```

For instance, if you wanted to set some storm property on
the config called `topology.ticks.tuple.freq.secs` to 1000 and `storm.local.dir` to `/opt/my/path`
you could create a file called `custom_config.json` containing
```
{
  "topology.ticks.tuple.freq.secs" : 1000,
  "storm.local.dir" : "/opt/my/path"
}
```
and pass `--extra_options custom_config.json` to `start_parser_topology.sh`.