### PR TITLE
METRON-247 Deployment fails on hosts with no 'eth0' network interface

### DIFF
--- a/metron-deployment/amazon-ec2/playbook.yml
+++ b/metron-deployment/amazon-ec2/playbook.yml
@@ -62,6 +62,7 @@
     - include: tasks/check-volume.yml vol_name=xvda vol_src=/dev/xvda vol_size={{ xvda_vol_size }}
   tags:
     - ec2
+    - ec2-mount
 
 #
 # build the metron cluster

--- a/metron-deployment/amazon-ec2/playbook.yml
+++ b/metron-deployment/amazon-ec2/playbook.yml
@@ -62,7 +62,6 @@
     - include: tasks/check-volume.yml vol_name=xvda vol_src=/dev/xvda vol_size={{ xvda_vol_size }}
   tags:
     - ec2
-    - ec2-mount
 
 #
 # build the metron cluster

--- a/metron-deployment/roles/sensor-test-mode/tasks/snort.yml
+++ b/metron-deployment/roles/sensor-test-mode/tasks/snort.yml
@@ -30,3 +30,9 @@
     dest: /etc/snort/rules/test.rules
     line: "alert tcp any any -> any any (msg:'snort test alert'; sid:999158; )"
     create: yes
+
+- name: Configure home network
+  lineinfile:
+    dest: /etc/snort/snort.conf
+    regexp: "^ipvar HOME_NET.*$"
+    line: "ipvar HOME_NET any"

--- a/metron-deployment/roles/snort/defaults/main.yml
+++ b/metron-deployment/roles/snort/defaults/main.yml
@@ -22,4 +22,5 @@ snort_alert_csv_path: /var/log/snort/alert.csv
 snort_src_url: "https://snort.org/downloads/archive/snort/snort-{{ snort_version }}.src.rpm"
 snort_community_rules_url: "https://www.snort.org/downloads/community/community-rules.tar.gz"
 dag_src_url: "https://snort.org/downloads/snort/daq-{{ daq_version }}.src.rpm"
-
+sniff_interface: eth0
+snort_home_net: "{{ hostvars[inventory_hostname]['ansible_' + sniff_interface]['ipv4']['address'] }}"

--- a/metron-deployment/roles/snort/tasks/snort.yml
+++ b/metron-deployment/roles/snort/tasks/snort.yml
@@ -63,11 +63,11 @@
 - name: Download snort configuration
   copy: src=snort.conf dest=/etc/snort/snort.conf
 
-- name: Configure network
+- name: Configure home network
   lineinfile:
     dest: /etc/snort/snort.conf
     regexp: "^ipvar HOME_NET.*$"
-    line: "ipvar HOME_NET {{ ansible_eth0.ipv4.address }}"
+    line: "ipvar HOME_NET {{ snort_home_net }}"
 
 - name: Configure alerting
   lineinfile:


### PR DESCRIPTION
Snort was previously using the IPv4 address of the `eth0` network interface as its HOME_NET.  This is a problem, of course, if there is no such interface.  The deployment was failing when run on hosts that do not have an `eth0` network interface.

This fix uses the IPv4 address of the `sniff_interface` as a sensible default.  This works fine for most development or demo builds of Metron.  For other deployments, the user can override `snort_home_net` to define this value appropriately for their environment.

In the case of using canned or replayed pcap data for testing, this value also needs to be adjusted based on the pcap data.  For this scenario, I altered 'sensor-test-mode' to use a `HOME_NET` of `any` so that it correctly alerts on every packet seen.