### PR TITLE
METRON-386 Create Ambari Service Definition for Elasticsearch

### DIFF
--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-env.xml
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-env.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<configuration>
+  <property>
+    <name>elastic_user</name>
+    <value>elasticsearch</value>
+    <property-type>USER</property-type>
+    <description>The user for Elasticsearch</description>
+  </property>
+  <property>
+    <name>user_group</name>
+    <value>elasticsearch</value>
+    <description>The group for Elasticsearch</description>
+  </property>
+  <property>
+    <name>elastic_log_dir</name>
+    <value>/var/log/elasticsearch</value>
+    <description>Log directory for elastic</description>
+  </property>
+  <property>
+    <name>elastic_pid_dir</name>
+    <value>/var/run/elasticsearch</value>
+    <description>The directory for pid files</description>
+  </property>
+
+  <!-- elasticsearch-env.sh -->
+  <property>
+    <name>content</name>
+    <description>This is the jinja template for elastic-env.sh file</description>
+    <value>
+#!/bin/bash
+
+# Set ELASTICSEARCH specific environment variables here.
+
+# The java implementation to use.
+export JAVA_HOME={{java64_home}}
+export PATH=$PATH:$JAVA_HOME/bin
+    </value>
+  </property>
+</configuration>

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-site.xml
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-site.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Elastic search  Configurations -->
+
+<configuration supports_final="true">
+    <!-- Configurations -->
+    <property>
+        <name>cluster_name</name>
+        <value>metron</value>
+        <description>Cluster name identifies your cluster</description>
+    </property>
+    <property>
+        <name>zen_discovery_ping_unicast_hosts</name>
+        <!--Ideally this gets populated by the list of master eligible nodes (as an acceptable default).  Unsure how to do this.-->
+        <value></value>
+        <description>Unicast discovery list of hosts to act as gossip routers, in comma separated format.</description>
+    </property>
+    <property>
+        <name>index_number_of_shards</name>
+        <value>4</value>
+        <description>Set the number of shards (splits) of an index</description>
+    </property>
+    <property>
+        <name>index_number_of_replicas</name>
+        <value>2</value>
+        <description>Set the number of replicas (additional copies) of an index</description>
+    </property>
+    <!--  Logging Configurations -->
+    <property>
+        <name>path_data</name>
+        <value>"/opt/lmm/es_data"</value>
+        <description>Path to directory where to store index data allocated for this node. e.g. "/mnt/first", "/mnt/second"</description>
+    </property>    
+    <!--  Discovery -->
+    <property>
+        <name>transport_tcp_port</name>
+        <value>9300-9400</value>
+        <description>Set a custom port for the node to node communication</description>
+    </property>
+    <property>
+        <name>http_port</name>
+        <value>9200-9300</value>
+        <description>Set a custom port to listen for HTTP traffic</description>
+    </property>
+    <!--  Discovery -->
+    <property>
+        <name>discovery_zen_ping_multicast_enabled</name>
+        <value>false</value>
+        <description>master eligible nodes</description>
+    </property>
+    <property>
+        <name>discovery_zen_ping_timeout</name>
+        <value>3s</value>
+        <description>Wait for ping responses for master discovery</description>
+    </property>
+    <property>
+        <name>discovery_zen_fd_ping_interval</name>
+        <value>15s</value>
+        <description>Wait for ping for cluster discovery</description>
+    </property>
+    <property>
+        <name>discovery_zen_fd_ping_timeout</name>
+        <value>60s</value>
+        <description>Wait for ping for cluster discovery</description>
+    </property>
+    <property>
+        <name>discovery_zen_fd_ping_retries</name>
+        <value>5</value>
+        <description>Number of ping retries before blacklisting</description>
+    </property>
+    <!--  Gateway -->
+    <property>
+        <name>gateway_recover_after_data_nodes</name>
+        <value>3</value>
+        <description>Recover as long as this many data or master nodes have joined the cluster.</description>
+    </property>
+    <property>
+        <name>recover_after_time</name>
+        <value>15m</value>
+        <description>recover_after_time</description>
+    </property>
+    <property>
+        <name>expected_data_nodes</name>
+        <value>0</value>
+        <description>expected_data_nodes</description>
+    </property>
+    <!--  Index -->  
+    <property>
+        <name>index_merge_scheduler_max_thread_count</name>
+        <value>5</value>
+        <description>index.merge.scheduler.max_thread_count</description>
+    </property>
+    <property>
+        <name>indices_memory_index_store_throttle_type</name>
+        <value>none</value>
+        <description>index_store_throttle_type</description>
+    </property>
+    <property>
+        <name>index_refresh_interval</name>
+        <value>1s</value>
+        <description>index refresh interval</description>
+    </property>
+    <property>
+        <name>index_translog_flush_threshold_size</name>
+        <value>5g</value>
+        <description>index_translog_flush_threshold_size</description>
+    </property>
+    <property>
+        <name>indices_memory_index_buffer_size</name>
+        <value>10%</value>
+        <description>Percentage of heap used for write buffers</description>
+    </property>
+    <property>
+        <name>bootstrap_mlockall</name>
+        <value>true</value>
+        <description>The third option on Linux/Unix systems only, is to use mlockall to try to lock the process address space into RAM, preventing any Elasticsearch memory from being swapped out</description>
+    </property>
+    <property>
+        <name>threadpool_bulk_queue_size</name>
+        <value>3000</value>
+        <description>It tells ES the number of  requests that can be queued for execution in the node when there is no thread available to execute a bulk request</description>
+    </property>
+    <property>
+        <name>threadpool_index_queue_size</name>
+        <value>1000</value>
+        <description>It tells ES the number of  requests that can be queued for execution in the node when there is no thread available to execute index request</description>
+    </property>
+    <property>
+        <name>indices_cluster_send_refresh_mapping</name>
+        <value>false</value>
+        <description>In order to make the index request more efficient, we have set this property on our data nodes</description>
+    </property>
+    <property>
+        <name>indices_fielddata_cache_size</name>
+        <value>25%</value>
+        <description>You need to keep in mind that not setting this value properly can cause:Facet searches and sorting to have very poor performance:The ES node to run out of memory if you run the facet query against a large index</description>
+    </property>
+    <property>
+        <name>cluster_routing_allocation_disk_watermark_high</name>
+        <value>0.99</value>
+        <description>Property used when multiple drives are used to understand max thresholds</description>
+    </property>
+    <property>
+        <name>cluster_routing_allocation_disk_threshold_enabled</name>
+        <value>true</value>
+        <description>Property used when multiple drives are used to understand if thresholding is active</description>
+    </property>   
+   <property>
+        <name>cluster_routing_allocation_disk_watermark_low</name>
+        <value>.97</value>
+        <description>Property used when multiple drives are used to understand min thresholds</description>
+    </property>
+    <property>
+        <name>cluster_routing_allocation_node_concurrent_recoveries</name>
+        <value>4</value>
+        <description>Max concurrent recoveries, useful for fast recovery of the cluster nodes on restart</description>
+    </property>
+    <property>
+        <name>network_host</name>
+        <value>_lo_,_eth0_</value>
+        <description>Network interface(s) will bind to. </description>
+    </property>
+</configuration>

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-sysconfig.xml
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-sysconfig.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<configuration>
+    <property>
+        <name>elastic_home</name>
+        <value>/usr/share/elasticsearch/</value>
+        <description>Elasticsearch Home Directory</description>
+    </property>
+    <property>
+        <name>data_dir</name>
+        <value>/var/lib/elasticsearch/</value>
+        <description>Elasticsearch Data Directory</description>
+    </property>
+    <property>
+        <name>work_dir</name>
+        <value>/tmp/elasticsearch/</value>
+        <description>Elasticsearch Work Directory</description>
+    </property>
+    <property>
+        <name>conf_dir</name>
+        <value>/etc/elasticsearch/</value>
+        <description>Elasticsearch Configuration Directory</description>
+    </property>
+    <property>
+        <name>heap_size</name>
+        <value>128m</value>
+        <description>Heap size</description>
+    </property>
+    <property>
+        <name>max_open_files</name>
+        <value>65535</value>
+        <description>Maximum number of open files</description>
+    </property>
+    <property>
+        <name>max_map_count</name>
+        <value>262144</value>
+        <description>Maximum number of memory map areas for process</description>
+    </property>
+
+    <!--/etc/sysconfig/elasticsearch-->
+    <property>
+        <name>content</name>
+        <description>This is the jinja template for elastic-env.sh file</description>
+        <value>
+# Directory where the Elasticsearch binary distribution resides
+ES_HOME={{elastic_home}}
+
+# Heap Size (defaults to 256m min, 1g max)
+ES_HEAP_SIZE={{heap_size}}
+
+# Maximum number of open files
+MAX_OPEN_FILES={{max_open_files}}
+
+# Maximum number of VMA (Virtual Memory Areas) a process can own
+MAX_MAP_COUNT={{max_map_count}}
+
+# Elasticsearch log directory
+LOG_DIR={{log_dir}}
+
+# Elasticsearch data directory
+DATA_DIR={{data_dir}}
+
+# Elasticsearch work directory
+WORK_DIR={{work_dir}}
+
+# Elasticsearch conf directory
+CONF_DIR={{conf_dir}}
+
+# User to run as, change this to a specific elasticsearch user if possible
+# Also make sure, this user can write into the log directories in case you change them
+# This setting only works for the init script, but has to be configured separately for systemd startup
+ES_USER={{elastic_user}}
+
+# Additional Java OPTS
+ES_JAVA_OPTS="-verbose:gc -Xloggc:{{log_dir}}elasticsearch_gc.log -XX:-CMSConcurrentMTEnabled
+-XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCTimeStamps
+-XX:ErrorFile={{log_dir}}elasticsearch_err.log -XX:ParallelGCThreads=8"
+        </value>
+    </property>
+</configuration>

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/metainfo.xml
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/metainfo.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>ELASTICSEARCH</name>
+            <displayName>Elasticsearch</displayName>
+            <comment>Indexing and Search</comment>
+            <version>2.3.3</version>
+            <components>
+                <component>
+                    <name>ES_MASTER</name>
+                    <displayName>Elasticsearch Master-Eligible Node</displayName>
+                    <category>MASTER</category>
+                    <cardinality>1+</cardinality>
+                    <commandScript>
+                        <script>scripts/elastic_master.py</script>
+                        <scriptType>PYTHON</scriptType>
+                        <timeout>600</timeout>
+                    </commandScript>
+                </component>
+                <component>
+                    <name>ES_SLAVE</name>
+                    <displayName>Elasticsearch Data Node</displayName>
+                    <category>SLAVE</category>
+                    <cardinality>0+</cardinality>
+                    <commandScript>
+                        <script>scripts/elastic_slave.py</script>
+                        <scriptType>PYTHON</scriptType>
+                        <timeout>600</timeout>
+                    </commandScript>
+                </component>
+            </components>
+            <osSpecifics>
+                <osSpecific>
+                    <osFamily>any</osFamily>
+                    <packages>
+                        <package>
+                            <name>elasticsearch-2.3.3</name>
+                        </package>
+                    </packages>
+                </osSpecific>
+            </osSpecifics>
+            <commandScript>
+                <script>scripts/service_check.py</script>
+                <scriptType>PYTHON</scriptType>
+                <timeout>300</timeout>
+            </commandScript>
+            <configuration-dependencies>
+                <config-type>elastic-env</config-type>
+                <config-type>elastic-site</config-type>
+                <config-type>elastic-sysconfig</config-type>
+            </configuration-dependencies>
+            <restartRequiredAfterChange>true</restartRequiredAfterChange>
+        </service>
+    </services>
+</metainfo>

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic.py
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+from resource_management.core.resources.system import Directory
+from resource_management.core.resources.system import File
+from resource_management.core.source import InlineTemplate
+from resource_management.core.source import Template
+
+
+def elastic():
+    print "INSIDE THE %s" % __file__
+    import params
+
+    params.path_data = params.path_data.replace('"', '')
+    data_path = params.path_data.replace(' ', '').split(',')
+    data_path[:] = [x.replace('"', '') for x in data_path]
+
+    directories = [params.log_dir, params.pid_dir, params.conf_dir]
+    directories = directories + data_path
+
+    Directory(directories,
+              create_parents=True,
+              # recursive=True,
+              mode=0755,
+              owner=params.elastic_user,
+              group=params.elastic_user
+              )
+
+    print "Master env: ""{}/elastic-env.sh".format(params.conf_dir)
+    File("{}/elastic-env.sh".format(params.conf_dir),
+         owner=params.elastic_user,
+         content=InlineTemplate(params.elastic_env_sh_template)
+         )
+
+    configurations = params.config['configurations']['elastic-site']
+
+    print "Master yml: ""{}/elasticsearch.yml".format(params.conf_dir)
+    File("{}/elasticsearch.yml".format(params.conf_dir),
+         content=Template(
+             "elasticsearch.master.yaml.j2",
+             configurations=configurations),
+         owner=params.elastic_user,
+         group=params.elastic_user
+         )
+
+    print "Master sysconfig: /etc/sysconfig/elasticsearch"
+    File(format("/etc/sysconfig/elasticsearch"),
+         owner="root",
+         group="root",
+         content=InlineTemplate(params.sysconfig_template)
+         )

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic_master.py
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic_master.py
@@ -1,0 +1,79 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+from elastic import elastic
+from resource_management.core.resources.system import Execute
+from resource_management.libraries.script import Script
+
+
+class Elasticsearch(Script):
+    def install(self, env):
+        import params
+        env.set_params(params)
+
+        print 'Install the Master'
+        Execute('rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch')
+        Execute("echo \"[elasticsearch-2.x]\n"
+                "name=Elasticsearch repository for 2.x packages\n"
+                "baseurl=https://packages.elastic.co/elasticsearch/2.x/centos\n"
+                "gpgcheck=1\n"
+                "gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch\n"
+                "enabled=1\" > /etc/yum.repos.d/elasticsearch.repo")
+
+        self.install_packages(env)
+
+    def configure(self, env, upgrade_type=None, config_dir=None):
+        import params
+        env.set_params(params)
+
+        elastic()
+
+    def stop(self, env, upgrade_type=None):
+        import params
+        env.set_params(params)
+        stop_cmd = format("service elasticsearch stop")
+        print 'Stop the Master'
+        Execute(stop_cmd)
+
+    def start(self, env, upgrade_type=None):
+        import params
+        env.set_params(params)
+
+        self.configure(env)
+        start_cmd = format("service elasticsearch start")
+        print 'Start the Master'
+        Execute(start_cmd)
+
+    def status(self, env):
+        import params
+        env.set_params(params)
+        status_cmd = format("service elasticsearch status")
+        print 'Status of the Master'
+        Execute(status_cmd)
+
+    def restart(self, env):
+        import params
+        env.set_params(params)
+        self.configure(env)
+        restart_cmd = format("service elasticsearch restart")
+        print 'Restarting the Master'
+        Execute(restart_cmd)
+
+if __name__ == "__main__":
+    Elasticsearch().execute()

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic_slave.py
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic_slave.py
@@ -1,0 +1,76 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+from resource_management.libraries.script import Script
+from resource_management.core.resources.system import Execute
+from slave import slave
+
+
+class Elasticsearch(Script):
+    def install(self, env):
+        import params
+        env.set_params(params)
+        print 'Install the Slave'
+        Execute('rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch')
+        Execute("echo \"[elasticsearch-2.x]\n"
+                "name=Elasticsearch repository for 2.x packages\n"
+                "baseurl=https://packages.elastic.co/elasticsearch/2.x/centos\n"
+                "gpgcheck=1\n"
+                "gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch\n"
+                "enabled=1\" > /etc/yum.repos.d/elasticsearch.repo")
+        self.install_packages(env)
+
+    def configure(self, env, upgrade_type=None, config_dir=None):
+        import params
+        env.set_params(params)
+        slave()
+
+    def stop(self, env, upgrade_type=None):
+        import params
+        env.set_params(params)
+        stop_cmd = format("service elasticsearch stop")
+        print 'Stop the Slave'
+        Execute(stop_cmd)
+
+    def start(self, env, upgrade_type=None):
+        import params
+        env.set_params(params)
+        self.configure(env)
+        start_cmd = format("service elasticsearch start")
+        print 'Start the Slave'
+        Execute(start_cmd)
+
+    def status(self, env):
+        import params
+        env.set_params(params)
+        status_cmd = format("service elasticsearch status")
+        print 'Status of the Slave'
+        Execute(status_cmd)
+
+    def restart(self, env):
+        import params
+        env.set_params(params)
+        self.configure(env)
+        restart_cmd = format("service elasticsearch restart")
+        print 'Restarting the Slave'
+        Execute(restart_cmd)
+
+
+if __name__ == "__main__":
+    Elasticsearch().execute()

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/params.py
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/params.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+from resource_management.libraries.script import Script
+
+# server configurations
+config = Script.get_config()
+
+elastic_home = config['configurations']['elastic-sysconfig']['elastic_home']
+data_dir = config['configurations']['elastic-sysconfig']['data_dir']
+work_dir = config['configurations']['elastic-sysconfig']['work_dir']
+conf_dir = config['configurations']['elastic-sysconfig']['conf_dir']
+heap_size = config['configurations']['elastic-sysconfig']['heap_size']
+max_open_files = config['configurations']['elastic-sysconfig']['max_open_files']
+max_map_count = config['configurations']['elastic-sysconfig']['max_map_count']
+
+elastic_user = config['configurations']['elastic-env']['elastic_user']
+user_group = config['configurations']['elastic-env']['user_group']
+log_dir = config['configurations']['elastic-env']['elastic_log_dir']
+pid_dir = '/var/run/elasticsearch'
+pid_file = '/var/run/elasticsearch/elasticsearch.pid'
+hostname = config['hostname']
+java64_home = config['hostLevelParams']['java_home']
+elastic_env_sh_template = config['configurations']['elastic-env']['content']
+sysconfig_template = config['configurations']['elastic-sysconfig']['content']
+
+cluster_name = config['configurations']['elastic-site']['cluster_name']
+zen_discovery_ping_unicast_hosts = config['configurations']['elastic-site']['zen_discovery_ping_unicast_hosts']
+
+path_data = config['configurations']['elastic-site']['path_data']
+http_port = config['configurations']['elastic-site']['http_port']
+transport_tcp_port = config['configurations']['elastic-site']['transport_tcp_port']
+
+recover_after_time = config['configurations']['elastic-site']['recover_after_time']
+gateway_recover_after_data_nodes = config['configurations']['elastic-site']['gateway_recover_after_data_nodes']
+expected_data_nodes = config['configurations']['elastic-site']['expected_data_nodes']
+discovery_zen_ping_multicast_enabled = config['configurations']['elastic-site']['discovery_zen_ping_multicast_enabled']
+index_merge_scheduler_max_thread_count = config['configurations']['elastic-site']['index_merge_scheduler_max_thread_count']
+index_translog_flush_threshold_size = config['configurations']['elastic-site']['index_translog_flush_threshold_size']
+index_refresh_interval = config['configurations']['elastic-site']['index_refresh_interval']
+indices_memory_index_store_throttle_type = config['configurations']['elastic-site']['indices_memory_index_store_throttle_type']
+index_number_of_shards = config['configurations']['elastic-site']['index_number_of_shards']
+index_number_of_replicas = config['configurations']['elastic-site']['index_number_of_replicas']
+indices_memory_index_buffer_size = config['configurations']['elastic-site']['indices_memory_index_buffer_size']
+bootstrap_mlockall = config['configurations']['elastic-site']['bootstrap_mlockall']
+threadpool_bulk_queue_size = config['configurations']['elastic-site']['threadpool_bulk_queue_size']
+cluster_routing_allocation_node_concurrent_recoveries = config['configurations']['elastic-site']['cluster_routing_allocation_node_concurrent_recoveries']
+cluster_routing_allocation_disk_watermark_low = config['configurations']['elastic-site']['cluster_routing_allocation_disk_watermark_low']
+cluster_routing_allocation_disk_threshold_enabled = config['configurations']['elastic-site']['cluster_routing_allocation_disk_threshold_enabled']
+cluster_routing_allocation_disk_watermark_high = config['configurations']['elastic-site']['cluster_routing_allocation_disk_watermark_high']
+indices_fielddata_cache_size = config['configurations']['elastic-site']['indices_fielddata_cache_size']
+indices_cluster_send_refresh_mapping = config['configurations']['elastic-site']['indices_cluster_send_refresh_mapping']
+threadpool_index_queue_size = config['configurations']['elastic-site']['threadpool_index_queue_size']
+
+discovery_zen_ping_timeout = config['configurations']['elastic-site']['discovery_zen_ping_timeout']
+discovery_zen_fd_ping_interval = config['configurations']['elastic-site']['discovery_zen_fd_ping_interval']
+discovery_zen_fd_ping_timeout = config['configurations']['elastic-site']['discovery_zen_fd_ping_timeout']
+discovery_zen_fd_ping_retries = config['configurations']['elastic-site']['discovery_zen_fd_ping_retries']
+
+network_host = config['configurations']['elastic-site']['network_host']

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/properties_config.py
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/properties_config.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+from resource_management.core.resources.system import File
+from resource_management.core.source import InlineTemplate
+
+
+def properties_inline_template(configurations):
+    return InlineTemplate('''{% for key, value in configurations_dict.items() %}{{ key }}={{ value }}
+{% endfor %}''', configurations_dict=configurations)
+
+
+def properties_config(filename, configurations=None, conf_dir=None,
+                      mode=None, owner=None, group=None, brokerid=None):
+    config_content = properties_inline_template(configurations)
+    File(format("{conf_dir}/{filename}"), content=config_content, owner=owner,
+         group=group, mode=mode)

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/service_check.py
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/service_check.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+from __future__ import print_function
+
+import sys
+
+from resource_management.libraries.script import Script
+from resource_management.core.resources.system import Execute
+import subprocess
+
+
+class ServiceCheck(Script):
+    def service_check(self, env):
+        import params
+        env.set_params(params)
+
+        doc = '{"name": "Ambari Smoke test"}'
+        index = "ambari_smoke_test"
+
+        print("Running Elastic search service check", file=sys.stdout)
+
+        # Make sure the service is actually up.  We can live without everything allocated.
+        # Need both the retry and ES timeout.  Can hit the URL before ES is ready at all and get no response, but can
+        # also hit ES before things are green.
+        host = "localhost:9200"
+        Execute("curl -XGET 'http://%s/_cluster/health?wait_for_status=green&timeout=120s'" % host,
+                logoutput=True,
+                tries=6,
+                try_sleep=20
+                )
+
+        # Put a document into a new index.
+
+        Execute("curl -XPUT '%s/%s/test/1' -d '%s'" % (host, index, doc), logoutput=True)
+
+        # Retrieve the document.  Use subprocess because we actually need the results here.
+        cmd_retrieve = "curl -XGET '%s/%s/test/1'" % (host, index)
+        proc = subprocess.Popen(cmd_retrieve, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        (stdout, stderr) = proc.communicate()
+        response_retrieve = stdout
+        print("Retrieval response is: %s" % response_retrieve)
+        expected_retrieve = '{"_index":"%s","_type":"test","_id":"1","_version":1,"found":true,"_source":%s}' \
+            % (index, doc)
+
+        # Delete the index
+        cmd_delete = "curl -XDELETE '%s/%s'" % (host, index)
+        proc = subprocess.Popen(cmd_delete, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        (stdout, stderr) = proc.communicate()
+        response_delete = stdout
+        print("Delete index response is: %s" % response_retrieve)
+        expected_delete = '{"acknowledged":true}'
+
+        if (expected_retrieve == response_retrieve) and (expected_delete == response_delete):
+            print("Smoke test able to communicate with Elasticsearch")
+        else:
+            print("Elasticsearch service unable to retrieve document.")
+            sys.exit(1)
+
+        exit(0)
+
+
+if __name__ == "__main__":
+    ServiceCheck().execute()

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/slave.py
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/slave.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+from resource_management.core.resources.system import Directory
+from resource_management.core.resources.system import File
+from resource_management.core.source import InlineTemplate
+from resource_management.core.source import Template
+
+
+def slave():
+    import params
+
+    params.path_data = params.path_data.replace('"', '')
+    data_path = params.path_data.replace(' ', '').split(',')
+    data_path[:] = [x.replace('"', '') for x in data_path]
+
+    directories = [params.log_dir, params.pid_dir, params.conf_dir]
+    directories = directories + data_path
+
+    Directory(directories,
+              create_parents=True,
+              mode=0755,
+              owner=params.elastic_user,
+              group=params.elastic_user,
+              cd_access="a"
+              )
+
+    File("{}/elastic-env.sh".format(params.conf_dir),
+         owner=params.elastic_user,
+         content=InlineTemplate(params.elastic_env_sh_template)
+         )
+
+    configurations = params.config['configurations']['elastic-site']
+
+    File("{}/elasticsearch.yml".format(params.conf_dir),
+         content=Template(
+             "elasticsearch.slave.yaml.j2",
+             configurations=configurations),
+         owner=params.elastic_user,
+         group=params.elastic_user
+         )
+
+    print "Master sysconfig: /etc/sysconfig/elasticsearch"
+    File(format("/etc/sysconfig/elasticsearch"),
+         owner="root",
+         group="root",
+         content=InlineTemplate(params.sysconfig_template)
+         )

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/status_params.py
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/status_params.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+from resource_management.libraries.script import Script
+
+config = Script.get_config()
+
+elastic_pid_dir = config['configurations']['elastic-env']['elastic_pid_dir']
+elastic_pid_file = format("{elastic_pid_dir}/elasticsearch.pid")

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/templates/elasticsearch.master.yaml.j2
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/templates/elasticsearch.master.yaml.j2
@@ -1,0 +1,84 @@
+{#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#}
+
+cluster:
+  name:   {{cluster_name}} 
+  routing:
+    allocation.node_concurrent_recoveries: {{cluster_routing_allocation_node_concurrent_recoveries}}
+    allocation.disk.watermark.low: {{cluster_routing_allocation_disk_watermark_low}}
+    allocation.disk.threshold_enabled: {{cluster_routing_allocation_disk_threshold_enabled}}
+    allocation.disk.watermark.high: {{cluster_routing_allocation_disk_watermark_high}}
+
+discovery:
+  zen:
+    ping:
+      multicast:
+        enabled: {{discovery_zen_ping_multicast_enabled}}
+      unicast:
+        hosts: "{{zen_discovery_ping_unicast_hosts}}"
+
+node:
+  data: false
+  master: true
+  name: {{hostname}}
+path:
+  data: {{path_data}}
+
+http.cors.enabled: true
+
+port: {{http_port}}
+
+transport:
+  tcp:
+    port: {{transport_tcp_port}}
+
+gateway:
+  recover_after_data_nodes: {{gateway_recover_after_data_nodes}}
+  recover_after_time: {{recover_after_time}}
+  expected_data_nodes: {{expected_data_nodes}}
+  
+index:
+  number_of_shards: {{index_number_of_shards}}
+  merge.scheduler.max_thread_count: {{index_merge_scheduler_max_thread_count}}
+  translog.flush_threshold_size: {{index_translog_flush_threshold_size}}
+  refresh_interval: {{index_refresh_interval}}
+  number_of_replicas: {{index_number_of_replicas}}
+ 
+indices:
+  memory:
+   index_buffer_size: {{indices_memory_index_buffer_size}}
+   store.throttle.type: {{indices_memory_index_store_throttle_type}}
+  fielddata:
+   cache.size: {{indices_fielddata_cache_size}}
+  cluster:
+   send_refresh_mapping: {{indices_cluster_send_refresh_mapping}}
+
+bootstrap.mlockall: {{bootstrap_mlockall}}
+
+threadpool:
+  bulk:
+    queue_size: {{threadpool_bulk_queue_size}}
+  index:
+    queue_size: {{threadpool_index_queue_size}}
+
+discovery.zen.ping_timeout: {{discovery_zen_ping_timeout}}
+discovery.zen.fd.ping_interval: {{discovery_zen_fd_ping_interval}}
+discovery.zen.fd.ping_timeout: {{discovery_zen_fd_ping_timeout}}
+discovery.zen.fd.ping_retries: {{discovery_zen_fd_ping_retries}}
+
+network.host: {{network_host}}

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/templates/elasticsearch.slave.yaml.j2
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/templates/elasticsearch.slave.yaml.j2
@@ -1,0 +1,84 @@
+{#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#}
+
+cluster:
+  name:   {{cluster_name}} 
+  routing:
+    allocation.node_concurrent_recoveries: {{cluster_routing_allocation_node_concurrent_recoveries}}
+    allocation.disk.watermark.low: {{cluster_routing_allocation_disk_watermark_low}}
+    allocation.disk.threshold_enabled: {{cluster_routing_allocation_disk_threshold_enabled}}
+    allocation.disk.watermark.high: {{cluster_routing_allocation_disk_watermark_high}}
+
+discovery:
+  zen:
+    ping:
+      multicast:
+        enabled: {{discovery_zen_ping_multicast_enabled}}
+      unicast:
+        hosts: "{{zen_discovery_ping_unicast_hosts}}"
+
+node:
+  data: true
+  master: false
+  name: {{hostname}}
+path:
+  data: {{path_data}}
+
+http.cors.enabled: true
+
+port: {{http_port}}
+
+transport:
+  tcp:
+    port: {{transport_tcp_port}}
+
+gateway:
+  recover_after_data_nodes: {{gateway_recover_after_data_nodes}}
+  recover_after_time: {{recover_after_time}}
+  expected_data_nodes: {{expected_data_nodes}}
+  
+index:
+  number_of_shards: {{index_number_of_shards}}
+  merge.scheduler.max_thread_count: {{index_merge_scheduler_max_thread_count}}
+  translog.flush_threshold_size: {{index_translog_flush_threshold_size}}
+  refresh_interval: {{index_refresh_interval}}
+  number_of_replicas: {{index_number_of_replicas}}
+ 
+indices:
+  memory:
+   index_buffer_size: {{indices_memory_index_buffer_size}}
+   store.throttle.type: {{indices_memory_index_store_throttle_type}}
+  fielddata:
+   cache.size: {{indices_fielddata_cache_size}}
+  cluster:
+   send_refresh_mapping: {{indices_cluster_send_refresh_mapping}}
+
+bootstrap.mlockall: {{bootstrap_mlockall}}
+
+threadpool:
+  bulk:
+    queue_size: {{threadpool_bulk_queue_size}}
+  index:
+    queue_size: {{threadpool_index_queue_size}}
+
+discovery.zen.ping_timeout: {{discovery_zen_ping_timeout}}
+discovery.zen.fd.ping_interval: {{discovery_zen_fd_ping_interval}}
+discovery.zen.fd.ping_timeout: {{discovery_zen_fd_ping_timeout}}
+discovery.zen.fd.ping_retries: {{discovery_zen_fd_ping_retries}}
+
+network.host: {{network_host}}

--- a/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/role_command_order.json
+++ b/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH/2.3.3/role_command_order.json
@@ -1,0 +1,8 @@
+{
+  "_comment" : "Record format:",
+  "_comment" : "blockedRole-blockedCommand: [blockerRole1-blockerCommand1, blockerRole2-blockerCommand2, ...]",
+  "general_deps" : {
+    "_comment" : "dependencies for all cases",
+    "ELASTICSEARCH_SERVICE_CHECK-SERVICE_CHECK" : ["ES_MASTER-START", "ES_SLAVE-START"]
+  }
+}

--- a/metron-deployment/packaging/ambari/src/main/resources/stacks/HDP/2.4/services/ELASTICSEARCH/metainfo.xml
+++ b/metron-deployment/packaging/ambari/src/main/resources/stacks/HDP/2.4/services/ELASTICSEARCH/metainfo.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<metainfo>
+    <schemaVersion>2.0</schemaVersion>
+    <services>
+        <service>
+            <name>ELASTICSEARCH</name>
+            <displayName>Elasticsearch</displayName>
+            <comment>Indexing and Search</comment>
+            <version>2.3.3</version>
+            <extends>common-services/ELASTICSEARCH/2.3.3</extends>
+            <osSpecifics>
+                <osSpecific>
+                    <osFamily>any</osFamily>
+                    <packages>
+                        <package>
+                            <name>elasticsearch-2.3.3</name>
+                        </package>
+                    </packages>
+                </osSpecific>
+            </osSpecifics>
+        </service>
+    </services>
+</metainfo>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/METRON-386

Opening the PR to get community feedback.

Prereq:

Ambari 2.4
Testing this PR:

* Copy or mount the services and stack contents into the appropriate places on the ambari-server node. Afterwards, restart the Ambari server if it is running: ```service ambari-server restart```. For example:
  * incubator-metron/metron-deployment/packaging/ambari/src/main/resources/stacks/HDP/2.4/services/ELASTICSEARCH -> /var/lib/ambari-server/resources/stacks/HDP/2.4/services/ELASTICSEARCH
  * incubator-metron/metron-deployment/packaging/ambari/src/main/resources/common-services/ELASTICSEARCH -> /var/lib/ambari-server/resources/common-services/ELASTICSEARCH
* ES Master eligible nodes will not contain data. Don't colocate master eligible nodes and data nodes.
* It's necessary to provide the ES zen_discovery_ping_unicast_hosts.

Limitations / Notes
* This is based off of Symantec's work at: https://github.com/Symantec/ambari-elasticsearch-service.  Should I add this into the NOTICE that includes similar contributions?
* Most configs are used from Symantec's build.  If there are more sane configs, we should change the defaults (I'm not an ES expert by any means).
* It would be really nice if zen_discovery_ping_unicast_hosts could be automatically populated with something sane.  I'm unsure of how to accomplish this with Ambari.
* Master-eligible nodes are non-data holding nodes that are eligible to be elected master. Data nodes are, not surprisingly, nodes that only hold data, but are not master-eligible. It would be nice if thing could be modified to allow master eligible nodes to also hold data cleanly, but this is left as a further enhancement if needed.
* A service advisor definition could probably be added to force Ambari to avoid placing master-eligible and data nodes onto the same node.
