### PR TITLE
METRON-230: Bro parser should throw exception

### DIFF
--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/bro/BasicBroParserTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/bro/BasicBroParserTest.java
@@ -160,4 +160,22 @@ public class BasicBroParserTest extends TestCase {
 		Assert.assertEquals(broJson.get("ip_src_addr").toString(), rawJson.get("id.orig_h").toString());
 		Assert.assertTrue(broJson.get("original_string").toString().startsWith("HTTP"));
 	}
+
+	public void testBadMessage()  throws ParseException{
+		try {
+			broParser.parse("{ \"foo\" : \"bar\"}".getBytes());
+			Assert.fail("Should have marked this as a bad message.");
+		}
+		catch(IllegalStateException ise) {
+
+		}
+		//non json
+		try {
+			broParser.parse("foo bar".getBytes());
+			Assert.fail("Should have marked this as a bad message.");
+		}
+		catch(IllegalStateException ise) {
+
+		}
+	}
 }


### PR DESCRIPTION
Right now, if an invalid message comes to the bro parser, it returns null, which is interpreted as no messages from the parser.  INstead, we should throw an exception so the message can be routed to the error queue.