### PR TITLE
Metron-342 Fix permissions of {{ metron_directory }}/patterns directory

### DIFF
--- a/metron-deployment/roles/metron_streaming/tasks/grok_upload.yml
+++ b/metron-deployment/roles/metron_streaming/tasks/grok_upload.yml
@@ -25,6 +25,9 @@
   become: yes
   become_user: hdfs
 
+- name: Assign permissions of {{ metron_directory }}/patterns directory
+  file: path={{ metron_directory }}/patterns state=directory mode=0755
+  
 - name: Assign permissions of HDFS {{ metron_hdfs_output_dir }}/patterns directory
   command: hdfs dfs -chmod -R 775 {{ metron_hdfs_output_dir }}/patterns
   become: yes


### PR DESCRIPTION
This fix allow the `hdfs` user to access to grok patterns in `{{ metron_directory }}/patterns`.

This PR addresses https://issues.apache.org/jira/browse/METRON-342

Fix the following error during the installation:

```
TASK [metron_streaming : Upload Grok Patterns to hdfs:///apps/metron] **********
fatal: [node1]: FAILED! => {"changed": true, "cmd": ["hdfs", "dfs", "-put", "-f", "/usr/metron/0.2.0BETA/patterns", "/apps/metron"], "delta": "0:00:02.131558", "end": "2016-08-21 14:03:26.476524", "failed": true, "rc": 1, "start": "2016-08-21 14:03:24.344966", "stderr": "put: Error accessing file:/usr/metron/0.2.0BETA/patterns", "stdout": "", "stdout_lines": [], "warnings": []}

```
