### PR TITLE
METRON-400 Deploy Probes to running Docker Container

### DIFF
--- a/metron-deployment/playbooks/docker_probe_install.yml
+++ b/metron-deployment/playbooks/docker_probe_install.yml
@@ -1,0 +1,63 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+---
+#
+# sensors
+#
+- hosts: localhost
+  tasks:
+  - name: add container to inventory
+    add_host:
+      name: amb-server
+      ansible_connection: docker
+      groups: sensors
+    changed_when: false
+    tags: add-host
+
+- hosts: sensors
+  vars:
+    metron_version: 0.2.0BETA
+    metron_directory: /usr/metron/{{ metron_version }}
+    bro_version: "2.4.1"
+    fixbuf_version: "1.7.1"
+    yaf_version: "2.8.0"
+    daq_version: "2.0.6-1"
+    pycapa_repo: "https://github.com/OpenSOC/pycapa.git"
+    pycapa_home: "/opt/pycapa"
+    snort_version: "2.9.8.0-1"
+    snort_alert_csv_path: "/var/log/snort/alert.csv"
+    threat_intel_bulk_load: False
+    sensor_test_mode: True
+    install_pycapa: False
+    install_bro: True
+    install_snort: True
+    install_yaf: True
+    install_pcap_replay: True
+    sniff_interface: eth0
+    pcap_replay_interface: "{{ sniff_interface }}"
+    pcapservice_port: 8081
+    kafka_broker_url: amb2.service.consul:6667,amb1.service.consul:6667,amb3.service.consul:6667,amb5.service.consul:6667,amb4.service.consul:6667
+  connection: docker
+  roles:
+    - { role: bro,                    tags: ['bro'] }
+    - { role: flume,                  tags: ['snort','flume'] }
+    - { role: snort,                  tags: ['snort'] }
+    - { role: yaf,                    tags: ['yaf'] }
+    - { role: pcap_replay,            tags: ['pcap-replay'] }
+    - { role: sensor-test-mode,       tags: ['sensor-test-mode'] }
+  tags:
+    - sensors

--- a/metron-deployment/playbooks/docker_probe_install.yml
+++ b/metron-deployment/playbooks/docker_probe_install.yml
@@ -50,7 +50,7 @@
     sniff_interface: eth0
     pcap_replay_interface: "{{ sniff_interface }}"
     pcapservice_port: 8081
-    kafka_broker_url: amb2.service.consul:6667,amb1.service.consul:6667,amb3.service.consul:6667,amb5.service.consul:6667,amb4.service.consul:6667
+    kafka_broker_url: amb4.service.consul:6667
   connection: docker
   roles:
     - { role: bro,                    tags: ['bro'] }

--- a/metron-deployment/roles/bro/meta/main.yml
+++ b/metron-deployment/roles/bro/meta/main.yml
@@ -17,7 +17,6 @@
 ---
 dependencies:
   - libselinux-python
-  - ambari_gather_facts
   - build-tools
   - kafka-client
   - librdkafka

--- a/metron-deployment/roles/bro/tasks/dependencies.yml
+++ b/metron-deployment/roles/bro/tasks/dependencies.yml
@@ -31,6 +31,8 @@
     - swig
     - zlib-devel
     - perl
+    - crontabs
+    - net-tools
   register: result
   until: result.rc == 0
   retries: 5

--- a/metron-deployment/roles/sensor-test-mode/tasks/snort.yml
+++ b/metron-deployment/roles/sensor-test-mode/tasks/snort.yml
@@ -19,13 +19,11 @@
 # configure snort to alert on every packet
 #
 - name: Configure snort to use a set of test rules
-  become: True
   lineinfile:
     dest: /etc/snort/snort.conf
     line: "include $RULE_PATH/test.rules"
 
 - name: Create a snort alert for testing that alerts on every packet
-  become: True
   lineinfile:
     dest: /etc/snort/rules/test.rules
     line: "alert tcp any any -> any any (msg:'snort test alert'; sid:999158; )"

--- a/metron-deployment/roles/sensor-test-mode/tasks/yaf.yml
+++ b/metron-deployment/roles/sensor-test-mode/tasks/yaf.yml
@@ -19,7 +19,6 @@
 # configure yaf to generate a flow record for every packet
 #
 - name: Stop running instances of yaf
-  become: True
   service: name=yaf state=stopped
 
 - name: Configure yaf to generate a flow record for every network packet

--- a/metron-deployment/roles/snort/meta/main.yml
+++ b/metron-deployment/roles/snort/meta/main.yml
@@ -16,7 +16,6 @@
 #
 ---
 dependencies:
-  - ambari_gather_facts
   - epel
   - libselinux-python
   - build-tools

--- a/metron-deployment/roles/yaf/meta/main.yml
+++ b/metron-deployment/roles/yaf/meta/main.yml
@@ -16,7 +16,6 @@
 #
 ---
 dependencies:
-  - ambari_gather_facts
   - build-tools
   - java_jdk
   - libselinux-python

--- a/metron-deployment/roles/yaf/tasks/yaf.yml
+++ b/metron-deployment/roles/yaf/tasks/yaf.yml
@@ -50,5 +50,5 @@
   template: src=yaf dest=/etc/init.d/yaf mode=0755
 
 - name: Register the service with systemd
