### PR TITLE
METRON-398 Bump release version to 0.2.1BETA in master

### DIFF
--- a/metron-analytics/metron-maas-common/pom.xml
+++ b/metron-analytics/metron-maas-common/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.metron</groupId>
     <artifactId>metron-analytics</artifactId>
-    <version>0.2.0BETA</version>
+    <version>0.2.1BETA</version>
   </parent>
   <artifactId>metron-maas-common</artifactId>
   <properties>

--- a/metron-analytics/metron-maas-service/pom.xml
+++ b/metron-analytics/metron-maas-service/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.metron</groupId>
     <artifactId>metron-analytics</artifactId>
-    <version>0.2.0BETA</version>
+    <version>0.2.1BETA</version>
   </parent>
   <artifactId>metron-maas-service</artifactId>
   <properties>

--- a/metron-analytics/metron-maas-service/src/main/scripts/maas_deploy.sh
+++ b/metron-analytics/metron-maas-service/src/main/scripts/maas_deploy.sh
@@ -28,7 +28,7 @@ elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
 fi
 
 export HBASE_HOME=${HBASE_HOME:-/usr/hdp/current/hbase-client}
-export METRON_VERSION=0.2.0BETA
+export METRON_VERSION=${project.version}
 export METRON_HOME=/usr/metron/$METRON_VERSION
 export DM_JAR=metron-maas-service-$METRON_VERSION-uber.jar
 CP=$METRON_HOME/lib/$DM_JAR

--- a/metron-analytics/metron-maas-service/src/main/scripts/maas_service.sh
+++ b/metron-analytics/metron-maas-service/src/main/scripts/maas_service.sh
@@ -28,7 +28,7 @@ elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
 fi
 
 export HBASE_HOME=${HBASE_HOME:-/usr/hdp/current/hbase-client}
-export METRON_VERSION=0.2.0BETA
+export METRON_VERSION=${project.version}
 export METRON_HOME=/usr/metron/$METRON_VERSION
 export DM_JAR=metron-maas-service-$METRON_VERSION-uber.jar
 CP=$METRON_HOME/lib/$DM_JAR

--- a/metron-analytics/metron-profiler/README.md
+++ b/metron-analytics/metron-profiler/README.md
@@ -168,22 +168,22 @@ This section will describe the steps required to get your first profile running.
     ```
     $ vagrant ssh
     $ sudo su -
-    $ cd /usr/metron/0.2.0BETA/
+    $ cd /usr/metron/0.2.1BETA/
     ```
 
-3. Create a table within HBase that will store the profile data. The table name and column family must match the Profiler topology configuration stored at `/usr/metron/0.2.0BETA/config/profiler.properties`.
+3. Create a table within HBase that will store the profile data. The table name and column family must match the Profiler topology configuration stored at `/usr/metron/0.2.1BETA/config/profiler.properties`.
     ```
     $ /usr/hdp/current/hbase-client/bin/hbase shell
     hbase(main):001:0> create 'profiler', 'P'
     ```
 
-4. Shorten the flush intervals to more immediately see results.  Edit the Profiler topology properties located at `/usr/metron/0.2.0BETA/config/profiler.properties`.  Alter the following two properties.
+4. Shorten the flush intervals to more immediately see results.  Edit the Profiler topology properties located at `/usr/metron/0.2.1BETA/config/profiler.properties`.  Alter the following two properties.
     ```
     profiler.flush.interval.seconds=30
     profiler.hbase.flush.interval.seconds=30
     ```
 
