### PR TITLE
METRON-197: Validation should be the last step in the ParserBolt

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/writer/BulkWriterComponent.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/writer/BulkWriterComponent.java
@@ -59,7 +59,7 @@ public class BulkWriterComponent<MESSAGE_T> {
   }
 
   public void error(Exception e, Iterable<Tuple> tuples) {
-    tuples.forEach(t -> collector.fail(t));
+    tuples.forEach(t -> collector.ack(t));
     LOG.error("Failing " + Iterables.size(tuples) + " tuples", e);
     ErrorUtils.handleError(collector, e, Constants.ERROR_STREAM);
   }

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBoltTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBoltTest.java
@@ -144,8 +144,7 @@ public class BulkMessageWriterBoltTest extends BaseEnrichmentBoltTest {
     for(int i = 0; i < 5; i++) {
       bulkMessageWriterBolt.execute(tuple);
     }
-    verify(outputCollector, times(0)).ack(tuple);
-    verify(outputCollector, times(5)).fail(tuple);
+    verify(outputCollector, times(5)).ack(tuple);
     verify(outputCollector, times(1)).emit(eq(Constants.ERROR_STREAM), any(Values.class));
     verify(outputCollector, times(1)).reportError(any(Throwable.class));
   }

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/bolt/ParserBolt.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/bolt/ParserBolt.java
@@ -141,7 +141,7 @@ public class ParserBolt extends ConfiguredParserBolt implements Serializable {
       if(sensorParserConfig != null) {
         List<FieldValidator> fieldValidations = getConfigurations().getFieldValidations();
         Optional<List<JSONObject>> messages = parser.parseOptional(originalMessage);
-        for (JSONObject message : messages.orElse(Collections.EMPTY_LIST)) {
+        for (JSONObject message : messages.orElse(Collections.emptyList())) {
           if (parser.validate(message) && filter != null && filter.emitTuple(message)) {
             if(!isGloballyValid(message, fieldValidations)) {
               message.put(Constants.SENSOR_TYPE, getSensorType()+ ".invalid");

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/bolt/ParserBolt.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/bolt/ParserBolt.java
@@ -171,7 +171,7 @@ public class ParserBolt extends ConfiguredParserBolt implements Serializable {
       }
     } catch (Throwable ex) {
       ErrorUtils.handleError(collector, ex, Constants.ERROR_STREAM);
-      collector.fail(tuple);
+      collector.ack(tuple);
     }
   }
 

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/interfaces/MessageParser.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/interfaces/MessageParser.java
@@ -20,10 +20,15 @@ package org.apache.metron.parsers.interfaces;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface MessageParser<T> extends Configurable{
-	void init();
-	List<T> parse(byte[] rawMessage);
-	boolean validate(T message);
+  void init();
+  List<T> parse(byte[] rawMessage);
+  default Optional<List<T>> parseOptional(byte[] parseMessage) {
+    return Optional.of(parse(parseMessage));
+  }
+
+  boolean validate(T message);
 
 }

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/bolt/ParserBoltTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/bolt/ParserBoltTest.java
@@ -318,27 +318,20 @@ public void testImplicitBatchOfOne() throws Exception {
     when(parser.parse(any())).thenReturn(ImmutableList.of(new JSONObject()));
     when(filter.emitTuple(any())).thenReturn(true);
     parserBolt.withMessageFilter(filter);
-    writeNonBatch(outputCollector, parserBolt, t1);
-    writeNonBatch(outputCollector, parserBolt, t2);
-    writeNonBatch(outputCollector, parserBolt, t3);
-    writeNonBatch(outputCollector, parserBolt, t4);
+    parserBolt.execute(t1);
+    parserBolt.execute(t2);
+    parserBolt.execute(t3);
+    parserBolt.execute(t4);
     parserBolt.execute(t5);
-    verify(outputCollector, times(0)).ack(t1);
-    verify(outputCollector, times(1)).fail(t1);
-    verify(outputCollector, times(0)).ack(t2);
-    verify(outputCollector, times(1)).fail(t2);
-    verify(outputCollector, times(0)).ack(t3);
-    verify(outputCollector, times(1)).fail(t3);
-    verify(outputCollector, times(0)).ack(t4);
-    verify(outputCollector, times(1)).fail(t4);
-    verify(outputCollector, times(0)).ack(t5);
-    verify(outputCollector, times(1)).fail(t5);
-
+    verify(outputCollector, times(1)).ack(t1);
+    verify(outputCollector, times(1)).ack(t2);
+    verify(outputCollector, times(1)).ack(t3);
+    verify(outputCollector, times(1)).ack(t4);
+    verify(outputCollector, times(1)).ack(t5);
 
   }
   private static void writeNonBatch(OutputCollector collector, ParserBolt bolt, Tuple t) {
     bolt.execute(t);
-    verify(collector, times(1)).ack(t);
   }
 
 }

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/bolt/ParserBoltTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/bolt/ParserBoltTest.java
@@ -338,26 +338,7 @@ public void testImplicitBatchOfOne() throws Exception {
   }
   private static void writeNonBatch(OutputCollector collector, ParserBolt bolt, Tuple t) {
     bolt.execute(t);
-    verify(collector, times(0)).ack(t);
+    verify(collector, times(1)).ack(t);
   }
 
-/*=======
-    verify(writer, times(1)).init();
-    byte[] sampleBinary = "some binary message".getBytes();
-    JSONParser jsonParser = new JSONParser();
-    final JSONObject sampleMessage1 = (JSONObject) jsonParser.parse("{ \"field1\":\"value1\" }");
-    final JSONObject sampleMessage2 = (JSONObject) jsonParser.parse("{ \"field2\":\"value2\" }");
-    List<JSONObject> messages = new ArrayList<JSONObject>() {{
-      add(sampleMessage1);
-      add(sampleMessage2);
-    }};
-    final JSONObject finalMessage1 = (JSONObject) jsonParser.parse("{ \"field1\":\"value1\", \"source.type\":\"" + sensorType + "\" }");
-    when(tuple.getBinary(0)).thenReturn(sampleBinary);
-    when(parser.parse(sampleBinary)).thenReturn(messages);
-    when(parser.validate(any(JSONObject.class))).thenReturn(true);
-    parserBolt.execute(tuple);
-    verify(writer, times(1)).write(eq(sensorType), any(Configurations.class), eq(tuple), eq(finalMessage1));
-    verify(outputCollector, times(1)).ack(tuple);
-  }
->>>>>>> master*/
 }

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/bolt/ParserBoltTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/bolt/ParserBoltTest.java
@@ -43,10 +43,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -103,6 +100,7 @@ public class ParserBoltTest extends BaseBoltTest {
           }
         };
       }
