### PR TITLE
METRON-225 Amazon-ec2 run script continues running on Maven build error

### DIFF
--- a/metron-deployment/amazon-ec2/run.sh
+++ b/metron-deployment/amazon-ec2/run.sh
@@ -61,6 +61,7 @@ $DEPLOYDIR/../scripts/platform-info.sh >> $LOGFILE
 # build metron
 cd ../..
 mvn package -DskipTests
+RC=$?; if [[ $RC != 0 ]]; then exit $RC; fi
 
 # deploy metron
 cd $DEPLOYDIR


### PR DESCRIPTION
[METRON-225](https://issues.apache.org/jira/browse/METRON-225)

The AWS deployment will now correctly fail, if the Maven build fails.