### PR TITLE
METRON-399 Stellar Date Functions Should Default to Current Time

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DateFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DateFunctions.java
@@ -134,18 +134,41 @@ public class DateFunctions {
   }
 
   /**
+   * Gets the value from a list of arguments.
+   *
+   * If the argument at the specified position does not exist, a default value will be returned.
+   * If the argument at the specified position exists, but cannot be coerced to the right type, null is returned.
+   * Otherwise, the argument value is returned.
+   *
+   * @param args A list of arguments.
+   * @param position The position of the argument to get.
+   * @param clazz The type of class expected.
+   * @param defaultValue The default value.
+   * @param <T> The expected type of the argument.
+   */
+  private static <T> T getOrDefault(List<Object> args, int position, Class<T> clazz, T defaultValue) {
+      T result = defaultValue;
+      if(args.size() > position) {
+        result = ConversionUtils.convert(args.get(position), clazz);
+      }
+      return result;
+  }
+
+  /**
    * Stellar Function: DAY_OF_WEEK
    *
    * The numbered day within the week.  The first day of the week, Sunday, has a value of 1.
+   *
+   * If no argument is supplied, returns the current day of week.
    */
   public static class DayOfWeek extends BaseStellarFunction {
     @Override
     public Object apply(List<Object> args) {
 
-      // expect epoch milliseconds
-      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      // expects epoch millis, otherwise defaults to current time
+      Long epochMillis = getOrDefault(args, 0, Long.class, System.currentTimeMillis());
       if(epochMillis == null) {
-        return null;
+        return null;  // invalid argument
       }
 
       // create a calendar
@@ -165,10 +188,10 @@ public class DateFunctions {
     @Override
     public Object apply(List<Object> args) {
 
-      // expect epoch milliseconds
-      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      // expects epoch millis, otherwise defaults to current time
+      Long epochMillis = getOrDefault(args, 0, Long.class, System.currentTimeMillis());
       if(epochMillis == null) {
-        return null;
+        return null;  // invalid argument
       }
 
       // create a calendar
@@ -188,10 +211,10 @@ public class DateFunctions {
     @Override
     public Object apply(List<Object> args) {
 
-      // expect epoch milliseconds
-      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      // expects epoch millis, otherwise defaults to current time
+      Long epochMillis = getOrDefault(args, 0, Long.class, System.currentTimeMillis());
       if(epochMillis == null) {
-        return null;
+        return null;  // invalid argument
       }
 
       // create a calendar
@@ -211,10 +234,10 @@ public class DateFunctions {
     @Override
     public Object apply(List<Object> args) {
 
-      // expect epoch milliseconds
-      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      // expects epoch millis, otherwise defaults to current time
+      Long epochMillis = getOrDefault(args, 0, Long.class, System.currentTimeMillis());
       if(epochMillis == null) {
-        return null;
+        return null;  // invalid argument
       }
 
       // create a calendar
@@ -234,10 +257,10 @@ public class DateFunctions {
     @Override
     public Object apply(List<Object> args) {
 
-      // expect epoch milliseconds
-      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      // expects epoch millis, otherwise defaults to current time
+      Long epochMillis = getOrDefault(args, 0, Long.class, System.currentTimeMillis());
       if(epochMillis == null) {
-        return null;
+        return null;  // invalid argument
       }
 
       // create a calendar
@@ -257,10 +280,10 @@ public class DateFunctions {
     @Override
     public Object apply(List<Object> args) {
 
-      // expect epoch milliseconds
-      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      // expects epoch millis, otherwise defaults to current time
+      Long epochMillis = getOrDefault(args, 0, Long.class, System.currentTimeMillis());
       if(epochMillis == null) {
-        return null;
+        return null;  // invalid argument
       }
 
       // create a calendar
@@ -280,10 +303,10 @@ public class DateFunctions {
     @Override
     public Object apply(List<Object> args) {
 
-      // expect epoch milliseconds
-      Long epochMillis = ConversionUtils.convert(args.get(0), Long.class);
+      // expects epoch millis, otherwise defaults to current time
+      Long epochMillis = getOrDefault(args, 0, Long.class, System.currentTimeMillis());
       if(epochMillis == null) {
-        return null;
+        return null;  // invalid argument
       }
 
       // create a calendar

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/DateFunctionsTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/DateFunctionsTest.java
@@ -39,6 +39,7 @@ import static java.lang.String.format;
 public class DateFunctionsTest {
 
   private Map<String, Object> variables = new HashMap<>();
+  private Calendar calendar;
 
   /**
    * Runs a Stellar expression.
@@ -58,6 +59,7 @@ public class DateFunctionsTest {
   @Before
   public void setup() {
     variables.put("epoch", AUG2016);
+    calendar = Calendar.getInstance();
   }
 
   @Test
@@ -66,10 +68,46 @@ public class DateFunctionsTest {
     assertEquals(Calendar.THURSDAY, result);
   }
 
+  /**
+   * If no argument, then return the current day of week.
+   */
+  @Test
+  public void testDayOfWeekNow() {
+    Object result = run(format("DAY_OF_WEEK()", AUG2016));
+    assertEquals(calendar.get(Calendar.DAY_OF_WEEK), result);
+  }
+
+  /**
+   * If refer to variable that does not exist, expect null returned.
+   */
+  @Test
+  public void testDayOfWeekNull() {
+    Object result = run(format("DAY_OF_WEEK(nada)", AUG2016));
+    assertEquals(null, result);
+  }
+
   @Test
   public void testWeekOfMonth() {
     Object result = run(format("WEEK_OF_MONTH(epoch)", AUG2016));
     assertEquals(4, result);
+  }
+
+  /**
+   * If no argument, then return the current week of month.
+   */
+  @Test
+  public void testWeekOfMonthNow() {
+    Object result = run(format("WEEK_OF_MONTH()", AUG2016));
+    assertEquals(calendar.get(Calendar.WEEK_OF_MONTH), result);
+  }
+
+  /**
+   * If refer to variable that does not exist, expect null returned.
+   */
+  @Test
+  public void testWeekOfMonthNull() {
+    Object result = run(format("WEEK_OF_MONTH(nada)", AUG2016));
+    assertEquals(null, result);
   }
 
   @Test
@@ -78,10 +116,46 @@ public class DateFunctionsTest {
     assertEquals(Calendar.AUGUST, result);
   }
 
+  /**
+   * If no argument, then return the current month.
+   */
+  @Test
+  public void testMonthNow() {
+    Object result = run(format("MONTH()", AUG2016));
+    assertEquals(calendar.get(Calendar.MONTH), result);
+  }
+
+  /**
+   * If refer to variable that does not exist, expect null returned.
+   */
+  @Test
+  public void testMonthNull() {
+    Object result = run(format("MONTH(nada)", AUG2016));
+    assertEquals(null, result);
+  }
+
   @Test
   public void testYear() {
     Object result = run(format("YEAR(epoch)", AUG2016));
     assertEquals(2016, result);
+  }
+
+  /**
+   * If no argument, then return the current year.
+   */
+  @Test
+  public void testYearNow() {
+    Object result = run(format("YEAR()", AUG2016));
+    assertEquals(calendar.get(Calendar.YEAR), result);
+  }
+
+  /**
+   * If refer to variable that does not exist, expect null returned.
+   */
+  @Test
+  public void testYearNull() {
+    Object result = run(format("YEAR(nada)", AUG2016));
+    assertEquals(null, result);
   }
 
   @Test
@@ -90,15 +164,69 @@ public class DateFunctionsTest {
     assertEquals(25, result);
   }
 
+  /**
+   * If no argument, then return the current day of month.
+   */
+  @Test
+  public void testDayOfMonthNow() {
+    Object result = run(format("DAY_OF_MONTH()", AUG2016));
+    assertEquals(calendar.get(Calendar.DAY_OF_MONTH), result);
+  }
+
+  /**
+   * If refer to variable that does not exist, expect null returned.
+   */
+  @Test
+  public void testDayOfMonthNull() {
+    Object result = run(format("DAY_OF_MONTH(nada)", AUG2016));
+    assertEquals(null, result);
+  }
+
   @Test
   public void testWeekOfYear() {
     Object result = run(format("WEEK_OF_YEAR(epoch)", AUG2016));
     assertEquals(35, result);
   }
 
+  /**
+   * If no argument, then return the current week of year.
+   */
+  @Test
+  public void testWeekOfYearNow() {
+    Object result = run(format("WEEK_OF_YEAR()", AUG2016));
+    assertEquals(calendar.get(Calendar.WEEK_OF_YEAR), result);
+  }
+
+  /**
+   * If refer to variable that does not exist, expect null returned.
+   */
+  @Test
+  public void testWeekOfYearNull() {
+    Object result = run(format("WEEK_OF_YEAR(nada)", AUG2016));
+    assertEquals(null, result);
+  }
+
   @Test
   public void testDayOfYear() {
     Object result = run(format("DAY_OF_YEAR(epoch)", AUG2016));
     assertEquals(238, result);
+  }
+
+  /**
+   * If no argument, then return the current day of year.
+   */
+  @Test
+  public void testDayOfYearNow() {
+    Object result = run(format("DAY_OF_YEAR()", AUG2016));
+    assertEquals(calendar.get(Calendar.DAY_OF_YEAR), result);
+  }
+
+  /**
+   * If refer to variable that does not exist, expect null returned.
+   */
+  @Test
+  public void testDayOfYearNull() {
+    Object result = run(format("DAY_OF_YEAR(nada)", AUG2016));
+    assertEquals(null, result);
   }
 }


### PR DESCRIPTION
### [METRON-399](https://issues.apache.org/jira/browse/METRON-399)

The Stellar date functions expect an argument of a Long containing the epoch time in milliseconds.  If no argument is supplied, a parse exception is thrown.

```
WEEK_OF_YEAR(timestamp)
```

This should be changed so that if no argument is supplied, the function assumes the current time.

```
WEEK_OF_YEAR()
```

If an argument is passed that is not valid, the function should continue to return null.

This updates the functioning of all date functions included in #231 .  
