### PR TITLE
Changed surefire version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
                     <!-- Separates the unit tests from the integration tests. -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18</version>
+                    <version>2.2</version>
                     <configuration>
                         <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
                         <argLine>-Xmx2048m</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
                         <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
                         <argLine>-Xmx2048m</argLine>
                         <skip>true</skip>
-                        <!-- Show 100% of the lines from the stack trace (doesn't work) -->
+                        <!-- Show 100% of the lines from the stack trace -->
                         <trimStackTrace>false</trimStackTrace>
                     </configuration>
                     <executions>


### PR DESCRIPTION
As it's on [surefire documentation](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html) the label <trimStackTrace> is available from 2.2 ahead. 

Update surefire fix the comment.