### PR TITLE
METRON-264: Create Docker container to simplify management of deploy dependencies	

### DIFF
--- a/metron-deployment/contrib/ansible-docker/Dockerfile
+++ b/metron-deployment/contrib/ansible-docker/Dockerfile
@@ -46,7 +46,4 @@ RUN tar xzvf apache-maven-3.2.5-bin.tar.gz
 RUN mv apache-maven-3.2.5 /opt/maven
 RUN ln -s /opt/maven/bin/mvn /usr/bin/mvn
 WORKDIR /root
-RUN git clone https://github.com/apache/incubator-metron
-WORKDIR /root/incubator-metron/metron-platform
-RUN mvn clean package -DskipTests
-WORKDIR /root/incubator-metron/metron-deployment
+

--- a/metron-deployment/contrib/ansible-docker/Dockerfile
+++ b/metron-deployment/contrib/ansible-docker/Dockerfile
@@ -1,0 +1,52 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+FROM centos:6.6
+MAINTAINER Apache Metron
+
+RUN yum install -y tar
+RUN yum install -y wget
+RUN yum groupinstall -y "Development tools"
+RUN yum install -y zlib-dev openssl-devel sqlite-devel bzip2-devel libffi-devel
+RUN wget https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz -O /usr/src/Python-2.7.10.tgz
+WORKDIR /usr/src
+RUN tar xvf Python-2.7.10.tgz
+WORKDIR /usr/src/Python-2.7.10
+RUN ./configure
+RUN make altinstall
+WORKDIR /usr/src
+RUN wget --no-check-certificate https://pypi.python.org/packages/source/s/setuptools/setuptools-11.3.tar.gz -O /usr/src/setuptools-11.3.tar.gz
+RUN tar xvf setuptools-11.3.tar.gz
+WORKDIR /usr/src/setuptools-11.3
+RUN python2.7 setup.py install
+RUN easy_install-2.7 pip
+RUN pip2.7 install ansible==2.0.0.2
+RUN pip2.7 install boto
+COPY ansible.cfg /root
+ENV ANSIBLE_CONFIG /root/ansible.cfg
+RUN yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel
+RUN yum install -y which
+RUN yum install -y nss
+WORKDIR /usr/src
+RUN wget http://apache.cs.utah.edu/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz
+RUN tar xzvf apache-maven-3.2.5-bin.tar.gz
+RUN mv apache-maven-3.2.5 /opt/maven
+RUN ln -s /opt/maven/bin/mvn /usr/bin/mvn
+WORKDIR /root
+RUN git clone https://github.com/apache/incubator-metron
+WORKDIR /root/incubator-metron/metron-platform
+RUN mvn clean package -DskipTests
+WORKDIR /root/incubator-metron/metron-deployment

--- a/metron-deployment/contrib/ansible-docker/README.md
+++ b/metron-deployment/contrib/ansible-docker/README.md
@@ -1,0 +1,17 @@
+# Overview
+The Metron ansible-docker container is provided in an effort reduce the installation burden of deploying Metron in a live envirionment.
+It is provisioned with software required to sucessfully run the deployment scripts.
+
+## Building the Container
+1. Install Docker [https://www.docker.com/products/overview]
+2. Navigate to <project-directory>/metron-deployment/contrib/ansible-docker
+3. Build the container `docker build -t ansible-docker:2.0.0.2 .`
+
+## Using the Container
+Full instruction are found on the wiki [https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=65144361].
+
+tl;dr
+
+1. docker run -it -v <project-directory>:/root/incubator-metron ansible-docker:2.0.0.2 bash
+2. cd /root/incubator-metron
+3. mvn clean package -DskipTests

--- a/metron-deployment/contrib/ansible-docker/ansible.cfg
+++ b/metron-deployment/contrib/ansible-docker/ansible.cfg
@@ -1,0 +1,28 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+[defaults]
+host_key_checking = False
+library = ../extra_modules
+roles_path = ../roles
+pipelining = True
+remote_user = centos
+forks = 20
+log_path = ./ansible.log
+
+# fix for "ssh throws 'unix domain socket too long' " problem
+[ssh_connection]
+control_path = ~/.ssh/ansible-ssh-%%h-%%r


### PR DESCRIPTION
Provides a Docker container for running deployment.

Tested with EC2 and on bare metal.