### PR TITLE
METRON-334 Travis cache Maven dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ jdk:
 script:
   - |
     mvn -q integration-test install
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Adding .m2 directory to caching, so that it is reused on subsequent builds.