### PR TITLE
METRON-222: Address ConcurrentModificationException in BulkMessageWriter

### DIFF
--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/BulkMessageWriterBolt.java
@@ -61,26 +61,11 @@ public class BulkMessageWriterBolt extends ConfiguredEnrichmentBolt {
     }
   }
 
-  private JSONObject cloneMessage(Tuple tuple) {
-    JSONObject ret = new JSONObject();
-    JSONObject message = (JSONObject) tuple.getValueByField("message");
-    try {
-      for (Iterator<Map.Entry<String, Object>> it = message.entrySet().iterator(); it.hasNext(); ) {
-        Map.Entry<String, Object> kv = it.next();
-        ret.put(kv.getKey(), kv.getValue());
-      }
-    }
-    catch(ConcurrentModificationException cme) {
-      LOG.error(cme.getMessage() + "\n" + ErrorUtils.generateThreadDump(), cme);
-      throw cme;
-    }
-    return ret;
-  }
 
   @SuppressWarnings("unchecked")
   @Override
   public void execute(Tuple tuple) {
-    JSONObject message = cloneMessage(tuple);
+    JSONObject message =(JSONObject)tuple.getValueByField("message");
     String sensorType = MessageUtils.getSensorType(message);
     try
     {

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentJoinBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentJoinBolt.java
@@ -81,7 +81,7 @@ public class EnrichmentJoinBolt extends JoinBolt<JSONObject> {
       message.remove(o);
     }
     message.put(getClass().getSimpleName().toLowerCase() + ".joiner.ts", "" + System.currentTimeMillis());
-    return (JSONObject) message.clone();
+    return  message;
   }
 
   public Map<String, List<String>> getFieldMap(String sourceType) {

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentSplitterBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/EnrichmentSplitterBolt.java
@@ -90,7 +90,7 @@ public class EnrichmentSplitterBolt extends SplitBolt<JSONObject> {
             message = (JSONObject) tuple.getValueByField(messageFieldName);
             message.put(getClass().getSimpleName().toLowerCase() + ".splitter.begin.ts", "" + System.currentTimeMillis());
         }
-        return (JSONObject)message.clone();
+        return message;
     }
 
     @Override

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/SplitBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/SplitBolt.java
@@ -64,7 +64,6 @@ public abstract class SplitBolt<T extends Cloneable> extends
   public void emit(Tuple tuple, T message) {
     if (message == null) return;
     String key = getKey(tuple, message);
-    collector.emit("message", tuple, new Values(key, message));
     Map<String, T> streamMessageMap = splitMessage(message);
     for (String streamId : streamMessageMap.keySet()) {
       T streamMessage = streamMessageMap.get(streamId);
@@ -73,6 +72,7 @@ public abstract class SplitBolt<T extends Cloneable> extends
       }
       collector.emit(streamId, new Values(key, streamMessage));
     }
+    collector.emit("message", tuple, new Values(key, message));
     collector.ack(tuple);
     emitOther(tuple, message);
   }


### PR DESCRIPTION
In the situation where multiple consecutive bolts exist in different executors in the same JVM, the passed tuples are not serialized or deserialized for performance in Storm.  As such, we were emitting a message and then immediately mutating it.  Meanwhile, in a different thread (executor) the message, a HashMap, is being iterated on in the next bolt.  This causes a CME.