### PR TITLE
METRON-368 Simplify Profile Configuration with Sensible Defaults

### DIFF
--- a/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileSplitterBolt.java
+++ b/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileSplitterBolt.java
@@ -26,6 +26,7 @@ import backtype.storm.topology.OutputFieldsDeclarer;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Tuple;
 import backtype.storm.tuple.Values;
+import org.apache.commons.lang.StringUtils;
 import org.apache.metron.common.bolt.ConfiguredProfilerBolt;
 import org.apache.metron.common.configuration.profiler.ProfileConfig;
 import org.apache.metron.common.configuration.profiler.ProfilerConfig;
@@ -118,7 +119,7 @@ public class ProfileSplitterBolt extends ConfiguredProfilerBolt {
 
     // is this message needed by this profile?
     String onlyIf = profile.getOnlyif();
-    if (executor.execute(onlyIf, message, Boolean.class)) {
+    if (StringUtils.isBlank(onlyIf) || executor.execute(onlyIf, message, Boolean.class)) {
 
       // what is the name of the entity in this message?
       String entity = executor.execute(profile.getForeach(), message, String.class);

--- a/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileBuilderBoltTest.java
+++ b/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileBuilderBoltTest.java
@@ -75,7 +75,7 @@ public class ProfileBuilderBoltTest extends BaseBoltTest {
    * }
    */
   @Multiline
-  private String profile;
+  private String basicProfile;
 
   /**
    * {
@@ -103,6 +103,28 @@ public class ProfileBuilderBoltTest extends BaseBoltTest {
   @Multiline
   private String profileWithBadInit;
 
+  /**
+   * {
+   *   "profile": "test",
+   *   "foreach": "ip_src_addr",
+   *   "update": { "x": "2" },
+   *   "result": "x"
+   * }
+   */
+  @Multiline
+  private String profileWithNoInit;
+
+  /**
+   * {
+   *   "profile": "test",
+   *   "foreach": "ip_src_addr",
+   *   "init": { "x": "2" },
+   *   "result": "x"
+   * }
+   */
+  @Multiline
+  private String profileWithNoUpdate;
+
   private JSONObject message;
 
   public static Tuple mockTickTuple() {
@@ -116,8 +138,7 @@ public class ProfileBuilderBoltTest extends BaseBoltTest {
     return tuple;
   }
 
-  @Before
-  public void setup() throws Exception {
+  public void setup(String profile) throws Exception {
 
     // parse the input message
     JSONParser parser = new JSONParser();
@@ -152,8 +173,9 @@ public class ProfileBuilderBoltTest extends BaseBoltTest {
    * Ensure that the bolt can update a profile based on new messages that it receives.
    */
   @Test
-  public void testUpdateProfile() throws Exception {
+  public void testProfileUpdate() throws Exception {
 
+    setup(basicProfile);
     ProfileBuilderBolt bolt = createBolt();
     bolt.execute(tuple);
     bolt.execute(tuple);
@@ -164,12 +186,46 @@ public class ProfileBuilderBoltTest extends BaseBoltTest {
   }
 
   /**
+   * If the 'init' field is not defined, then the profile should
+   * behave as normal, but with no variable initialization.
+   */
+  @Test
+  public void testProfileWithNoInit() throws Exception {
+
+    setup(profileWithNoInit);
+    ProfileBuilderBolt bolt = createBolt();
+    bolt.execute(tuple);
+    bolt.execute(tuple);
+
+    // validate
+    assertEquals(2, bolt.getExecutor().getState().get("x"));
+  }
+
+  /**
+   * If the 'update' field is not defined, then no updates should occur as messages
+   * are received.
+   */
+  @Test
+  public void testProfileWithNoUpdate() throws Exception {
+
+    setup(profileWithNoUpdate);
+    ProfileBuilderBolt bolt = createBolt();
+    bolt.execute(tuple);
+    bolt.execute(tuple);
+    bolt.execute(tuple);
+
+    // validate
+    assertEquals(2, bolt.getExecutor().getState().get("x"));
+  }
+
+  /**
    * Ensure that the bolt can flush the profile when a tick tuple is received.
    */
   @Test
-  public void testFlushProfile() throws Exception {
+  public void testProfileFlush() throws Exception {
 
     // setup
+    setup(basicProfile);
     ProfileBuilderBolt bolt = createBolt();
     bolt.execute(tuple);
     bolt.execute(tuple);
@@ -200,8 +256,9 @@ public class ProfileBuilderBoltTest extends BaseBoltTest {
    * is received from the Splitter.
    */
   @Test
-  public void testFlushProfileWithNoMessages() throws Exception {
+  public void testProfileFlushWithNoMessages() throws Exception {
 
+    setup(basicProfile);
     ProfileBuilderBolt bolt = createBolt();
 
     // no messages have been received before a flush occurs
@@ -219,6 +276,7 @@ public class ProfileBuilderBoltTest extends BaseBoltTest {
   @Test
   public void testStateClearedAfterFlush() throws Exception {
 
+    setup(basicProfile);
     ProfileBuilderBolt bolt = createBolt();
     bolt.execute(tuple);
     bolt.execute(tuple);
@@ -236,8 +294,7 @@ public class ProfileBuilderBoltTest extends BaseBoltTest {
   public void testProfileWithBadUpdate() throws Exception {
 
     // setup - ensure the bad profile is used
-    ProfileConfig profileConfig = JSONUtils.INSTANCE.load(profileWithBadUpdate, ProfileConfig.class);
-    when(tuple.getValueByField(eq("profile"))).thenReturn(profileConfig);
+    setup(profileWithBadUpdate);
 
     // execute
     ProfileBuilderBolt bolt = createBolt();
@@ -255,8 +312,7 @@ public class ProfileBuilderBoltTest extends BaseBoltTest {
   public void testProfileWithBadInit() throws Exception {
 
     // setup - ensure the bad profile is used
-    ProfileConfig profileConfig = JSONUtils.INSTANCE.load(profileWithBadInit, ProfileConfig.class);
-    when(tuple.getValueByField(eq("profile"))).thenReturn(profileConfig);
+    setup(profileWithBadInit);
 
     // execute
     ProfileBuilderBolt bolt = createBolt();

--- a/metron-analytics/metron-profiler/src/test/resources/log4j.properties
+++ b/metron-analytics/metron-profiler/src/test/resources/log4j.properties
@@ -1,0 +1,28 @@
+#
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+# Root logger option
+log4j.rootLogger=ERROR, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/metron-platform/metron-hbase/src/test/java/org/apache/metron/hbase/client/HBaseClientTest.java
+++ b/metron-platform/metron-hbase/src/test/java/org/apache/metron/hbase/client/HBaseClientTest.java
@@ -22,24 +22,32 @@ package org.apache.metron.hbase.client;
 
 import backtype.storm.tuple.Tuple;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
-import org.apache.hadoop.hbase.client.*;
+import org.apache.hadoop.hbase.client.Durability;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.metron.hbase.TableProvider;
 import org.apache.metron.hbase.Widget;
 import org.apache.metron.hbase.WidgetMapper;
 import org.apache.storm.hbase.bolt.mapper.HBaseMapper;
 import org.apache.storm.hbase.bolt.mapper.HBaseProjectionCriteria;
 import org.apache.storm.hbase.common.ColumnList;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests the HBaseClient
@@ -51,18 +59,19 @@ public class HBaseClientTest {
   private static HBaseTestingUtility util;
   private HBaseClient client;
   private HTableInterface table;
-
   private Tuple tuple1;
   private Tuple tuple2;
-
   private Widget widget1;
   private Widget widget2;
-
   private HBaseMapper mapper;
 
   @BeforeClass
   public static void startHBase() throws Exception {
-    util = new HBaseTestingUtility();
+    Configuration config = HBaseConfiguration.create();
+    config.set("hbase.master.hostname", "localhost");
+    config.set("hbase.regionserver.hostname", "localhost");
+
+    util = new HBaseTestingUtility(config);
     util.startMiniCluster();
   }
 

--- a/metron-platform/metron-hbase/src/test/resources/log4j.properties
+++ b/metron-platform/metron-hbase/src/test/resources/log4j.properties
@@ -1,0 +1,28 @@
+#
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+# Root logger option
+log4j.rootLogger=ERROR, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
### [METRON-368](https://issues.apache.org/jira/browse/METRON-368)

Note: This change depends on #208 #212.  The diff will be easier to grok once those PRs have been merged.

### Changes
The user should not need to define every configuration field.  This will help simplify the configuration for many types of profiles.

* If the user does not define 'onlyif', then all messages should be included in a profile.  
* If the user does not define 'init' then no vars should be initialized.
* If the user does not define 'update' then no vars should be updated.

### Testing
* Create a profile with no 'onlyif' field.  All messages should be applied to the profile.  
* Create a profile with no 'init' field. The profiler should not error.
* Create a profile with no 'update' field.  The profiler should not error
