### PR TITLE
METRON-254 pcap inspector emits fields that are named based on the enum, rather than the standardized field names

### DIFF
--- a/metron-platform/metron-pcap-backend/src/main/java/org/apache/metron/utils/PcapInspector.java
+++ b/metron-platform/metron-pcap-backend/src/main/java/org/apache/metron/utils/PcapInspector.java
@@ -149,7 +149,7 @@ public class PcapInspector {
         }};
         for(Constants.Fields field : Constants.Fields.values()) {
           if(result.containsKey(field)) {
-            fieldResults.add(field + ": " + result.get(field));
+            fieldResults.add(field.getName() + ": " + result.get(field));
           }
         }
         System.out.println(Joiner.on(",").join(fieldResults));


### PR DESCRIPTION
PcapInspector utility prints field names that are enum names (i.e. SRC_ADDR) as opposed to the standard field names (ip_src_addr)

Check this by running some pcap data through (follow steps 1-7 from https://github.com/apache/incubator-metron/pull/156)