### PR TITLE
METRON-228: Fixing NPE when enrichment config does not exist.

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/EnrichmentWriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/EnrichmentWriterConfiguration.java
@@ -39,15 +39,24 @@ public class EnrichmentWriterConfiguration implements WriterConfiguration{
 
   @Override
   public String getIndex(String sensorName) {
-    return config.getSensorEnrichmentConfig(sensorName).getIndex();
+    if(config != null && config.getSensorEnrichmentConfig(sensorName) != null) {
+      return config.getSensorEnrichmentConfig(sensorName).getIndex();
+    }
+    return sensorName;
   }
 
   @Override
   public Map<String, Object> getSensorConfig(String sensorName) {
-    return config.getSensorEnrichmentConfig(sensorName).getConfiguration();
+    if(config != null && config.getSensorEnrichmentConfig(sensorName) != null) {
+      return config.getSensorEnrichmentConfig(sensorName).getConfiguration();
+    }
+    return null;
   }
   @Override
   public Map<String, Object> getGlobalConfig() {
-    return config.getGlobalConfig();
+    if(config != null) {
+      return config.getGlobalConfig();
+    }
+    return null;
   }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/EnrichmentWriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/EnrichmentWriterConfiguration.java
@@ -31,7 +31,10 @@ public class EnrichmentWriterConfiguration implements WriterConfiguration{
 
   @Override
   public int getBatchSize(String sensorName) {
-    return config.getSensorEnrichmentConfig(sensorName).getBatchSize();
+    if(config != null && config.getSensorEnrichmentConfig(sensorName) != null) {
+      return config.getSensorEnrichmentConfig(sensorName).getBatchSize();
+    }
+    return 1;
   }
 
   @Override

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/ParserWriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/ParserWriterConfiguration.java
@@ -32,14 +32,28 @@ public class ParserWriterConfiguration implements WriterConfiguration {
   }
   @Override
   public int getBatchSize(String sensorName) {
-    Object batchObj = config.getSensorParserConfig(sensorName).getParserConfig().get(BATCH_CONF);
-    return batchObj == null?1:ConversionUtils.convert(batchObj, Integer.class);
+    if(config != null
+    && config.getSensorParserConfig(sensorName) != null
+    && config.getSensorParserConfig(sensorName).getParserConfig() != null
+      ) {
+      Object batchObj = config.getSensorParserConfig(sensorName).getParserConfig().get(BATCH_CONF);
+      return batchObj == null ? 1 : ConversionUtils.convert(batchObj, Integer.class);
+    }
+    return 1;
   }
 
   @Override
   public String getIndex(String sensorName) {
-    Object indexObj = config.getSensorParserConfig(sensorName).getParserConfig().get(INDEX_CONF);
-    return indexObj.toString();
+    if(config != null && config.getSensorParserConfig(sensorName) != null
+    && config.getSensorParserConfig(sensorName).getParserConfig() != null
+      ) {
+      Object indexObj = config.getSensorParserConfig(sensorName).getParserConfig().get(INDEX_CONF);
+      if(indexObj != null) {
+        return indexObj.toString();
+      }
+      return null;
+    }
+    return sensorName;
   }
 
   @Override

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/writer/EnrichmentWriterConfigurationTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/writer/EnrichmentWriterConfigurationTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.common.writer;
+
+import org.apache.metron.common.configuration.EnrichmentConfigurations;
+import org.apache.metron.common.configuration.writer.EnrichmentWriterConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EnrichmentWriterConfigurationTest {
+  @Test
+  public void testDefaultBatchSize() {
+    EnrichmentWriterConfiguration config = new EnrichmentWriterConfiguration(
+           new EnrichmentConfigurations()
+    );
+    Assert.assertEquals(1, config.getBatchSize("foo"));
+  }
+}

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/writer/ParserWriterConfigurationTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/writer/ParserWriterConfigurationTest.java
@@ -18,24 +18,21 @@
 
 package org.apache.metron.common.writer;
 
-import org.apache.metron.common.configuration.EnrichmentConfigurations;
-import org.apache.metron.common.configuration.writer.EnrichmentWriterConfiguration;
+import org.apache.metron.common.configuration.ParserConfigurations;
+import org.apache.metron.common.configuration.writer.ParserWriterConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class EnrichmentWriterConfigurationTest {
+public class ParserWriterConfigurationTest {
   @Test
   public void testDefaultBatchSize() {
-    EnrichmentWriterConfiguration config = new EnrichmentWriterConfiguration(
-           new EnrichmentConfigurations()
-    );
+    ParserWriterConfiguration config = new ParserWriterConfiguration( new ParserConfigurations() );
     Assert.assertEquals(1, config.getBatchSize("foo"));
   }
+
   @Test
   public void testDefaultIndex() {
-    EnrichmentWriterConfiguration config = new EnrichmentWriterConfiguration(
-           new EnrichmentConfigurations()
-    );
+    ParserWriterConfiguration config = new ParserWriterConfiguration( new ParserConfigurations() );
     Assert.assertEquals("foo", config.getIndex("foo"));
   }
 }


### PR DESCRIPTION
Because we are pulling the batch size from the enrichment sensor config, if it does not exist then it will throw a NPE.