-5. Create the Profiler definition in a file located at `/usr/metron/0.2.0BETA/config/zookeeper/profiler.json`.  The following JSON will create a profile that simply counts the number of messages.
+5. Create the Profiler definition in a file located at `/usr/metron/0.2.1BETA/config/zookeeper/profiler.json`.  The following JSON will create a profile that simply counts the number of messages.
     ```
     {
       "inputTopic": "indexing",

--- a/metron-analytics/metron-profiler/pom.xml
+++ b/metron-analytics/metron-profiler/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-analytics</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <artifactId>metron-profiler</artifactId>
     <properties>

--- a/metron-analytics/pom.xml
+++ b/metron-analytics/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.apache.metron</groupId>
 		<artifactId>Metron</artifactId>
-		<version>0.2.0BETA</version>
+		<version>0.2.1BETA</version>
 	</parent>
 	<description>Stream analytics for Metron</description>
 	<url>https://metron.incubator.apache.org/</url>

--- a/metron-deployment/amazon-ec2/conf/defaults.yml
+++ b/metron-deployment/amazon-ec2/conf/defaults.yml
@@ -75,7 +75,7 @@ num_partitions: 3
 retention_in_gb: 25
 
 # metron variables
-metron_version: 0.2.0BETA
+metron_version: 0.2.1BETA
 metron_directory: /usr/metron/{{ metron_version }}
 pcapservice_port: 8081
 

--- a/metron-deployment/inventory/full-dev-platform/group_vars/all
+++ b/metron-deployment/inventory/full-dev-platform/group_vars/all
@@ -46,7 +46,7 @@ threatintel_hbase_table: threatintel
 enrichment_hbase_table: enrichment
 
 # metron
-metron_version: 0.2.0BETA
+metron_version: 0.2.1BETA
 metron_directory: /usr/metron/{{ metron_version }}
 bro_version: "2.4.1"
 fixbuf_version: "1.7.1"

--- a/metron-deployment/inventory/metron_example/group_vars/all
+++ b/metron-deployment/inventory/metron_example/group_vars/all
@@ -54,7 +54,7 @@ num_partitions: 3
 retention_in_gb: 25
 
 # metron variables
-metron_version: 0.2.0BETA
+metron_version: 0.2.1BETA
 metron_directory: /usr/metron/{{ metron_version }}
 pcapservice_port: 8081
 

--- a/metron-deployment/inventory/multinode-vagrant/group_vars/all
+++ b/metron-deployment/inventory/multinode-vagrant/group_vars/all
@@ -35,7 +35,7 @@ elasticsearch_network_interface: eth1
 elasticsearch_web_port: 9200
 
 # metron variables
-metron_version: 0.2.0BETA
+metron_version: 0.2.1BETA
 pcapservice_port: 8081
 
 # sensors

--- a/metron-deployment/pom.xml
+++ b/metron-deployment/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>Metron</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <description>Building and deploying Metron</description>
     <properties>

--- a/metron-deployment/roles/metron_pcapservice/defaults/main.yml
+++ b/metron-deployment/roles/metron_pcapservice/defaults/main.yml
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 ---
-metron_version: 0.2.0BETA
+metron_version: 0.2.1BETA
 metron_directory: /usr/metron/{{ metron_version }}
 pcapservice_jar_name: metron-api-{{ metron_version }}.jar
 pcapservice_jar_src: "{{ playbook_dir }}/../../metron-platform/metron-api/target/{{ pcapservice_jar_name }}"

--- a/metron-platform/README.md
+++ b/metron-platform/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Current Build
 
-The latest build of metron-platform is 0.2.0BETA.
+The latest build of metron-platform is 0.2.1BETA.
 
 We are still in the process of merging/porting additional features from our production code base into this open source release. This release will be followed by a number of additional beta releases until the port is complete. We will also work on getting additional documentation and user/developer guides to the community as soon as we can. At this time we offer no support for the beta software, but will try to respond to requests as promptly as we can.
 

--- a/metron-platform/elasticsearch-shaded/pom.xml
+++ b/metron-platform/elasticsearch-shaded/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>metron-platform</artifactId>
         <groupId>org.apache.metron</groupId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>elasticsearch-shaded</artifactId>

--- a/metron-platform/metron-api/pom.xml
+++ b/metron-platform/metron-api/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.apache.metron</groupId>
 		<artifactId>metron-platform</artifactId>
-		<version>0.2.0BETA</version>
+		<version>0.2.1BETA</version>
 	</parent>
 	<artifactId>metron-api</artifactId>
 	<description>Metron API</description>

--- a/metron-platform/metron-common/pom.xml
+++ b/metron-platform/metron-common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <artifactId>metron-common</artifactId>
     <name>metron-common</name>

--- a/metron-platform/metron-data-management/pom.xml
+++ b/metron-platform/metron-data-management/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <artifactId>metron-data-management</artifactId>
     <properties>

--- a/metron-platform/metron-elasticsearch/pom.xml
+++ b/metron-platform/metron-elasticsearch/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <artifactId>metron-elasticsearch</artifactId>
     <properties>

--- a/metron-platform/metron-enrichment/pom.xml
+++ b/metron-platform/metron-enrichment/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <artifactId>metron-enrichment</artifactId>
     <properties>

--- a/metron-platform/metron-hbase/pom.xml
+++ b/metron-platform/metron-hbase/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <artifactId>metron-hbase</artifactId>
     <properties>

--- a/metron-platform/metron-indexing/pom.xml
+++ b/metron-platform/metron-indexing/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <artifactId>metron-indexing</artifactId>
     <properties>

--- a/metron-platform/metron-integration-test/pom.xml
+++ b/metron-platform/metron-integration-test/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.metron</groupId>
     <artifactId>metron-platform</artifactId>
-    <version>0.2.0BETA</version>
+    <version>0.2.1BETA</version>
   </parent>
   <artifactId>metron-integration-test</artifactId>
   <description>Metron Integration Test</description>

--- a/metron-platform/metron-parsers/pom.xml
+++ b/metron-platform/metron-parsers/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <artifactId>metron-parsers</artifactId>
     <properties>

--- a/metron-platform/metron-pcap-backend/pom.xml
+++ b/metron-platform/metron-pcap-backend/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <artifactId>metron-pcap-backend</artifactId>
     <name>Metron PCAP Backend</name>

--- a/metron-platform/metron-pcap/pom.xml
+++ b/metron-platform/metron-pcap/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <artifactId>metron-pcap</artifactId>
     <description>Metron Pcap</description>

--- a/metron-platform/metron-solr/pom.xml
+++ b/metron-platform/metron-solr/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <artifactId>metron-solr</artifactId>
     <properties>

--- a/metron-platform/metron-test-utilities/pom.xml
+++ b/metron-platform/metron-test-utilities/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.metron</groupId>
     <artifactId>metron-platform</artifactId>
-    <version>0.2.0BETA</version>
+    <version>0.2.1BETA</version>
   </parent>
   <artifactId>metron-test-utilities</artifactId>
   <description>Metron Test Utilities</description>

--- a/metron-platform/metron-writer/pom.xml
+++ b/metron-platform/metron-writer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.metron</groupId>
         <artifactId>metron-platform</artifactId>
-        <version>0.2.0BETA</version>
+        <version>0.2.1BETA</version>
     </parent>
     <artifactId>metron-writer</artifactId>
     <name>metron-writer</name>

--- a/metron-platform/pom.xml
+++ b/metron-platform/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.apache.metron</groupId>
 		<artifactId>Metron</artifactId>
-		<version>0.2.0BETA</version>
+		<version>0.2.1BETA</version>
 	</parent>
 	<description>Stream analytics for Metron</description>
 	<url>https://metron.incubator.apache.org/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.metron</groupId>
     <artifactId>Metron</artifactId>
-    <version>0.2.0BETA</version>
+    <version>0.2.1BETA</version>
     <packaging>pom</packaging>
     <name>Metron</name>
     <description>Metron Top Level Project</description>
@@ -173,36 +173,8 @@
                         <exclude>**/target/**</exclude>
                         <exclude>**/bro-plugin-kafka/build/**</exclude>
                         <exclude>**/files/opensoc-ui</exclude>
-                        <exclude>metron-ui/lib/public/css/normalize.min.css</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/pcap/lib/showdown.js</exclude>
-                        <!-- 3rd party bundled javascript dependencies -->
-                        <exclude>metron-ui/lib/public/vendor/**</exclude>
-                        <!-- Kibana panels copied from kibana and bundled -->
-                        <exclude>metron-ui/lib/public/app/panels/dashcontrol/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/filtering/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/histogram/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/hits/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/map/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/query/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/sparklines/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/table/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/terms/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/text/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/timepicker/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/trends/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/bettermap/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/column/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/derivequeries/**</exclude>
-                        <exclude>metron-ui/lib/public/app/panels/stats/**</exclude>
-                        <exclude>metron-ui/lib/public/app/partials/**</exclude>
-                        <exclude>metron-ui/lib/public/app/services/**</exclude>
-                        <exclude>metron-ui/lib/public/app/services/**</exclude>
-                        <!-- fontawesome fonts are declared in the license, so we can exclude here -->
-                        <exclude>metron-ui/lib/public/css/font-awesome.min.css</exclude>
-                        <exclude>metron-ui/lib/public/font/**</exclude>
-                        <exclude>metron-ui/node_modules/**</exclude>
 			<!-- pickle file - binary format -->
-			<exclude>metron-deployment/packaging/ambari/src/main/resources/common-services/KIBANA/4.5.1/package/scripts/dashboard/*.p</exclude>
+			<exclude>**/packaging/ambari/src/main/resources/common-services/KIBANA/4.5.1/package/scripts/dashboard/*.p</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Update Metron version from 0.2.0BETA to 0.2.1BETA. Covers metron main, metron-analytics, and metron-deployment. Removed old metron-ui references in the rat check. Modified the metron-analytics shell scripts to use ${project.version} instead of hard-coded version.

Addresses - [https://issues.apache.org/jira/browse/METRON-398](https://issues.apache.org/jira/browse/METRON-398)

Tested via running builds and will run quick check in full/quick dev imminently.

**Testing**
Run the following builds in order:
```
[metron-home]$ mvn clean install
[metron-home]/metron-deployment$ mvn clean install
[metron-home]/metron-analytics$ mvn clean install
```

Note that for metron-deployment you should double check the Docker setup requirements in the [README.md](https://github.com/apache/incubator-metron/blob/master/metron-deployment/README.md)

The builds should all succeed without error, though you will see some warnings in metron-deployment, which is OK.