### PR TITLE
METRON-253: Reloading parser configurations from zookeeper doesn't call init()

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/FieldTransformer.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/FieldTransformer.java
@@ -34,7 +34,7 @@ public class FieldTransformer implements Serializable {
   private List<String> output;
   private FieldTransformation transformation;
   private Map<String, Object> config = new HashMap<>();
-
+  private boolean initialized = false;
   public FieldTransformer() {
   }
 
@@ -81,17 +81,19 @@ public class FieldTransformer implements Serializable {
   }
 
   public void initAndValidate() {
-    if(getTransformation() == null) {
-      throw new IllegalStateException("Mapping cannot be null.");
-    }
+    if(!initialized) {
+      if (getTransformation() == null) {
+        throw new IllegalStateException("Mapping cannot be null.");
+      }
 
-    if(output== null || output.isEmpty()) {
-      if(input == null || input.isEmpty()) {
-        throw new IllegalStateException("You must specify an input field if you want to leave the output fields empty");
+      if (output == null || output.isEmpty()) {
+        if (input == null || input.isEmpty()) {
+          throw new IllegalStateException("You must specify an input field if you want to leave the output fields empty");
+        } else {
+          output = input;
+        }
       }
-      else {
-        output = input;
-      }
+      initialized = true;
     }
   }
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/ParserConfigurations.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/ParserConfigurations.java
@@ -39,6 +39,7 @@ public class ParserConfigurations extends Configurations {
   }
 
   public void updateSensorParserConfig(String sensorType, SensorParserConfig sensorParserConfig) {
+    sensorParserConfig.init();
     configurations.put(getKey(sensorType), sensorParserConfig);
   }
 


### PR DESCRIPTION
This results in a NPE if you do not specify an output column (this output column gets inferred as part of init())

To validate this:
* Get a running instance of metron
* Run `/usr/metron/0.2.0BETA/bin/zk_load_configs.sh -m PUSH -i /usr/metron/0.2.0BETA/config/zookeeper -z node1:2181`
* Wait a full 2 minutes
* Check the `parser_error` topic via the kafka console consumer and ensure you don't see any weird NPEs

The problem here is that init() is not getting run on the sensor parser config, so some syntactic sugar in the FieldTransformer isn't getting updated.  Specifically, if you only specify `input` and not `output`, then it will NPE.