### PR TITLE
METRON-314: Kibana Default Dashboard - Map Broken

### DIFF
--- a/metron-deployment/roles/kibana/defaults/main.yml
+++ b/metron-deployment/roles/kibana/defaults/main.yml
@@ -18,5 +18,5 @@ kibana_repo_url: http://packages.elastic.co/kibana/4.5/centos
 kibana_repo_key_url: http://packages.elastic.co/GPG-KEY-elasticsearch
 kibana_index_url: "http://{{ groups.search[0] }}:{{ elasticsearch_web_port }}/.kibana"
 kibana_index_def: "/tmp/kibana-index.json"
-kibana_version: 4.5.1
+kibana_version: 4.5.3
 nodesource_repo_setup: https://rpm.nodesource.com/setup_4.x

--- a/metron-deployment/roles/kibana/tasks/kibana.yml
+++ b/metron-deployment/roles/kibana/tasks/kibana.yml
@@ -17,7 +17,7 @@
 ---
 - name: Install Kibana
   yum:
-    name: kibana
+    name: "kibana-{{ kibana_version }}"
     state: installed
   register: result
   until: result.rc == 0


### PR DESCRIPTION
Changed kibana_version to 4.5.3 and version locked the Kibana install.

Tested on Vagrant install.