### PR TITLE
METRON-243 Ensure templates are installed on all search hosts

### DIFF
--- a/metron-deployment/roles/metron_elasticsearch_templates/tasks/load_templates.yml
+++ b/metron-deployment/roles/metron_elasticsearch_templates/tasks/load_templates.yml
@@ -20,14 +20,14 @@
 
 - name : Wait for Elasticsearch Host to Start
   wait_for:
-    host: "{{ groups.search[0] }}"
+    host: "{{ inventory_hostname }}"
     port: "{{ elasticsearch_web_port }}"
     delay: 10
     timeout: 300
 
 - name: Wait for Index to Become Available
   uri:
-    url: "http://{{ groups.search[0] }}:{{ elasticsearch_web_port }}/_cat/health"
+    url: "http://{{ inventory_hostname }}:{{ elasticsearch_web_port }}/_cat/health"
     method: GET
     status_code: 200
     return_content: yes
@@ -38,7 +38,7 @@
 
 - name: Add Elasticsearch templates for topologies
   uri:
-    url: "http://{{ groups.search[0] }}:{{ elasticsearch_web_port }}/_template/{{ item | basename | replace('.template','') }}"
+    url: "http://{{ inventory_hostname }}:{{ elasticsearch_web_port }}/_template/{{ item | basename | replace('.template','') }}"
     method: PUT
     body: "{{ lookup('file',item) }}"
     status_code: 200
@@ -46,7 +46,7 @@
 
 - name: Validate Elasticsearch templates
   uri:
-    url: "http://{{ groups.search[0] }}:{{ elasticsearch_web_port }}/_template/{{ item | basename | replace('.template','') }}"
+    url: "http://{{ inventory_hostname }}:{{ elasticsearch_web_port }}/_template/{{ item | basename | replace('.template','') }}"
     method: HEAD
     body: "{{ lookup('file',item) }}"
     status_code: 200

--- a/metron-deployment/roles/metron_elasticsearch_templates/tasks/main.yml
+++ b/metron-deployment/roles/metron_elasticsearch_templates/tasks/main.yml
@@ -16,4 +16,3 @@
 #
 ---
 - include: load_templates.yml
-  run_once: true


### PR DESCRIPTION
### [METRON-243](https://issues.apache.org/jira/browse/METRON-243)

I have a working theory on this one.  I will need some additional testing, but I wanted to get some eyeballs on this to validate my thought process.  I would love it if others were to run this through full AWS deployments and report their results.

#### Problem
Kibana reports this error in the web interface when accessing the Metron Dashboard.  THis does not occur on Vagrant deployments.  This occurs sometimes on AWS deployments.
```
[unsupported_operation_exception] custom format isn't supported
```

#### Root Cause
The dashboard expects certain data types for the Snort, Bro, and YAF indices. If the indices were created WITHOUT the index template definitions, the dashboard will throw this error.

In some cases, the index templates that appear to be properly installed during deployment, are later dropped when Elasticsearch is restarted by Monit. This causes Kibana to report this error. Now what might cause the index templates to go missing?  Here are the steps that can cause this to occur.

* The 'elasticsearch' role installs Elasticsearch on each node in the 'search' host group. After installation, Elasticsearch is not yet started.
* In the next step, the 'metron_elasticsearch_templates' role uses Ansible's 'run_once' functionality. The effect of using 'run_once' is that Ansible chooses a single node in the 'search' host group; let's call this host ES1. 
* Only on ES1, Elasticsearch is started, the index templates are installed, and then the index templates are validated. We effectively have a single node Elasticsearch cluster at this point.
* After all components have been installed, the 'monit-start' role ensures that all services are stopped across the cluster. At this point the single-node Elasticsearch cluster, which was left running, is shutdown. 
* The 'monit-start' role then determines which services need started and starts them. At this point all of the Elasticsearch nodes are started which creates a multi-node Elasticsearch cluster.
* Here is the sticky wicket...
  * If ES1 is elected master, then the index template that was previously configured is propagated to the other nodes in the cluster.
  * If ES1 is not elected master, then the index template is forgotten as the master knows nothing about them.

This explains why it occurs sometimes, but not all the time for AWS deployments.
This would also explain why the problem never occurs on Vagrant deployments.

#### Fix
This PR ensures that ALL Elasticsearch nodes are started when the index templates are configured.  A side effect is that the index templates are installed multiple times, once per host in the cluster.  This does not cause a problem necessarily, but is duplicative.