+
     };
     parserBolt.setCuratorFramework(client);
     parserBolt.setTreeCache(cache);
@@ -120,7 +118,7 @@ public class ParserBoltTest extends BaseBoltTest {
     final JSONObject finalMessage1 = (JSONObject) jsonParser.parse("{ \"field1\":\"value1\", \"source.type\":\"" + sensorType + "\" }");
     final JSONObject finalMessage2 = (JSONObject) jsonParser.parse("{ \"field2\":\"value2\", \"source.type\":\"" + sensorType + "\" }");
     when(tuple.getBinary(0)).thenReturn(sampleBinary);
-    when(parser.parse(sampleBinary)).thenReturn(messages);
+    when(parser.parseOptional(sampleBinary)).thenReturn(Optional.of(messages));
     when(parser.validate(eq(messages.get(0)))).thenReturn(true);
     when(parser.validate(eq(messages.get(1)))).thenReturn(false);
     parserBolt.execute(tuple);
@@ -166,7 +164,7 @@ public void testImplicitBatchOfOne() throws Exception {
   verify(parser, times(1)).init();
   verify(batchWriter, times(1)).init(any(), any());
   when(parser.validate(any())).thenReturn(true);
-  when(parser.parse(any())).thenReturn(ImmutableList.of(new JSONObject()));
+  when(parser.parseOptional(any())).thenReturn(Optional.of(ImmutableList.of(new JSONObject())));
   when(filter.emitTuple(any())).thenReturn(true);
   parserBolt.withMessageFilter(filter);
   parserBolt.execute(t1);
@@ -202,7 +200,7 @@ public void testImplicitBatchOfOne() throws Exception {
     verify(parser, times(1)).init();
     verify(batchWriter, times(1)).init(any(), any());
     when(parser.validate(any())).thenReturn(true);
-    when(parser.parse(any())).thenReturn(ImmutableList.of(new JSONObject()));
+    when(parser.parseOptional(any())).thenReturn(Optional.of(ImmutableList.of(new JSONObject())));
     parserBolt.withMessageFilter(filter);
     parserBolt.execute(t1);
     verify(outputCollector, times(1)).ack(t1);
@@ -236,7 +234,7 @@ public void testImplicitBatchOfOne() throws Exception {
     verify(parser, times(1)).init();
     verify(batchWriter, times(1)).init(any(), any());
     when(parser.validate(any())).thenReturn(true);
-    when(parser.parse(any())).thenReturn(ImmutableList.of(new JSONObject()));
+    when(parser.parseOptional(any())).thenReturn(Optional.of(ImmutableList.of(new JSONObject())));
     when(filter.emitTuple(any())).thenReturn(true);
     parserBolt.withMessageFilter(filter);
     parserBolt.execute(t1);
@@ -271,7 +269,7 @@ public void testImplicitBatchOfOne() throws Exception {
     verify(parser, times(1)).init();
     verify(batchWriter, times(1)).init(any(), any());
     when(parser.validate(any())).thenReturn(true);
-    when(parser.parse(any())).thenReturn(ImmutableList.of(new JSONObject()));
+    when(parser.parseOptional(any())).thenReturn(Optional.of(ImmutableList.of(new JSONObject())));
     when(filter.emitTuple(any())).thenReturn(true);
     parserBolt.withMessageFilter(filter);
     writeNonBatch(outputCollector, parserBolt, t1);


### PR DESCRIPTION
Right now we are doing the validation prior to the messageFilter.  We should only validate the parsed messages which passes through the filter.