### PR TITLE
METRON-255: Expose the IPProtocolTransformer as a function in the Stellar transformation language

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/TransformationFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/TransformationFunctions.java
@@ -22,6 +22,7 @@ import org.apache.metron.common.dsl.functions.DateFunctions;
 import org.apache.metron.common.dsl.functions.MapFunctions;
 import org.apache.metron.common.dsl.functions.NetworkFunctions;
 import org.apache.metron.common.dsl.functions.StringFunctions;
+import org.apache.metron.common.field.transformation.IPProtocolTransformation;
 import org.apache.metron.common.utils.ConversionUtils;
 
 import java.util.List;
@@ -48,6 +49,7 @@ public enum TransformationFunctions implements Function<List<Object>, Object> {
   ,URL_TO_PATH(new NetworkFunctions.URLToPath())
   ,URL_TO_PROTOCOL(new NetworkFunctions.URLToProtocol())
   ,TO_EPOCH_TIMESTAMP(new DateFunctions.ToTimestamp())
+  ,PROTOCOL_TO_NAME(new IPProtocolTransformation())
   ;
   Function<List<Object>, Object> func;
   TransformationFunctions(Function<List<Object>, Object> func) {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/transformation/IPProtocolTransformation.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/transformation/IPProtocolTransformation.java
@@ -19,10 +19,15 @@
 package org.apache.metron.common.field.transformation;
 
 
-import java.util.HashMap;
-import java.util.Map;
+import org.apache.hadoop.yarn.util.ConverterUtils;
+import org.apache.metron.common.utils.ConversionUtils;
 
-public class IPProtocolTransformation extends SimpleFieldTransformation {
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public class IPProtocolTransformation extends SimpleFieldTransformation implements Function<List<Object>, Object> {
 
   private final static Map<Integer, String> PROTOCOLS = new HashMap<>();
 
@@ -172,6 +177,24 @@ public class IPProtocolTransformation extends SimpleFieldTransformation {
     if(value != null && value instanceof Number) {
       int protocolNum = ((Number)value).intValue();
       ret.put(outputField, PROTOCOLS.get(protocolNum));
+    }
+    return ret;
+  }
+
+
+  @Override
+  public Object apply(List<Object> objects) {
+    Object keyObj = objects.get(0);
+    if(keyObj == null) {
+      return keyObj;
+    }
+    Integer key = ConversionUtils.convert(keyObj, Integer.class);
+    if(key == null ) {
+      return keyObj;
+    }
+    Object ret = PROTOCOLS.get(key);
+    if(ret == null ) {
+      return keyObj;
     }
     return ret;
   }

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/transformation/TransformationTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/transformation/TransformationTest.java
@@ -105,6 +105,14 @@ public class TransformationTest {
   }
 
   @Test
+  public void testProtocolToName() {
+    String query = "PROTOCOL_TO_NAME(protocol)";
+    Assert.assertEquals("TCP", run(query, ImmutableMap.of("protocol", "6")));
+    Assert.assertEquals("TCP", run(query, ImmutableMap.of("protocol", 6)));
+    Assert.assertEquals(null, run(query, ImmutableMap.of("foo", 6)));
+    Assert.assertEquals("chicken", run(query, ImmutableMap.of("protocol", "chicken")));
+  }
+  @Test
   public void testDateConversion() {
     long expected =1452013350000L;
     {


### PR DESCRIPTION
We have a TransformationFunction to map IANA protocol numbers to normalized strings. This should be exposed in the query language.