-  shell: systemctl enable pcap-replay
+  shell: systemctl enable yaf
   when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"


### PR DESCRIPTION
This was tested in the following ways:

## Regression Testing ##
- [X] Full Dev - Worked as expected 
- [X] EC2 - Worked as expected

## Functional Testing ##
- [X] Run on docker HDP instance from [docker-ambari](https://github.com/sequenceiq/docker-ambari) Note: used custom (dlyle65535/ambari-agent:2.4.0.0-1130-jdk8 and dlyle65535/ambari-server:2.4.0.0-1130-jdk8)
 
## Steps to Stand-Alone Test ##
**Note:** 
You'll need docker.py installed and Ansible > 2, we still recommend 2.0.0.2.
Ansible will error without docker.py installed and give you a chance to:
```
pip install 'docker-py>=1.7.0'
```
### Provision Container ###
Start the container: 
``` 
docker run -d --hostname amb-server --privileged --name amb-server -it dlyle65535/ambari-server:2.4.0.0-1130-jdk8
```
Run a shell on the container: 
```
docker exec -it amb-server bash
```
Change nameserver to 8.8.8.8 (change to nameserver 8.8.8.8, delete 2nd line)
```
vi /etc/resolv.conf
```
Get HDP repo:
```
wget -nv http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.4.2.0/hdp.repo -O /etc/yum.repos.d/hdp.repo
```

Install Zookeeper:
```
yum install -y zookeeper-server
```
Setup and Start Zookeeper:
```
export ZOOKEEPER_CONF_DIR=/etc/zookeeper/conf
export ZOOKEEPER_HOME=/usr/hdp/current/zookeeper-server
export ZOO_LOG_DIR=/var/log/zookeeper
export ZOOPIDFILE=/var/run/zookeeper/zookeeper_server.pid
export SERVER_JVMFLAGS=-Xmx1024m
export JAVA=$JAVA_HOME/bin/java
export CLASSPATH=$CLASSPATH:$ZOOKEEPER_HOME/*
export ZOOCFGDIR=$ZOOKEEPER_CONF_DIR
export ZOOCFG=zoo.cfg
source $ZOOKEEPER_CONF_DIR/zookeeper-env.sh
/usr/hdp/current/zookeeper-server/bin/zkServer.sh start
```
Test Zookeeper:
```
/usr/hdp/current/zookeeper-server/bin/zkCli.sh -server localhost:2181 ls /
```

The command should return:
> Connecting to localhost:2181
> 
> WATCHER::
> 
> WatchedEvent state:SyncConnected type:None path:null
> [zookeeper]
> 

Install and Start Kafka:
``` 
yum install -y kafka
/usr/hdp/current/kafka-broker/bin/kafka start
```

Test Kafka:

```
/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --zookeeper localhost:2181 --create --topic test --replication-factor 1 --partitions 1
/usr/hdp/current/kafka-broker/bin/kafka-console-producer.sh --broker-list localhost:9092 --topic test
```
Add some test data and hit ctrl-c.
```
/usr/hdp/current/kafka-broker//bin/kafka-console-consumer.sh --zookeeper localhost:2181 --topic test --from-beginning
```
You should see your test data - ctrl-c to exit.

Create Probe Data Topics:
```
/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --zookeeper localhost:2181 --create --topic bro --replication-factor 1 --partitions 1
/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --zookeeper localhost:2181 --create --topic snort --replication-factor 1 --partitions 1
/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --zookeeper localhost:2181 --create --topic yaf --replication-factor 1 --partitions 1
```
Exit Container Shell:
```
exit
```
Install Probes using Ansible:
1. cd <metron-home>/metron-deployment/playbooks
2. In playbooks/docker_probe_install.yml change kafka_broker_url to  amb-server:9092 (kafka_broker_url: amb-server:9092)
3. export DOCKER_VERSION=<docker -version> e.g. 1.12.1 (omit any trailing rc stuff)
ansible-playbook docker_probe_install.yml
4. run ansible-playbook
```
ansible-playbook docker_probe_install.yml
```
It should complete with:

> PLAY RECAP *********************************************************************
> amb-server                 : ok=100  changed=60   unreachable=0    failed=0
> localhost                  : ok=2    changed=0    unreachable=0    failed=0
> docker exec -it amb-server bash

Start Sensor Probes:
```
service pcap-replay start
/usr/local/bro/bin/broctl start
service yaf start
service snortd start
/usr/hdp/current/flume-server/bin/flume-ng agent -f /etc/flume/conf/flume-snort.conf -n snort > /dev/null 2>&1 &
```
Check for Data
```
/usr/hdp/current/kafka-broker/bin/kafka-console-consumer.sh --zookeeper localhost:2181 --from-beginning --topic bro
/usr/hdp/current/kafka-broker/bin/kafka-console-consumer.sh --zookeeper localhost:2181 --from-beginning --topic snort
/usr/hdp/current/kafka-broker/bin/kafka-console-consumer.sh --zookeeper localhost:2181 --from-beginning --topic yaf
```