### PR TITLE
METRON-401 ParseException Thrown by ThreatIntelJoinBolt

### DIFF
--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/ThreatIntelJoinBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/ThreatIntelJoinBolt.java
@@ -40,10 +40,10 @@ import java.util.Map;
 
 public class ThreatIntelJoinBolt extends EnrichmentJoinBolt {
 
-  protected static final Logger LOG = LoggerFactory
-          .getLogger(ThreatIntelJoinBolt.class);
+  protected static final Logger LOG = LoggerFactory.getLogger(ThreatIntelJoinBolt.class);
   private FunctionResolver functionResolver;
   private org.apache.metron.common.dsl.Context stellarContext;
+
   public ThreatIntelJoinBolt(String zookeeperUrl) {
     super(zookeeperUrl);
   }
@@ -73,6 +73,7 @@ public class ThreatIntelJoinBolt extends EnrichmentJoinBolt {
     this.stellarContext = new Context.Builder()
                                 .with(Context.Capabilities.ZOOKEEPER_CLIENT, () -> client)
                                 .build();
+    this.functionResolver = StellarFunctions.FUNCTION_RESOLVER();
   }
 
   @Override

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/threatintel/triage/ThreatTriageTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/threatintel/triage/ThreatTriageTest.java
@@ -20,7 +20,6 @@ package org.apache.metron.threatintel.triage;
 
 import org.adrianwalker.multilinestring.Multiline;
 import org.apache.metron.common.configuration.enrichment.SensorEnrichmentConfig;
-import org.apache.metron.common.configuration.enrichment.threatintel.ThreatTriageConfig;
 import org.apache.metron.common.dsl.Context;
 import org.apache.metron.common.dsl.StellarFunctions;
 import org.apache.metron.common.utils.JSONUtils;
@@ -32,96 +31,99 @@ import java.util.HashMap;
 
 public class ThreatTriageTest {
   /**
-   {
-    "threatIntel" : {
-      "triageConfig" :
-      {
-        "riskLevelRules" : {
-            "user.type in [ 'admin', 'power' ] and asset.type == 'web'" : 10
-           ,"asset.type == 'web'" : 5
-          ,"user.type == 'normal'  and asset.type == 'web'" : 0
-          ,"user.type in whitelist" : -1
-                          }
-        ,"aggregator" : "MAX"
-      },
-      "config" : {
-        "whitelist" : [ "abnormal" ]
-                 }
-    }
-   }
+   * {
+   *  "threatIntel": {
+   *    "triageConfig": {
+   *      "riskLevelRules" : {
+   *        "user.type in [ 'admin', 'power' ] and asset.type == 'web'" : 10,
+   *        "asset.type == 'web'" : 5,
+   *        "user.type == 'normal'  and asset.type == 'web'" : 0,
+   *        "user.type in whitelist" : -1
+   *      },
+   *      "aggregator" : "MAX"
+   *    },
+   *    "config": {
+   *      "whitelist": [ "abnormal" ]
+   *    }
+   *  }
+   * }
    */
   @Multiline
   public static String smokeTestProcessorConfig;
 
-  private static ThreatTriageProcessor getProcessor(String config) throws IOException {
-    SensorEnrichmentConfig c = JSONUtils.INSTANCE.load(config, SensorEnrichmentConfig.class);
-    return new ThreatTriageProcessor(c, StellarFunctions.FUNCTION_RESOLVER(), Context.EMPTY_CONTEXT());
-  }
-
   @Test
   public void smokeTest() throws Exception {
     ThreatTriageProcessor threatTriageProcessor = getProcessor(smokeTestProcessorConfig);
-    Assert.assertEquals("Expected a score of 0"
-                       , 0d
-                       ,new ThreatTriageProcessor(new SensorEnrichmentConfig(), StellarFunctions.FUNCTION_RESOLVER(), Context.EMPTY_CONTEXT()).apply(new HashMap<Object, Object>() {{
-                          put("user.type", "admin");
-                          put("asset.type", "web");
-                                        }}
-                                        )
-                       , 1e-10
-                       );
-    Assert.assertEquals("Expected a score of 10"
-                       , 10d
-                       , threatTriageProcessor.apply(new HashMap<Object, Object>() {{
-                          put("user.type", "admin");
-                          put("asset.type", "web");
-                                        }}
-                                        )
-                       , 1e-10
-                       );
-    Assert.assertEquals("Expected a score of 5"
-                       , 5d
-                       , threatTriageProcessor.apply(new HashMap<Object, Object>() {{
-                          put("user.type", "normal");
-                          put("asset.type", "web");
-                                        }}
-                                        )
-                       , 1e-10
-                       );
-    Assert.assertEquals("Expected a score of 0"
-                       , 0d
-                       , threatTriageProcessor.apply(new HashMap<Object, Object>() {{
-                          put("user.type", "foo");
-                          put("asset.type", "bar");
-                                        }}
-                                        )
-                       , 1e-10
-                       );
-    Assert.assertEquals("Expected a score of -Inf"
-                       , Double.NEGATIVE_INFINITY
-                       , threatTriageProcessor.apply(new HashMap<Object, Object>() {{
-                          put("user.type", "abnormal");
-                          put("asset.type", "bar");
-                                        }}
-                                        )
-                       , 1e-10
-                       );
+
+    Assert.assertEquals(
+            "Expected a score of 0",
+            0d,
+            new ThreatTriageProcessor(
+                    new SensorEnrichmentConfig(),
+                    StellarFunctions.FUNCTION_RESOLVER(),
+                    Context.EMPTY_CONTEXT()).apply(
+                            new HashMap<Object, Object>() {{
+                              put("user.type", "admin");
+                              put("asset.type", "web");
+                            }}),
+            1e-10);
+
+    Assert.assertEquals(
+            "Expected a score of 10",
+            10d,
+            threatTriageProcessor.apply(
+                    new HashMap<Object, Object>() {{
+                      put("user.type", "admin");
+                      put("asset.type", "web");
+                    }}
+            ),
+            1e-10);
+
+    Assert.assertEquals(
+            "Expected a score of 5",
+            5d,
+            threatTriageProcessor.apply(
+                    new HashMap<Object, Object>() {{
+                      put("user.type", "normal");
+                      put("asset.type", "web");
+                    }}
+            ),
+            1e-10);
+
+    Assert.assertEquals(
+            "Expected a score of 0",
+            0d,
+            threatTriageProcessor.apply(
+                    new HashMap<Object, Object>() {{
+                      put("user.type", "foo");
+                      put("asset.type", "bar");
+                    }}),
+            1e-10);
+
+    Assert.assertEquals(
+            "Expected a score of -Inf",
+            Double.NEGATIVE_INFINITY,
+            threatTriageProcessor.apply(
+                    new HashMap<Object, Object>() {{
+                      put("user.type", "abnormal");
+                      put("asset.type", "bar");
+                    }}),
+            1e-10);
   }
 
   /**
-   {
-    "threatIntel" : {
-      "triageConfig" :
-      {
-        "riskLevelRules" : {
-            "user.type in [ 'admin', 'power' ] and asset.type == 'web'" : 10
-           ,"asset.type == 'web'" : 5
-           ,"user.type == 'normal'  and asset.type == 'web'" : 0
-                          }
-        ,"aggregator" : "POSITIVE_MEAN"
-      }
-                   }
-   }
+   * {
+   *  "threatIntel": {
+   *  "triageConfig": {
+   *    "riskLevelRules" : {
+   *      "user.type in [ 'admin', 'power' ] and asset.type == 'web'" : 10,
+   *      "asset.type == 'web'" : 5,
+   *      "user.type == 'normal' and asset.type == 'web'" : 0
+   *     },
+   *     "aggregator" : "POSITIVE_MEAN"
+   *    }
+   *  }
+   * }
    */
   @Multiline
   public static String positiveMeanProcessorConfig;
@@ -130,33 +132,66 @@ public class ThreatTriageTest {
   public void positiveMeanAggregationTest() throws Exception {
 
     ThreatTriageProcessor threatTriageProcessor = getProcessor(positiveMeanProcessorConfig);
-    Assert.assertEquals("Expected a score of 0"
-                       , 5d
-                       , threatTriageProcessor.apply(new HashMap<Object, Object>() {{
-                          put("user.type", "normal");
-                          put("asset.type", "web");
-                                        }}
-                                        )
-                       , 1e-10
-                       );
-    Assert.assertEquals("Expected a score of 7.5"
-                       , (10 + 5)/2.0
-                       , threatTriageProcessor.apply(new HashMap<Object, Object>() {{
-                          put("user.type", "admin");
-                          put("asset.type", "web");
-                                        }}
-                                        )
-                       , 1e-10
-                       );
+    Assert.assertEquals(
+            "Expected a score of 0",
+            5d,
+            threatTriageProcessor.apply(
+                    new HashMap<Object, Object>() {{
+                      put("user.type", "normal");
+                      put("asset.type", "web");
+                    }}),
+            1e-10);
 
-    Assert.assertEquals("Expected a score of 0"
-                       , 0d
-                       , threatTriageProcessor.apply(new HashMap<Object, Object>() {{
-                          put("user.type", "foo");
-                          put("asset.type", "bar");
-                                        }}
-                                        )
-                       , 1e-10
-                       );
+    Assert.assertEquals(
+            "Expected a score of 7.5",
+            (10 + 5)/2.0,
+            threatTriageProcessor.apply(
+                    new HashMap<Object, Object>() {{
+                      put("user.type", "admin");
+                      put("asset.type", "web");
+                    }}),
+            1e-10);
+
+    Assert.assertEquals(
+            "Expected a score of 0",
+            0d,
+            threatTriageProcessor.apply(
+                    new HashMap<Object, Object>() {{
+                      put("user.type", "foo");
+                      put("asset.type", "bar");
+                    }}),
+            1e-10);
+  }
+
+  /**
+   * {
+   *    "threatIntel" : {
+   *      "triageConfig": {
+   *        "riskLevelRules": {
+   *          "not(IN_SUBNET(ip_dst_addr, '192.168.0.0/24'))" : 10
+   *        },
+   *        "aggregator" : "MAX"
+   *      }
+   *    }
+   * }
+   */
+  @Multiline
+  private static String testWithStellarFunction;
+
+  @Test
+  public void testWithStellarFunction() throws Exception {
+    ThreatTriageProcessor threatTriageProcessor = getProcessor(testWithStellarFunction);
+    Assert.assertEquals(
+            10d,
+            threatTriageProcessor.apply(
+                    new HashMap<Object, Object>() {{
+                      put("ip_dst_addr", "172.2.2.2");
+                    }}),
+            1e-10);
+  }
+
+  private static ThreatTriageProcessor getProcessor(String config) throws IOException {
+    SensorEnrichmentConfig c = JSONUtils.INSTANCE.load(config, SensorEnrichmentConfig.class);
+    return new ThreatTriageProcessor(c, StellarFunctions.FUNCTION_RESOLVER(), Context.EMPTY_CONTEXT());
   }
 }


### PR DESCRIPTION
If the configuration for the ThreatIntelJoinBolt used any Stellar code that called a function, the following error occured.

```
org.apache.metron.common.dsl.ParseException: Unable to find string function IN_SUBNET.  Valid functions are...
```

The `FunctionResolver` used by the `ThreatIntelJoinBolt` was not being initialized.  If the configuration included any function calls, the functions could not be resolved and a ParseException was thrown.  

Configuration containing Stellar code that does not call any functions was not impacted.  This is why the existing unit and functional tests did not catch this.  Updated the unit tests to validate the fix.