### PR TITLE
Fixed error when start up the system.

### DIFF
--- a/metron-deployment/extra_modules/ambari_cluster_state.py
+++ b/metron-deployment/extra_modules/ambari_cluster_state.py
@@ -142,7 +142,7 @@ def main():
         blueprint_var=dict(type='dict', required=False),
         blueprint_name=dict(type='str', default=None, required=False),
         configurations=dict(type='list', default=None, required=False),
-        wait_for_complete=dict(default=False, required=False, choices=BOOLEANS),
+        wait_for_complete=dict(default=False, required=False, choices=BOOLEANS+['True', True, 'False', False]),
     )
 
     required_together = ['blueprint_var', 'blueprint_name']


### PR DESCRIPTION
When start ./run.sh, this error appeard:
fatal: [node1]: FAILED! => {"changed": false, "failed": true, "msg": "value of wait_for_complete must be one of: yes,on,1,true,1,True,no,off,0,false,0,False, got: True"}
In:
  TASK [ambari_config : Deploy cluster with Ambari; http://node1:8080] ***********