### PR TITLE
METRON-284: SensorParserConfig object cannot be serialized with the default Jackson ObjectMapper	

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/FieldTransformer.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/FieldTransformer.java
@@ -77,6 +77,10 @@ public class FieldTransformer implements Serializable {
     return transformationName;
   }
 
+  public FieldTransformation getFieldTransformation() {
+    return transformation;
+  }
+
   public void setTransformation(String transformation) {
     this.transformationName = transformation;
     this.transformation = FieldTransformations.get(transformation);

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/FieldTransformer.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/FieldTransformer.java
@@ -18,6 +18,7 @@
 
 package org.apache.metron.common.configuration;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
 import org.apache.metron.common.field.transformation.FieldTransformation;
 import org.apache.metron.common.field.transformation.FieldTransformations;
@@ -77,6 +78,7 @@ public class FieldTransformer implements Serializable {
     return transformationName;
   }
 
+  @JsonIgnore
   public FieldTransformation getFieldTransformation() {
     return transformation;
   }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/FieldTransformer.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/FieldTransformer.java
@@ -33,6 +33,7 @@ public class FieldTransformer implements Serializable {
   private List<String> input = new ArrayList<>();
   private List<String> output;
   private FieldTransformation transformation;
+  private String transformationName;
   private Map<String, Object> config = new HashMap<>();
   private boolean initialized = false;
   public FieldTransformer() {
@@ -72,11 +73,12 @@ public class FieldTransformer implements Serializable {
     this.config = config;
   }
 
-  public FieldTransformation getTransformation() {
-    return transformation;
+  public String getTransformation() {
+    return transformationName;
   }
 
   public void setTransformation(String transformation) {
+    this.transformationName = transformation;
     this.transformation = FieldTransformations.get(transformation);
   }
 

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/SensorEnrichmentConfigTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/SensorEnrichmentConfigTest.java
@@ -20,10 +20,14 @@ package org.apache.metron.common.configuration;
 import junit.framework.Assert;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+import org.apache.commons.io.IOUtils;
 import org.apache.metron.TestConstants;
 import org.apache.metron.common.configuration.enrichment.SensorEnrichmentConfig;
 import org.junit.Test;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.util.Map;
 
@@ -37,5 +41,18 @@ public class SensorEnrichmentConfigTest {
     SensorEnrichmentConfig sensorEnrichmentConfig = SensorEnrichmentConfig.fromBytes(sensorConfigBytes);
     Assert.assertNotNull(sensorEnrichmentConfig);
     Assert.assertTrue(sensorEnrichmentConfig.toString() != null && sensorEnrichmentConfig.toString().length() > 0);
+  }
+
+  @Test
+  public void testSerDe() throws IOException {
+    for(File enrichmentConfig : new File(new File(TestConstants.ENRICHMENTS_CONFIGS_PATH), "enrichments").listFiles()) {
+      SensorEnrichmentConfig config = null;
+      try (BufferedReader br = new BufferedReader(new FileReader(enrichmentConfig))) {
+        String parserStr = IOUtils.toString(br);
+        config = SensorEnrichmentConfig.fromBytes(parserStr.getBytes());
+      }
+      SensorEnrichmentConfig config2 = SensorEnrichmentConfig.fromBytes(config.toJSON().getBytes());
+      Assert.assertEquals(config2, config);
+    }
   }
 }

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/SensorParserConfigTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/SensorParserConfigTest.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.common.configuration;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.metron.TestConstants;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.*;
+
+public class SensorParserConfigTest {
+
+  @Test
+  public void testSerDe() throws IOException {
+    for(File parserConfig : new File(new File(TestConstants.PARSER_CONFIGS_PATH), "parsers").listFiles()) {
+      SensorParserConfig config = null;
+      try (BufferedReader br = new BufferedReader(new FileReader(parserConfig))) {
+        String parserStr = IOUtils.toString(br);
+        config = SensorParserConfig.fromBytes(parserStr.getBytes());
+      }
+      SensorParserConfig config2 = SensorParserConfig.fromBytes(config.toJSON().getBytes());
+      Assert.assertEquals(config2, config);
+    }
+  }
+}

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/transformation/FieldTransformationTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/transformation/FieldTransformationTest.java
@@ -106,7 +106,7 @@ public class FieldTransformationTest {
   public void testValidSerde_simple() throws IOException {
     SensorParserConfig c = SensorParserConfig.fromBytes(Bytes.toBytes(config));
     Assert.assertEquals(1, c.getFieldTransformations().size());
-    Assert.assertEquals(IPProtocolTransformation.class, c.getFieldTransformations().get(0).getTransformation().getClass());
+    Assert.assertEquals(IPProtocolTransformation.class, c.getFieldTransformations().get(0).getFieldTransformation().getClass());
     Assert.assertEquals(ImmutableList.of("protocol"), c.getFieldTransformations().get(0).getInput());
   }
 


### PR DESCRIPTION
The SensorParserConfig object cannot be serialized without a custom Jackson ObjectMapper. Specifically, this is caused by the way the FieldTransformer is implemented. A call to SensorParserConfig.toJSON() will fail with this message if a transformer is configured:
No serializer found for class org.apache.metron.common.field.transformation.MTLTransformation and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) )
