### PR TITLE
METRON-256: Make the PCap values returned ordered by timestamp

### DIFF
--- a/metron-platform/metron-pcap-backend/src/test/java/org/apache/metron/pcap/integration/PcapTopologyIntegrationTest.java
+++ b/metron-platform/metron-pcap-backend/src/test/java/org/apache/metron/pcap/integration/PcapTopologyIntegrationTest.java
@@ -281,6 +281,7 @@ public class PcapTopologyIntegrationTest {
                         , FileSystem.get(new Configuration())
                         , new FixedPcapFilter.Configurator()
                 );
+        assertInOrder(results);
         Assert.assertEquals(results.size(), 2);
       }
       {
@@ -296,6 +297,7 @@ public class PcapTopologyIntegrationTest {
                         , FileSystem.get(new Configuration())
                         , new QueryPcapFilter.Configurator()
                 );
+        assertInOrder(results);
         Assert.assertEquals(results.size(), 2);
       }
       {
@@ -312,6 +314,7 @@ public class PcapTopologyIntegrationTest {
                         , FileSystem.get(new Configuration())
                         , new FixedPcapFilter.Configurator()
                 );
+        assertInOrder(results);
         Assert.assertEquals(results.size(), 0);
       }
       {
@@ -327,6 +330,7 @@ public class PcapTopologyIntegrationTest {
                         , FileSystem.get(new Configuration())
                         , new QueryPcapFilter.Configurator()
                 );
+        assertInOrder(results);
         Assert.assertEquals(results.size(), 0);
       }
       {
@@ -343,6 +347,7 @@ public class PcapTopologyIntegrationTest {
                         , FileSystem.get(new Configuration())
                         , new FixedPcapFilter.Configurator()
                 );
+        assertInOrder(results);
         Assert.assertEquals(results.size(), 0);
       }
       {
@@ -358,6 +363,7 @@ public class PcapTopologyIntegrationTest {
                         , FileSystem.get(new Configuration())
                         , new QueryPcapFilter.Configurator()
                 );
+        assertInOrder(results);
         Assert.assertEquals(results.size(), 0);
       }
       {
@@ -372,6 +378,7 @@ public class PcapTopologyIntegrationTest {
                         , FileSystem.get(new Configuration())
                         , new FixedPcapFilter.Configurator()
                 );
+        assertInOrder(results);
         Assert.assertEquals(results.size(), pcapEntries.size());
       }
       {
@@ -387,6 +394,7 @@ public class PcapTopologyIntegrationTest {
                         , FileSystem.get(new Configuration())
                         , new QueryPcapFilter.Configurator()
                 );
+        assertInOrder(results);
         Assert.assertEquals(results.size(), pcapEntries.size());
       }
       {
@@ -402,6 +410,7 @@ public class PcapTopologyIntegrationTest {
                         , FileSystem.get(new Configuration())
                         , new FixedPcapFilter.Configurator()
                 );
+        assertInOrder(results);
         Assert.assertTrue(results.size() > 0);
         Assert.assertEquals(results.size()
                 , Iterables.size(filterPcaps(pcapEntries, new Predicate<JSONObject>() {
@@ -429,6 +438,7 @@ public class PcapTopologyIntegrationTest {
                         , FileSystem.get(new Configuration())
                         , new QueryPcapFilter.Configurator()
                 );
+        assertInOrder(results);
         Assert.assertTrue(results.size() > 0);
         Assert.assertEquals(results.size()
                 , Iterables.size(filterPcaps(pcapEntries, new Predicate<JSONObject>() {
@@ -440,6 +450,7 @@ public class PcapTopologyIntegrationTest {
                 }, withHeaders)
                 )
         );
+        assertInOrder(results);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PcapMerger.merge(baos, results);
         Assert.assertTrue(baos.toByteArray().length > 0);
@@ -449,6 +460,18 @@ public class PcapTopologyIntegrationTest {
       runner.stop();
       clearOutDir(outDir);
       clearOutDir(queryDir);
+    }
+  }
+
+  public static void assertInOrder(Iterable<byte[]> packets) {
+    long previous = 0;
+    for(byte[] packet : packets) {
+      for(JSONObject json : TO_JSONS.apply(packet)) {
+        Long current = Long.parseLong(json.get("ts_micro").toString());
+        Assert.assertNotNull(current);
+        Assert.assertTrue(Long.compareUnsigned(current, previous) >= 0);
+        previous = current;
+      }
     }
   }
 

--- a/metron-platform/metron-pcap/src/main/java/org/apache/metron/pcap/mr/PcapJob.java
+++ b/metron-platform/metron-pcap/src/main/java/org/apache/metron/pcap/mr/PcapJob.java
@@ -224,6 +224,7 @@ public class PcapJob {
     job.setMapperClass(PcapJob.PcapMapper.class);
     job.setMapOutputKeyClass(LongWritable.class);
     job.setMapOutputValueClass(BytesWritable.class);
+    job.setNumReduceTasks(1);
     job.setReducerClass(PcapReducer.class);
     job.setOutputKeyClass(LongWritable.class);
     job.setOutputValueClass(BytesWritable.class);


### PR DESCRIPTION
Right now we are not specifying the partitioner for the MR job to filter PCaps as part of PCap retrieval, so we are getting back packets in the wrong order.