### PR TITLE
METRON-394 Create Stellar Date Functions to Use with Profile 'Group By'

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/StellarFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/StellarFunctions.java
@@ -56,6 +56,7 @@ public enum StellarFunctions implements StellarFunction {
   TO_STRING(new StringFunctions.ToString()),
   TO_INTEGER(new ConversionFunctions.Cast<>(Integer.class)),
   TO_DOUBLE(new ConversionFunctions.Cast<>(Double.class)),
+  TO_LONG(new ConversionFunctions.Cast<>(Long.class)),
 
   // map functions
   MAP_GET(new MapFunctions.MapGet()),
@@ -74,6 +75,13 @@ public enum StellarFunctions implements StellarFunction {
 
   // date functions
   TO_EPOCH_TIMESTAMP(new DateFunctions.ToTimestamp()),
+  YEAR(new DateFunctions.Year()),
+  MONTH(new DateFunctions.MonthOfYear()),
+  DAY_OF_MONTH(new DateFunctions.DayOfMonth()),
+  DAY_OF_WEEK(new DateFunctions.DayOfWeek()),
+  WEEK_OF_MONTH(new DateFunctions.WeekOfMonth()),
+  WEEK_OF_YEAR(new DateFunctions.WeekOfYear()),
+  DAY_OF_YEAR(new DateFunctions.DayOfYear()),
 
   // validation functions
   IS_EMPTY ( new DataStructureFunctions.IsEmpty()),

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DateFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DateFunctions.java
@@ -22,20 +22,26 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import org.apache.metron.common.dsl.BaseStellarFunction;
+import org.apache.metron.common.utils.ConversionUtils;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.List;
 import java.util.Optional;
 import java.util.TimeZone;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
 
+/**
+ * Stellar data functions.
+ */
 public class DateFunctions {
 
   private static class TimezonedFormat {
+
     private String format;
     private Optional<String> timezone;
+
     public TimezonedFormat(String format, String timezone) {
       this.format = format;
       this.timezone = Optional.of(timezone);
@@ -45,6 +51,7 @@ public class DateFunctions {
       this.format = format;
       this.timezone = Optional.empty();
     }
+
     public SimpleDateFormat toDateFormat() {
       return createFormat(format, timezone);
     }
@@ -58,7 +65,6 @@ public class DateFunctions {
 
       if (format != null ? !format.equals(that.format) : that.format != null) return false;
       return timezone != null ? timezone.equals(that.timezone) : that.timezone == null;
-
     }
 
     @Override
@@ -69,19 +75,19 @@ public class DateFunctions {
     }
   }
 
-  private static LoadingCache<TimezonedFormat, ThreadLocal<SimpleDateFormat>> formatCache
-          = CacheBuilder.newBuilder().build(new CacheLoader<TimezonedFormat, ThreadLocal<SimpleDateFormat>>() {
-            @Override
-            public ThreadLocal<SimpleDateFormat> load(final TimezonedFormat format) throws Exception {
-              return new ThreadLocal<SimpleDateFormat>() {
-                @Override
-                public SimpleDateFormat initialValue() {
-                  return format.toDateFormat();
-                }
-              };
-            }
-          }
-                        );
+  private static LoadingCache<TimezonedFormat, ThreadLocal<SimpleDateFormat>> formatCache =
+          CacheBuilder.newBuilder().build(
+                  new CacheLoader<TimezonedFormat, ThreadLocal<SimpleDateFormat>>() {
+                    @Override
+                    public ThreadLocal<SimpleDateFormat> load(final TimezonedFormat format) throws Exception {
+                      return new ThreadLocal<SimpleDateFormat>() {
+                        @Override
+                        public SimpleDateFormat initialValue() {
+                        return format.toDateFormat();
+                        }
+                      };
+                    }
+                  });
 
   public static SimpleDateFormat createFormat(String format, Optional<String> timezone) {
     SimpleDateFormat sdf = new SimpleDateFormat(format);
@@ -90,19 +96,21 @@ public class DateFunctions {
     }
     return sdf;
   }
+
   public static long getEpochTime(String date, String format, Optional<String> timezone) throws ExecutionException, ParseException {
-    TimezonedFormat fmt = null;
+    TimezonedFormat fmt;
     if(timezone.isPresent()) {
       fmt = new TimezonedFormat(format, timezone.get());
-    }
-    else {
+    } else {
       fmt = new TimezonedFormat(format);
     }
     SimpleDateFormat sdf = formatCache.get(fmt).get();
     return sdf.parse(date).getTime();
   }
 
-
+  /**
+   * Stellar Function: TO_EPOCH_TIMESTAMP
+   */
   public static class ToTimestamp extends BaseStellarFunction {
     @Override
     public Object apply(List<Object> objects) {
@@ -114,17 +122,176 @@ public class DateFunctions {
       }
       if(dateObj != null && formatObj != null) {
         try {
-          return getEpochTime(dateObj.toString()
-                             , formatObj.toString()
-                             , tzObj == null?Optional.empty():Optional.of(tzObj.toString())
-                             );
-        } catch (ExecutionException e) {
-          return null;
-        } catch (ParseException e) {
+          Optional<String> tz = (tzObj == null) ? Optional.empty() : Optional.of(tzObj.toString());
+          return getEpochTime(dateObj.toString(), formatObj.toString(), tz);
+
+        } catch (ExecutionException | ParseException e) {
           return null;
         }
       }
       return null;
     }
   }
+
+  /**
+   * Stellar Function: DAY_OF_WEEK
+   *
+   * The numbered day within the week.  The first day of the week, Sunday, has a value of 1.
+   */
+  public static class DayOfWeek extends BaseStellarFunction {
+    @Override
+    public Object apply(List<Object> args) {
+
+      // expect epoch milliseconds
+      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      if(epochMillis == null) {
+        return null;
+      }
+
+      // create a calendar
+      Calendar calendar = Calendar.getInstance();
+      calendar.setTimeInMillis(epochMillis);
+
+      return calendar.get(Calendar.DAY_OF_WEEK);
+    }
+  }
+
+  /**
+   * Stellar Function: DAY_OF_MONTH
+   *
+   * The day within the month.  The first day within the month has a value of 1.
+   */
+  public static class DayOfMonth extends BaseStellarFunction {
+    @Override
+    public Object apply(List<Object> args) {
+
+      // expect epoch milliseconds
+      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      if(epochMillis == null) {
+        return null;
+      }
+
+      // create a calendar
+      Calendar calendar = Calendar.getInstance();
+      calendar.setTimeInMillis(epochMillis);
+
+      return calendar.get(Calendar.DAY_OF_MONTH);
+    }
+  }
+
+  /**
+   * Stellar Function: WEEK_OF_MONTH
+   *
+   * The numbered week within the month.  The first week has a value of 1.
+   */
+  public static class WeekOfMonth extends BaseStellarFunction {
+    @Override
+    public Object apply(List<Object> args) {
+
+      // expect epoch milliseconds
+      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      if(epochMillis == null) {
+        return null;
+      }
+
+      // create a calendar
+      Calendar calendar = Calendar.getInstance();
+      calendar.setTimeInMillis(epochMillis);
+
+      return calendar.get(Calendar.WEEK_OF_MONTH);
+    }
+  }
+
+  /**
+   * Stellar Function: WEEK_OF_YEAR
+   *
+   * The numbered week within the year.  The first week in the year has a value of 1.
+   */
+  public static class WeekOfYear extends BaseStellarFunction {
+    @Override
+    public Object apply(List<Object> args) {
+
+      // expect epoch milliseconds
+      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      if(epochMillis == null) {
+        return null;
+      }
+
+      // create a calendar
+      Calendar calendar = Calendar.getInstance();
+      calendar.setTimeInMillis(epochMillis);
+
+      return calendar.get(Calendar.WEEK_OF_YEAR);
+    }
+  }
+
+  /**
+   * Stellar Function: MONTH
+   *
+   * A number representing the month.  The first month, January, has a value of 0.
+   */
+  public static class MonthOfYear extends BaseStellarFunction {
+    @Override
+    public Object apply(List<Object> args) {
+
+      // expect epoch milliseconds
+      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      if(epochMillis == null) {
+        return null;
+      }
+
+      // create a calendar
+      Calendar calendar = Calendar.getInstance();
+      calendar.setTimeInMillis(epochMillis);
+
+      return calendar.get(Calendar.MONTH);
+    }
+  }
+
+  /**
+   * Stellar Function: YEAR
+   *
+   * The calendar year.
+   */
+  public static class Year extends BaseStellarFunction {
+    @Override
+    public Object apply(List<Object> args) {
+
+      // expect epoch milliseconds
+      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      if(epochMillis == null) {
+        return null;
+      }
+
+      // create a calendar
+      Calendar calendar = Calendar.getInstance();
+      calendar.setTimeInMillis(epochMillis);
+
+      return calendar.get(Calendar.YEAR);
+    }
+  }
+
+  /**
+   * Stellar Function: DAY_OF_YEAR
+   *
+   * The day number within the year.  The first day of the year has value of 1.
+   */
+  public static class DayOfYear extends BaseStellarFunction {
+    @Override
+    public Object apply(List<Object> args) {
+
+      // expect epoch milliseconds
+      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      if(epochMillis == null) {
+        return null;
+      }
+
+      // create a calendar
+      Calendar calendar = Calendar.getInstance();
+      calendar.setTimeInMillis(epochMillis);
+
+      return calendar.get(Calendar.DAY_OF_YEAR);
+    }
+  }
 }
+

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/DateFunctionsTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/DateFunctionsTest.java
@@ -1,0 +1,104 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.metron.common.stellar;
+
+import org.apache.metron.common.dsl.Context;
+import org.apache.metron.common.dsl.StellarFunctions;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static java.lang.String.format;
+
+/**
+ * Tests the DateFunctions class.
+ */
+public class DateFunctionsTest {
+
+  private Map<String, Object> variables = new HashMap<>();
+
+  /**
+   * Runs a Stellar expression.
+   * @param expr The expression to run.
+   */
+  private Object run(String expr) {
+    StellarProcessor processor = new StellarProcessor();
+    assertTrue(processor.validate(expr));
+    return processor.parse(expr, x -> variables.get(x), StellarFunctions.FUNCTION_RESOLVER(), Context.EMPTY_CONTEXT());
+  }
+
+  /**
+   * Thu Aug 25 2016 09:27:10 EST
+   */
+  private long AUG2016 = 1472131630748L;
+
+  @Before
+  public void setup() {
+    variables.put("epoch", AUG2016);
+  }
+
+  @Test
+  public void testDayOfWeek() {
+    Object result = run(format("DAY_OF_WEEK(epoch)", AUG2016));
+    assertEquals(Calendar.THURSDAY, result);
+  }
+
+  @Test
+  public void testWeekOfMonth() {
+    Object result = run(format("WEEK_OF_MONTH(epoch)", AUG2016));
+    assertEquals(4, result);
+  }
+
+  @Test
+  public void testMonth() {
+    Object result = run(format("MONTH(epoch)", AUG2016));
+    assertEquals(Calendar.AUGUST, result);
+  }
+
+  @Test
+  public void testYear() {
+    Object result = run(format("YEAR(epoch)", AUG2016));
+    assertEquals(2016, result);
+  }
+
+  @Test
+  public void testDayOfMonth() {
+    Object result = run(format("DAY_OF_MONTH(epoch)", AUG2016));
+    assertEquals(25, result);
+  }
+
+  @Test
+  public void testWeekOfYear() {
+    Object result = run(format("WEEK_OF_YEAR(epoch)", AUG2016));
+    assertEquals(35, result);
+  }
+
+  @Test
+  public void testDayOfYear() {
+    Object result = run(format("DAY_OF_YEAR(epoch)", AUG2016));
+    assertEquals(238, result);
+  }
+}


### PR DESCRIPTION
### [METRON-394](https://issues.apache.org/jira/browse/METRON-394)

[METRON-392](https://issues.apache.org/jira/browse/METRON-392) and #230  Allows a user to optionally define a custom set of 'groupBy' expressions that controls how Profile data is persisted. This is intended to allow for contiguous scans when training on subsets of the data.

A common use case would be grouping the data by some calendar period, like day of week. This would allow a contiguous scan to access all profile data, for example, on Mondays only. The Stellar expression DAY_OF_WEEK(start) would achieve this.

The following functions have been added for this purpose.
* WEEK_OF_MONTH
* WEEK_OF_YEAR
* DAY_OF_WEEK
* DAY_OF_MONTH
* DAY_OF_YEAR
* MONTH
* YEAR
