### PR TITLE
METRON-281 Simplify deployment to alternative AWS region

### DIFF
--- a/metron-deployment/amazon-ec2/conf/defaults.yml
+++ b/metron-deployment/amazon-ec2/conf/defaults.yml
@@ -31,16 +31,30 @@ services_to_start:
   - snort-parser
   - enrichment
 
+# the ami for cent6 by region
+amis_by_region:
+  us-east-1:        ami-1c221e76    # US East (N. Virginia)
+  us-west-2:        ami-05cf2265    # US West (Oregon)
+  us-west-1:        ami-ac5f2fcc    # US West (N. California)
+  eu-central-1:     ami-2bf11444    # EU (Frankfurt)
+  eu-west-1:        ami-edb9069e    # EU (Ireland)
+  ap-south-1:       ami-9b1c76f4    # Asia Pacific (Mumbai)
+  ap-southeast-1:   ami-106aa373    # Asia Pacific (Singapore)
+  ap-southeast-2:   ami-87d2f4e4    # Asia Pacific (Sydney)
+  ap-northeast-1:   ami-fa3d3f94    # Asia Pacific (Tokyo)
+  ap-northeast-2:   ami-56478938    # Asia Pacific (Seoul)
+  sa-east-1:        ami-03b93b6f    # South America (Sao Paulo)
+
 # ec2
 env: metron-test
 region: us-west-2
 instance_type: m4.xlarge
-image: ami-05cf2265
 volume_type: standard
 key_name: metron-key
 xvda_vol_size: 50
 xvdb_vol_size: 100
 xvdc_vol_size: 100
+image: "{{ amis_by_region[region] }}"
 
 # ambari
 ambari_host: "{{ groups.ambari_master[0] }}"


### PR DESCRIPTION
[METRON-281](https://issues.apache.org/jira/browse/METRON-281)

To use an alternative AWS region, the user has to manually define the new AWS region along with lookup and redefine the Centos 6 AMI identifier that applies for their chosen region. The AMI identifiers can be difficult to find as they are not on the primary page for the CentOS 6 image.

This was simplified so that a user only has to specify the region they wish to deploy Metron to. The user no longer has to lookup and redefine the AMI identifier.  At the same time, the user can choose to override the `image` setting to override and use a specific AMI identifier, if desired.