### PR TITLE
METRON-217: Found a grabbag of bugs

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/ErrorUtils.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/ErrorUtils.java
@@ -17,6 +17,9 @@
  */
 package org.apache.metron.common.utils;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -60,5 +63,26 @@ public class ErrorUtils {
 		JSONObject error = ErrorUtils.generateErrorMessage(t.getMessage(), t);
 		collector.emit(errorStream, new Values(error));
 		collector.reportError(t);
+	}
+
+	public static String generateThreadDump() {
+		final StringBuilder dump = new StringBuilder();
+		final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+		final ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadMXBean.getAllThreadIds(), 100);
+		for (ThreadInfo threadInfo : threadInfos) {
+			dump.append('"');
+			dump.append(threadInfo.getThreadName());
+			dump.append("\" ");
+			final Thread.State state = threadInfo.getThreadState();
+			dump.append("\n   java.lang.Thread.State: ");
+			dump.append(state);
+			final StackTraceElement[] stackTraceElements = threadInfo.getStackTrace();
+			for (final StackTraceElement stackTraceElement : stackTraceElements) {
+				dump.append("\n        at ");
+				dump.append(stackTraceElement);
+			}
+			dump.append("\n\n");
+		}
+		return dump.toString();
 	}
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/writer/BulkWriterComponent.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/writer/BulkWriterComponent.java
@@ -58,7 +58,7 @@ public class BulkWriterComponent<MESSAGE_T> {
     }
   }
 
