### PR TITLE
METRON-117 Deployment Report Created for All Deployments

### DIFF
--- a/metron-deployment/amazon-ec2/playbook.yml
+++ b/metron-deployment/amazon-ec2/playbook.yml
@@ -62,19 +62,9 @@
     - include: tasks/check-volume.yml vol_name=xvda vol_src=/dev/xvda vol_size={{ xvda_vol_size }}
   tags:
     - ec2
+    - mount
 
 #
 # build the metron cluster
 #
 - include: ../playbooks/metron_full_install.yml
-
-#
-# provisioning report
-#
-- hosts: localhost
-  vars_files:
-    - conf/defaults.yml
-  tasks:
-    - include: tasks/provisioning-report.yml
-  tags:
-    - ec2

--- a/metron-deployment/playbooks/metron_install.yml
+++ b/metron-deployment/playbooks/metron_install.yml
@@ -125,33 +125,32 @@
 - hosts: sensors
   become: true
   roles:
-    - { role: ambari_gather_facts, tags: [ 'always'] }
-    - { role: tap_interface, tags: ['tap'] }
-    - { role: pycapa, tags: ['pycapa'] }
-    - { role: bro, tags: ['bro'] }
-    - { role: flume,  tags: ['snort','flume'] }
-    - { role: snort, tags: ['snort'] }
-    - { role: yaf, tags: ['yaf'] }
-    - { role: pcap_replay, tags: ['pcap-replay'] }
-    - { role: sensor-test-mode, tags: ['sensor-test-mode'] }
+    - { role: ambari_gather_facts,    tags: ['always'] }
+    - { role: tap_interface,          tags: ['tap'] }
+    - { role: pycapa,                 tags: ['pycapa'] }
+    - { role: bro,                    tags: ['bro'] }
+    - { role: flume,                  tags: ['snort','flume'] }
+    - { role: snort,                  tags: ['snort'] }
+    - { role: yaf,                    tags: ['yaf'] }
+    - { role: pcap_replay,            tags: ['pcap-replay'] }
+    - { role: sensor-test-mode,       tags: ['sensor-test-mode'] }
   tags:
     - sensors
 
 #
-# monit
+# monitor and start metron services with monit
 #
 - hosts: metron
   become: true
   roles:
-    - role: ambari_gather_facts
-    - role: monit
-  tags:
-    - monit
+    - { role: ambari_gather_facts,    tags: ['always'] }
+    - { role: monit,                  tags: ['monit'] }
+    - { role: monit-start,            tags: ['start'] }
 
+#
+# deployment report
+#
 - hosts: metron
-  become: true
+  become: false
   roles:
-    - role: ambari_gather_facts
-    - role: monit-start
-  tags:
-    - start
+    - { role: deployment-report,      tags: ['report'] }

--- a/metron-deployment/roles/deployment-report/defaults/main.yml
+++ b/metron-deployment/roles/deployment-report/defaults/main.yml
@@ -1,0 +1,18 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+---
+timeout_secs: 120

--- a/metron-deployment/roles/deployment-report/meta/main.yml
+++ b/metron-deployment/roles/deployment-report/meta/main.yml
@@ -1,0 +1,19 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+---
+dependencies:
+  - ambari_gather_facts

--- a/metron-deployment/roles/deployment-report/tasks/main.yml
+++ b/metron-deployment/roles/deployment-report/tasks/main.yml
@@ -15,14 +15,14 @@
 #  limitations under the License.
 #
 ---
-- name: Known hosts groups
-  debug: var=groups
-
 - name: Sanity check Metron web
-  local_action: wait_for host="{{ groups.web[0] }}" port=5000 timeout=20
+  local_action: wait_for host="{{ groups.web[0] }}" port=5000 timeout="{{ timeout_secs }}"
 
 - name: Sanity check Ambari web
-  local_action: wait_for host="{{ groups.ambari_master[0] }}" port="{{ ambari_port }}" timeout=20
+  local_action: wait_for host="{{ groups.ambari_master[0] }}" port="{{ ambari_port }}" timeout="{{ timeout_secs }}"
+
+- name: Known hosts groups
+  debug: var=groups
 
 - set_fact:
     Success:
@@ -31,6 +31,8 @@
       - "   Ambari          @ http://{{ groups.ambari_master[0] }}:{{ ambari_port }}"
       - "   Sensor Status   @ http://{{ groups.sensors[0] }}:2812"
       - "   Topology Status @ http://{{ groups.enrichment[0] }}:2812"
+      - "   Zookeeper       @ {{ zookeeper_url }}"
+      - "   Kafka           @ {{ kafka_broker_url }}"
       - For additional information, see https://metron.incubator.apache.org/'
 
 - debug: var=Success


### PR DESCRIPTION
### [METRON-117](https://issues.apache.org/jira/browse/METRON-117)

* The deployment report was only produced for AWS-based deployments.  Now all deployments, including Vagrant and Bare Metal, will produce the same deployment report. 
* Enhanced the report to show the Zookeeper and Kafka URLs.
* Example of report produced for Vagrant based deployment.
    ```
    TASK [deployment-report : Sanity check Metron web] *****************************
    ok: [node1 -> localhost]

    TASK [deployment-report : Sanity check Ambari web] *****************************
    ok: [node1 -> localhost]

    TASK [deployment-report : Known hosts groups] **********************************
    ok: [node1] => {
        "groups": {
            "all": [
                "localhost",
                "node1"
            ],
            "ambari_master": [
                "node1"
            ],
            "ambari_slave": [
                "node1"
            ],
            "enrichment": [
                "node1"
            ],
            "metron": [
                "node1"
            ],
            "metron_hbase_tables": [
                "node1"
            ],
            "metron_kafka_topics": [
                "node1"
            ],
            "mysql": [
                "node1"
            ],
            "pcap_server": [
                "node1"
            ],
            "search": [
                "node1"
            ],
            "sensors": [
                "node1"
            ],
            "ungrouped": [
                "localhost"
            ],
            "web": [
                "node1"
            ]
        }
    }

    TASK [deployment-report : set_fact] ********************************************
    ok: [node1]

    TASK [deployment-report : debug] ***********************************************
    ok: [node1] => {
        "Success": [
            "Apache Metron deployed successfully",
            "   Metron          @ http://node1:5000",
            "   Ambari          @ http://node1:8080",
            "   Sensor Status   @ http://node1:2812",
            "   Topology Status @ http://node1:2812",
            "   Zookeeper       @ node1:2181",
            "   Kafka           @ node1:6667",
            "For additional information, see https://metron.incubator.apache.org/'"
        ]
    }
    ```
