### PR TITLE
METRON-259 Using 'any' for Snort's HOME_NETWORK

### DIFF
--- a/metron-deployment/roles/snort/defaults/main.yml
+++ b/metron-deployment/roles/snort/defaults/main.yml
@@ -23,4 +23,4 @@ snort_src_url: "https://snort.org/downloads/archive/snort/snort-{{ snort_version
 snort_community_rules_url: "https://www.snort.org/downloads/community/community-rules.tar.gz"
 dag_src_url: "https://snort.org/downloads/snort/daq-{{ daq_version }}.src.rpm"
 sniff_interface: eth0
-snort_home_net: "{{ hostvars[inventory_hostname]['ansible_' + sniff_interface]['ipv4']['address'] }}"
+snort_home_net: any


### PR DESCRIPTION
In some cases, Ansible is not yet aware of the 'tap0' interface when the Snort deployment begins.  This causes the deployment to fail with this error.

```
ERROR! ERROR! 'dict object' has no attribute u'ansible_tap0
```

It is not really necessary to set the HOME_NETWORK of Snort to the IP address of the sniff interface.  This needs to be customized for Snort on a case-by-case basis for production deployments based on the target environment.  For demo and development purposes, `any` works just fine and is much simpler.