-  public void error(Exception e, Iterable<Tuple> tuples) {
+  public void error(Throwable e, Iterable<Tuple> tuples) {
     tuples.forEach(t -> collector.ack(t));
     LOG.error("Failing " + Iterables.size(tuples) + " tuples", e);
     ErrorUtils.handleError(collector, e, Constants.ERROR_STREAM);
@@ -98,7 +98,7 @@ public class BulkWriterComponent<MESSAGE_T> {
           commit(tupleList);
         }
 
-      } catch (Exception e) {
+      } catch (Throwable e) {
         if(handleError) {
           error(e, tupleList);
         }

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBolt.java
@@ -60,10 +60,20 @@ public class BulkMessageWriterBolt extends ConfiguredEnrichmentBolt {
     }
   }
 
+  private JSONObject cloneMessage(Tuple tuple) {
+    JSONObject ret = new JSONObject();
+    JSONObject message = (JSONObject) tuple.getValueByField("message");
+    for(Iterator<Map.Entry<String, Object>> it = message.entrySet().iterator();it.hasNext();) {
+      Map.Entry<String, Object> kv = it.next();
+      ret.put(kv.getKey(), kv.getValue());
+    }
+    return ret;
+  }
+
   @SuppressWarnings("unchecked")
   @Override
   public void execute(Tuple tuple) {
-    JSONObject message = new JSONObject((JSONObject) tuple.getValueByField("message"));
+    JSONObject message = cloneMessage(tuple);
     String sensorType = MessageUtils.getSensorType(message);
     try
     {

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBolt.java
@@ -64,7 +64,6 @@ public class BulkMessageWriterBolt extends ConfiguredEnrichmentBolt {
   @Override
   public void execute(Tuple tuple) {
     JSONObject message = new JSONObject((JSONObject) tuple.getValueByField("message"));
-    message.put("index." + bulkMessageWriter.getClass().getSimpleName().toLowerCase() + ".ts", "" + System.currentTimeMillis());
     String sensorType = MessageUtils.getSensorType(message);
     try
     {

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBolt.java
@@ -63,7 +63,7 @@ public class BulkMessageWriterBolt extends ConfiguredEnrichmentBolt {
   @SuppressWarnings("unchecked")
   @Override
   public void execute(Tuple tuple) {
-    JSONObject message = (JSONObject)((JSONObject) tuple.getValueByField("message")).clone();
+    JSONObject message = new JSONObject((JSONObject) tuple.getValueByField("message"));
     message.put("index." + bulkMessageWriter.getClass().getSimpleName().toLowerCase() + ".ts", "" + System.currentTimeMillis());
     String sensorType = MessageUtils.getSensorType(message);
     try
@@ -71,7 +71,7 @@ public class BulkMessageWriterBolt extends ConfiguredEnrichmentBolt {
       writerComponent.write(sensorType, tuple, message, bulkMessageWriter, new EnrichmentWriterConfiguration(getConfigurations()));
     }
     catch(Exception e) {
-      throw new RuntimeException("This should have been caught in the writerComponent.  If you see this, file a JIRA");
+      throw new RuntimeException("This should have been caught in the writerComponent.  If you see this, file a JIRA", e);
     }
   }
 

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentJoinBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentJoinBolt.java
@@ -81,7 +81,7 @@ public class EnrichmentJoinBolt extends JoinBolt<JSONObject> {
       message.remove(o);
     }
     message.put(getClass().getSimpleName().toLowerCase() + ".joiner.ts", "" + System.currentTimeMillis());
-    return message;
+    return (JSONObject) message.clone();
   }
 
   public Map<String, List<String>> getFieldMap(String sourceType) {

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentSplitterBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentSplitterBolt.java
@@ -90,7 +90,7 @@ public class EnrichmentSplitterBolt extends SplitBolt<JSONObject> {
             message = (JSONObject) tuple.getValueByField(messageFieldName);
             message.put(getClass().getSimpleName().toLowerCase() + ".splitter.begin.ts", "" + System.currentTimeMillis());
         }
-        return message;
+        return (JSONObject)message.clone();
     }
 
     @Override

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/SplitBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/SplitBolt.java
@@ -29,7 +29,7 @@ import org.apache.metron.common.bolt.ConfiguredEnrichmentBolt;
 import java.util.Map;
 import java.util.Set;
 
-public abstract class SplitBolt<T> extends
+public abstract class SplitBolt<T extends Cloneable> extends
         ConfiguredEnrichmentBolt {
 
   protected OutputCollector collector;

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/GrokParser.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/GrokParser.java
@@ -135,8 +135,9 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
       init();
     }
     List<JSONObject> messages = new ArrayList<>();
+    String originalMessage = null;
     try {
-      String originalMessage = new String(rawMessage, "UTF-8");
+      originalMessage = new String(rawMessage, "UTF-8");
       if (LOG.isDebugEnabled()) {
         LOG.debug("Grok perser parsing message: " + originalMessage);
       }
@@ -168,7 +169,7 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
       }
     } catch (Exception e) {
       LOG.error(e.getMessage(), e);
-      return null;
+      throw new RuntimeException("Grok parser Error: " + e.getMessage() + " on " + originalMessage , e);
     }
     return messages;
   }

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyBuilder.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyBuilder.java
@@ -64,7 +64,7 @@ public class ParserTopologyBuilder {
     SpoutConfig spoutConfig = new SpoutConfig(zkHosts, sensorTopic, "", sensorTopic).from(offset);
     KafkaSpout kafkaSpout = new KafkaSpout(spoutConfig);
     builder.setSpout("kafkaSpout", kafkaSpout, spoutParallelism)
-           .setNumTasks(parserNumTasks);
+           .setNumTasks(spoutNumTasks);
     MessageParser<JSONObject> parser = ReflectionUtils.createInstance(sensorParserConfig.getParserClassName());
     parser.configure(sensorParserConfig.getParserConfig());
     ParserBolt parserBolt = null;
@@ -89,7 +89,7 @@ public class ParserTopologyBuilder {
       }
     }
     builder.setBolt("parserBolt", parserBolt, parserParallelism)
-           .setNumTasks(spoutNumTasks)
+           .setNumTasks(parserNumTasks)
            .shuffleGrouping("kafkaSpout");
     return builder;
   }

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/websphere/GrokWebSphereParserTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/websphere/GrokWebSphereParserTest.java
@@ -225,7 +225,7 @@ public class GrokWebSphereParserTest {
 	}
 	
 	
-	@Test
+	@Test(expected=RuntimeException.class)
 	public void testParseEmptyLine() throws Exception {
 		
 		//Set up parser, attempt to parse malformed message
@@ -233,7 +233,6 @@ public class GrokWebSphereParserTest {
 		parser.configure(parserConfig);
 		String testString = "";
 		List<JSONObject> result = parser.parse(testString.getBytes());		
-		assertEquals(null, result);
 	}
 		
 }


### PR DESCRIPTION
Doing some scale testing, I found a grabbag of bugs:
* The elasticsearch writer should allow multiple ES hosts to be passed in via a List. This should be backwards compatible.
* There is a concurrent modification exception while cloning the message field
* The parser topology numSpoutTasks and numParserTasks are swapped
* The grok parser should throw an exception if it cannot parse so the message that could not be parsed is sent to the error queue.
