### PR TITLE
METRON-246 metron_streaming role needs to explicitly install defaults

### DIFF
--- a/metron-deployment/roles/metron_streaming/meta/main.yml
+++ b/metron-deployment/roles/metron_streaming/meta/main.yml
@@ -18,3 +18,4 @@
 dependencies:
   - ambari_gather_facts
   - java_jdk
+  - libselinux-python


### PR DESCRIPTION
Tested on quick-dev-platform and bare metal.