### PR TITLE
METRON-391 Create Stellar Function to Read Profile Data for Model Scoring

### DIFF
--- a/metron-analytics/metron-profiler-client/src/main/java/org/apache/metron/profiler/client/stellar/GetProfile.java
+++ b/metron-analytics/metron-profiler-client/src/main/java/org/apache/metron/profiler/client/stellar/GetProfile.java
@@ -1,0 +1,179 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.metron.profiler.client.stellar;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.metron.common.dsl.Context;
+import org.apache.metron.common.dsl.ParseException;
+import org.apache.metron.common.dsl.Stellar;
+import org.apache.metron.common.dsl.StellarFunction;
+import org.apache.metron.common.utils.ConversionUtils;
+import org.apache.metron.profiler.client.HBaseProfilerClient;
+import org.apache.metron.profiler.client.ProfilerClient;
+import org.apache.metron.profiler.hbase.ColumnBuilder;
+import org.apache.metron.profiler.hbase.RowKeyBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static org.apache.metron.common.dsl.Context.Capabilities.PROFILER_COLUMN_BUILDER;
+import static org.apache.metron.common.dsl.Context.Capabilities.PROFILER_HBASE_TABLE;
+import static org.apache.metron.common.dsl.Context.Capabilities.PROFILER_ROW_KEY_BUILDER;
+
+/**
+ * A Stellar function that can retrieve data contained within a Profile.
+ *
+ *  PROFILE_GET
+ *
+ * Retrieve all values for 'entity1' from 'profile1' over the past 4 hours.
+ *
+ *   <code>PROFILE_GET('profile1', 'entity1', 4, 'HOURS')</code>
+ *
+ * Retrieve all values for 'entity1' from 'profile1' over the past 2 days.
+ *
+ *   <code>PROFILE_GET('profile1', 'entity1', 2, 'DAYS')</code>
+ *
+ * Retrieve all values for 'entity1' from 'profile1' that occurred on 'weekdays' over the past month.
+ *
+ *   <code>PROFILE_GET('profile1', 'entity1', 1, 'MONTHS', 'weekdays')</code>
+ *
+ */
+@Stellar(
+        namespace="PROFILE",
+        name="GET",
+        description="Retrieves a series of values from a stored profile.",
+        params={
+          "profile - The name of the profile.",
+          "entity - The name of the entity.",
+          "durationAgo - How long ago should values be retrieved from?",
+          "units - The units of 'durationAgo'.",
+          "groups - Optional - The groups used to sort the profile."
+        },
+        returns="The profile measurements."
+)
+public class GetProfile implements StellarFunction {
+
+  private ProfilerClient client;
+
+  /**
+   * Initialization.
+   */
+  @Override
+  public void initialize(Context context) {
+
+    Context.Capabilities[] required = { PROFILER_HBASE_TABLE, PROFILER_ROW_KEY_BUILDER, PROFILER_COLUMN_BUILDER };
+    validateContext(context, required);
+
+    HTableInterface table = (HTableInterface) context.getCapability(PROFILER_HBASE_TABLE).get();
+    RowKeyBuilder rowKeyBuilder = (RowKeyBuilder) context.getCapability(PROFILER_ROW_KEY_BUILDER).get();
+    ColumnBuilder columnBuilder = (ColumnBuilder) context.getCapability(PROFILER_COLUMN_BUILDER).get();
+
+    client = new HBaseProfilerClient(table, rowKeyBuilder, columnBuilder);
+  }
+
+  /**
+   * Is the function initialized?
+   */
+  @Override
+  public boolean isInitialized() {
+    return client != null;
+  }
+
+  /**
+   * Apply the function.
+   * @param args The function arguments.
+   * @param context
+   */
+  @Override
+  public Object apply(List<Object> args, Context context) throws ParseException {
+
+    String profile = getArg(0, String.class, args);
+    String entity = getArg(1, String.class, args);
+    long durationAgo = getArg(2, Long.class, args);
+    String unitsName = getArg(3, String.class, args);
+    TimeUnit units = TimeUnit.valueOf(unitsName);
+    List<Object> groups = getGroupsArg(4, args);
+
+    return client.fetch(profile, entity, durationAgo, units, Integer.class, groups);
+  }
+
+  /**
+   * Get the groups defined by the user.
+   *
+   * The user can specify 0 or more groups.  All arguments from the specified position
+   * on are assumed to be groups.  If there is no argument in the specified position,
+   * then it is assumed the user did not specify any groups.
+   *
+   * @param startIndex The starting index of groups within the function argument list.
+   * @param args The function arguments.
+   * @return The groups.
+   */
+  private List<Object> getGroupsArg(int startIndex, List<Object> args) {
+    List<Object> groups = new ArrayList<>();
+
+    for(int i=startIndex; i<args.size(); i++) {
+      String group = getArg(i, String.class, args);
+      groups.add(group);
+    }
+
+    return groups;
+  }
+
+  /**
+   * Ensure that the context has all of the required capabilities.
+   * @param context The context to validate.
+   * @param required The required capabilities.
+   * @throws IllegalStateException if all of the required capabilities are not present in the Context.
+   */
+  private void validateContext(Context context, Context.Capabilities[] required) throws IllegalStateException {
+
+    // ensure that the required configuration is available
+    String missing = Stream
+            .of(required)
+            .filter(c -> !context.getCapability(c).isPresent())
+            .map(c -> c.toString())
+            .collect(Collectors.joining(", "));
+
+    if(StringUtils.isNotBlank(missing) || context == null) {
+      throw new IllegalStateException("missing required context: " + missing);
+    }
+  }
+
+  /**
+   * Get an argument from a list of arguments.
+   * @param index The index within the list of arguments.
+   * @param clazz The type expected.
+   * @param args All of the arguments.
+   * @param <T> The type of the argument expected.
+   */
+  private <T> T getArg(int index, Class<T> clazz, List<Object> args) {
+    if(index >= args.size()) {
+      throw new IllegalArgumentException(format("expected at least %d argument(s), found %d", index+1, args.size()));
+    }
+
+    return ConversionUtils.convert(args.get(index), clazz);
+  }
+}

--- a/metron-analytics/metron-profiler-client/src/test/java/org/apache/metron/profiler/client/GetProfileTest.java
+++ b/metron-analytics/metron-profiler-client/src/test/java/org/apache/metron/profiler/client/GetProfileTest.java
@@ -1,0 +1,211 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.metron.profiler.client;
+
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.metron.common.dsl.Context;
+import org.apache.metron.common.dsl.FunctionResolverSingleton;
+import org.apache.metron.common.dsl.ParseException;
+import org.apache.metron.profiler.ProfileMeasurement;
+import org.apache.metron.profiler.hbase.ColumnBuilder;
+import org.apache.metron.profiler.hbase.RowKeyBuilder;
+import org.apache.metron.profiler.hbase.SaltyRowKeyBuilder;
+import org.apache.metron.profiler.hbase.ValueOnlyColumnBuilder;
+import org.apache.metron.profiler.stellar.DefaultStellarExecutor;
+import org.apache.metron.profiler.stellar.StellarExecutor;
+import org.apache.metron.test.mock.MockHTable;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.metron.common.dsl.Context.Capabilities.PROFILER_HBASE_TABLE;
+import static org.apache.metron.common.dsl.Context.Capabilities.PROFILER_ROW_KEY_BUILDER;
+import static org.apache.metron.common.dsl.Context.Capabilities.PROFILER_COLUMN_BUILDER;
+
+/**
+ * Tests the GetProfile class.
+ */
+public class GetProfileTest {
+
+  private static final String tableName = "profiler";
+  private static final String columnFamily = "P";
+  private StellarExecutor executor;
+  private Map<String, Object> state;
+  private ProfileWriter profileWriter;
+
+  private <T> T run(String expression, Class<T> clazz) {
+    return executor.execute(expression, state, clazz);
+  }
+
+  @Before
+  public void setup() {
+    state = new HashMap<>();
+    final HTableInterface table = new MockHTable(tableName, columnFamily);
+
+    // used to write values to be read during testing
+    RowKeyBuilder rowKeyBuilder = new SaltyRowKeyBuilder();
+    ColumnBuilder columnBuilder = new ValueOnlyColumnBuilder(columnFamily);
+    profileWriter = new ProfileWriter(rowKeyBuilder, columnBuilder, table);
+
+    // create the necessary context used during initialization
+    Context context = new Context.Builder()
+            .with(PROFILER_ROW_KEY_BUILDER, () -> new SaltyRowKeyBuilder())
+            .with(PROFILER_COLUMN_BUILDER, () -> new ValueOnlyColumnBuilder(columnFamily))
+            .with(PROFILER_HBASE_TABLE, () -> table)
+            .build();
+
+    executor = new DefaultStellarExecutor();
+    executor.setContext(context);
+
+    // force re-initialization before each test
+    FunctionResolverSingleton.getInstance().reset();
+  }
+
+  /**
+   * Values should be retrievable that have NOT been stored within a group.
+   */
+  @Test
+  public void testWithNoGroups() {
+    final int periodsPerHour = 4;
+    final int expectedValue = 2302;
+    final int hours = 2;
+    final long startTime = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(hours);
+    final List<Object> group = Collections.emptyList();
+
+    // setup - write some measurements to be read later
+    final int count = hours * periodsPerHour;
+    ProfileMeasurement m = new ProfileMeasurement("profile1", "entity1", startTime, periodsPerHour);
+    profileWriter.write(m, count, group, val -> expectedValue);
+
+    // execute - read the profile values - no groups
+    String expr = "PROFILE_GET('profile1', 'entity1', 4, 'HOURS')";
+    List<Integer> result = run(expr, List.class);
+
+    // validate - expect to read all values from the past 4 hours
+    Assert.assertEquals(count, result.size());
+  }
+
+  /**
+   * Values should be retrievable that have been stored within a 'group'.
+   */
+  @Test
+  public void testWithOneGroup() {
+    final int periodsPerHour = 4;
+    final int expectedValue = 2302;
+    final int hours = 2;
+    final long startTime = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(hours);
+    final List<Object> group = Arrays.asList("weekends");
+
+    // setup - write some measurements to be read later
+    final int count = hours * periodsPerHour;
+    ProfileMeasurement m = new ProfileMeasurement("profile1", "entity1", startTime, periodsPerHour);
+    profileWriter.write(m, count, group, val -> expectedValue);
+
+    // create a variable that contains the groups to use
+    state.put("groups", group);
+
+    // execute - read the profile values
+    String expr = "PROFILE_GET('profile1', 'entity1', 4, 'HOURS', 'weekends')";
+    List<Integer> result = run(expr, List.class);
+
+    // validate - expect to read all values from the past 4 hours
+    Assert.assertEquals(count, result.size());
+  }
+
+  /**
+   * Values should be retrievable that have been stored within a 'group'.
+   */
+  @Test
+  public void testWithTwoGroups() {
+    final int periodsPerHour = 4;
+    final int expectedValue = 2302;
+    final int hours = 2;
+    final long startTime = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(hours);
+    final List<Object> group = Arrays.asList("weekdays", "tuesday");
+
+    // setup - write some measurements to be read later
+    final int count = hours * periodsPerHour;
+    ProfileMeasurement m = new ProfileMeasurement("profile1", "entity1", startTime, periodsPerHour);
+    profileWriter.write(m, count, group, val -> expectedValue);
+
+    // create a variable that contains the groups to use
+    state.put("groups", group);
+
+    // execute - read the profile values
+    String expr = "PROFILE_GET('profile1', 'entity1', 4, 'HOURS', 'weekdays', 'tuesday')";
+    List<Integer> result = run(expr, List.class);
+
+    // validate - expect to read all values from the past 4 hours
+    Assert.assertEquals(count, result.size());
+  }
+
+  /**
+   * Initialization should fail if the required context values are missing.
+   */
+  @Test(expected = ParseException.class)
+  public void testMissingContext() {
+    Context empty = Context.EMPTY_CONTEXT();
+
+    // 'unset' the context that was created during setup()
+    executor.setContext(empty);
+
+    // force re-initialization with no context
+    FunctionResolverSingleton.getInstance().initialize(empty);
+
+    // validate - function should be unable to initialize
+    String expr = "PROFILE_GET('profile1', 'entity1', 1000, 'SECONDS', groups)";
+    run(expr, List.class);
+  }
+
+  /**
+   * If the time horizon specified does not include any profile measurements, then
+   * none should be returned.
+   */
+  @Test
+  public void testOutsideTimeHorizon() {
+    final int periodsPerHour = 4;
+    final int expectedValue = 2302;
+    final int hours = 2;
+    final long startTime = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(hours);
+    final List<Object> group = Collections.emptyList();
+
+    // setup - write a single value from 2 hours ago
+    ProfileMeasurement m = new ProfileMeasurement("profile1", "entity1", startTime, periodsPerHour);
+    profileWriter.write(m, 1, group, val -> expectedValue);
+
+    // create a variable that contains the groups to use
+    state.put("groups", group);
+
+    // execute - read the profile values
+    String expr = "PROFILE_GET('profile1', 'entity1', 4, 'SECONDS')";
+    List<Integer> result = run(expr, List.class);
+
+    // validate - there should be no values from only 4 seconds ago
+    Assert.assertEquals(0, result.size());
+  }
+}

--- a/metron-analytics/metron-profiler-client/src/test/java/org/apache/metron/profiler/client/ProfileWriter.java
+++ b/metron-analytics/metron-profiler-client/src/test/java/org/apache/metron/profiler/client/ProfileWriter.java
@@ -1,0 +1,97 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.metron.profiler.client;
+
+import org.apache.hadoop.hbase.client.Durability;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.metron.hbase.client.HBaseClient;
+import org.apache.metron.profiler.ProfileMeasurement;
+import org.apache.metron.profiler.ProfilePeriod;
+import org.apache.metron.profiler.hbase.ColumnBuilder;
+import org.apache.metron.profiler.hbase.RowKeyBuilder;
+import org.apache.storm.hbase.common.ColumnList;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Writes ProfileMeasurement values that can be read during automated testing.
+ */
+public class ProfileWriter {
+
+  private RowKeyBuilder rowKeyBuilder;
+  private ColumnBuilder columnBuilder;
+  private HBaseClient hbaseClient;
+  private HBaseProfilerClient client;
+
+  public ProfileWriter(RowKeyBuilder rowKeyBuilder, ColumnBuilder columnBuilder, HTableInterface table) {
+    this.rowKeyBuilder = rowKeyBuilder;
+    this.columnBuilder = columnBuilder;
+    this.hbaseClient = new HBaseClient((c, t) -> table, table.getConfiguration(), table.getName().getNameAsString());
+    this.client = new HBaseProfilerClient(table, rowKeyBuilder, columnBuilder);
+  }
+
+  /**
+   * Writes profile measurements that can be used for testing.
+   *
+   * @param prototype      A prototype for the types of ProfileMeasurements that should be written.
+   * @param count          The number of profile measurements to write.
+   * @param group          The name of the group.
+   * @param valueGenerator A function that consumes the previous ProfileMeasurement value and produces the next.
+   */
+  public void write(ProfileMeasurement prototype, int count, List<Object> group, Function<Object, Object> valueGenerator) {
+
+    ProfileMeasurement m = prototype;
+    for(int i=0; i<count; i++) {
+
+      // create a measurement for the next profile period to be written
+      ProfilePeriod next = m.getPeriod().next();
+      m = new ProfileMeasurement(
+              prototype.getProfileName(),
+              prototype.getEntity(),
+              next.getTimeInMillis(),
+              prototype.getPeriodsPerHour());
+
+      // generate the next value that should be written
+      Object nextValue = valueGenerator.apply(m.getValue());
+      m.setValue(nextValue);
+
+      // write the measurement
+      write(m, group);
+    }
+  }
+
+  /**
+   * Write a ProfileMeasurement.
+   * @param m The ProfileMeasurement to write.
+   * @param groups The groups to use when writing the ProfileMeasurement.
+   */
+  private void write(ProfileMeasurement m, List<Object> groups) {
+
+    byte[] rowKey = rowKeyBuilder.rowKey(m, groups);
+    ColumnList cols = columnBuilder.columns(m);
+
+    List<Mutation> mutations = hbaseClient.constructMutationReq(rowKey, cols, Durability.SKIP_WAL);
+    hbaseClient.batchMutate(mutations);
+  }
+
+}

--- a/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/ProfileMeasurement.java
+++ b/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/ProfileMeasurement.java
@@ -51,6 +51,11 @@ public class ProfileMeasurement {
   private List<String> groupBy;
 
   /**
+   * The number of profile periods per hour.
+   */
+  private int periodsPerHour;
+
+  /**
    * The period in which the ProfileMeasurement was taken.
    */
   private ProfilePeriod period;
@@ -64,6 +69,7 @@ public class ProfileMeasurement {
   public ProfileMeasurement(String profileName, String entity, long epochMillis, int periodsPerHour) {
     this.profileName = profileName;
     this.entity = entity;
+    this.periodsPerHour = periodsPerHour;
     this.period = new ProfilePeriod(epochMillis, periodsPerHour);
   }
 
@@ -95,13 +101,17 @@ public class ProfileMeasurement {
     this.groupBy = groupBy;
   }
 
+  public int getPeriodsPerHour() {
+    return periodsPerHour;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
     ProfileMeasurement that = (ProfileMeasurement) o;
-
+    if (periodsPerHour != that.periodsPerHour) return false;
     if (profileName != null ? !profileName.equals(that.profileName) : that.profileName != null) return false;
     if (entity != null ? !entity.equals(that.entity) : that.entity != null) return false;
     if (value != null ? !value.equals(that.value) : that.value != null) return false;
@@ -116,6 +126,7 @@ public class ProfileMeasurement {
     result = 31 * result + (entity != null ? entity.hashCode() : 0);
     result = 31 * result + (value != null ? value.hashCode() : 0);
     result = 31 * result + (groupBy != null ? groupBy.hashCode() : 0);
+    result = 31 * result + periodsPerHour;
     result = 31 * result + (period != null ? period.hashCode() : 0);
     return result;
   }
@@ -127,6 +138,7 @@ public class ProfileMeasurement {
             ", entity='" + entity + '\'' +
             ", value=" + value +
             ", groupBy=" + groupBy +
+            ", periodsPerHour=" + periodsPerHour +
             ", period=" + period +
             '}';
   }

--- a/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileBuilderBolt.java
+++ b/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileBuilderBolt.java
@@ -112,6 +112,7 @@ public class ProfileBuilderBolt extends ConfiguredProfilerBolt {
   protected void initializeStellar() {
     Context context = new Context.Builder()
             .with(Context.Capabilities.ZOOKEEPER_CLIENT, () -> client)
+            .with(Context.Capabilities.GLOBAL_CONFIG, () -> getConfigurations().getGlobalConfig())
             .build();
     StellarFunctions.initialize(context);
     executor.setContext(context);

--- a/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileSplitterBolt.java
+++ b/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileSplitterBolt.java
@@ -82,8 +82,9 @@ public class ProfileSplitterBolt extends ConfiguredProfilerBolt {
 
   protected void initializeStellar() {
     Context context = new Context.Builder()
-                         .with(Context.Capabilities.ZOOKEEPER_CLIENT, () -> client)
-                         .build();
+            .with(Context.Capabilities.ZOOKEEPER_CLIENT, () -> client)
+            .with(Context.Capabilities.GLOBAL_CONFIG, () -> getConfigurations().getGlobalConfig())
+            .build();
     StellarFunctions.initialize(context);
     executor.setContext(context);
   }

--- a/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/stellar/DefaultStellarExecutor.java
+++ b/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/stellar/DefaultStellarExecutor.java
@@ -21,6 +21,7 @@
 package org.apache.metron.profiler.stellar;
 
 import org.apache.metron.common.dsl.Context;
+import org.apache.metron.common.dsl.FunctionResolver;
 import org.apache.metron.common.dsl.MapVariableResolver;
 import org.apache.metron.common.dsl.ParseException;
 import org.apache.metron.common.dsl.StellarFunctions;
@@ -44,7 +45,7 @@ public class DefaultStellarExecutor implements StellarExecutor, Serializable {
 
   /**
    * Provides additional context for initializing certain Stellar functions.  For
-   * example, references to find Zookeeper or HBase.
+   * example, references to Zookeeper or HBase.
    */
   private Context context;
 
@@ -61,41 +62,50 @@ public class DefaultStellarExecutor implements StellarExecutor, Serializable {
     this.state = new HashMap<>(initialState);
   }
 
+  /**
+   * The current state of the Stellar execution environment.
+   */
   @Override
   public Map<String, Object> getState() {
     return new HashMap<>(state);
   }
 
   /**
-   * Execute an expression and assign the result to a variable.
+   * Execute an expression and assign the result to a variable.  The variable is maintained
+   * in the context of this executor and is available to all subsequent expressions.
    *
-   * @param variable The variable name to assign to.
-   * @param expression The expression to execute.
-   * @param message The message that provides additional context for the expression.
+   * @param variable       The name of the variable to assign to.
+   * @param expression     The expression to execute.
+   * @param transientState Additional state available to the expression.  This most often represents
+   *                       the values available to the expression from an individual message. The state
+   *                       maps a variable name to a variable's value.
    */
   @Override
-  public void assign(String variable, String expression, Map<String, Object> message) {
-    Object result = execute(expression, message);
+  public void assign(String variable, String expression, Map<String, Object> transientState) {
+    Object result = execute(expression, transientState);
     state.put(variable, result);
   }
 
   /**
-   * Execute a Stellar expression and returns the result.
+   * Execute a Stellar expression and return the result.  The internal state of the executor
+   * is not modified.
    *
-   * @param expr The expression to execute.
-   * @param message The message that is accessible when Stellar is executed.
-   * @param clazz The expected class of the expression's result.
-   * @param <T> The expected class of the expression's result.
+   * @param expression The expression to execute.
+   * @param state      Additional state available to the expression.  This most often represents
+   *                   the values available to the expression from an individual message. The state
+   *                   maps a variable name to a variable's value.
+   * @param clazz      The expected type of the expression's result.
+   * @param <T>        The expected type of the expression's result.
    */
   @Override
-  public <T> T execute(String expr, Map<String, Object> message, Class<T> clazz) {
-    Object resultObject = execute(expr, message);
+  public <T> T execute(String expression, Map<String, Object> state, Class<T> clazz) {
+    Object resultObject = execute(expression, state);
 
     // perform type conversion, if necessary
     T result = ConversionUtils.convert(resultObject, clazz);
-    if(result == null) {
+    if (result == null) {
       throw new IllegalArgumentException(String.format("Unexpected type: expected=%s, actual=%s, expression=%s",
-              clazz.getSimpleName(), resultObject.getClass().getSimpleName(), expr));
+              clazz.getSimpleName(), resultObject.getClass().getSimpleName(), expression));
     }
 
     return result;
@@ -109,6 +119,7 @@ public class DefaultStellarExecutor implements StellarExecutor, Serializable {
   /**
    * Sets the Context for the Stellar execution environment.  This provides global data used
    * to initialize Stellar functions.
+   *
    * @param context The Stellar context.
    */
   @Override
@@ -119,17 +130,15 @@ public class DefaultStellarExecutor implements StellarExecutor, Serializable {
   /**
    * Execute a Stellar expression.
    *
-   * @param expr The expression to execute.
-   * @param msg The message that is accessible when Stellar is executed.
+   * @param expression     The expression to execute.
+   * @param transientState Additional state available to the expression.  This most often represents
+   *                       the values available to the expression from an individual message. The state
+   *                       maps a variable name to a variable's value.
    */
-  private Object execute(String expr, Map<String, Object> msg) {
-    try {
-      VariableResolver resolver = new MapVariableResolver(state, msg);
-      StellarProcessor processor = new StellarProcessor();
-      return processor.parse(expr, resolver, StellarFunctions.FUNCTION_RESOLVER(), context);
-
-    } catch (ParseException e) {
-      throw new ParseException(String.format("Bad expression: expr=%s, msg=%s, state=%s", expr, msg, state));
-    }
+  private Object execute(String expression, Map<String, Object> transientState) {
+    FunctionResolver functionResolver = StellarFunctions.FUNCTION_RESOLVER();
+    VariableResolver variableResolver = new MapVariableResolver(state, transientState);
+    StellarProcessor processor = new StellarProcessor();
+    return processor.parse(expression, variableResolver, functionResolver, context);
   }
 }

--- a/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/stellar/StellarExecutor.java
+++ b/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/stellar/StellarExecutor.java
@@ -21,37 +21,38 @@
 package org.apache.metron.profiler.stellar;
 
 import org.apache.metron.common.dsl.Context;
-import org.json.simple.JSONObject;
 
 import java.util.Map;
 
 /**
  * Executes Stellar expressions and maintains state across multiple invocations.
- *
- * There are two sets of functions in Stellar currently.  One can be executed with
- * a PredicateProcessor and the other a TransformationProcessor.  This interface
- * abstracts away that complication.
  */
 public interface StellarExecutor {
 
   /**
-   * Execute an expression and assign the result to a variable.
+   * Execute an expression and assign the result to a variable.  The variable is maintained
+   * in the context of this executor and is available to all subsequent expressions.
    *
-   * @param variable The name of the variable to assign to.
+   * @param variable   The name of the variable to assign to.
    * @param expression The expression to execute.
-   * @param message The message that provides additional context for the expression.
+   * @param state      Additional state available to the expression.  This most often represents
+   *                   the values available to the expression from an individual message. The state
+   *                   maps a variable name to a variable's value.
    */
-  void assign(String variable, String expression, Map<String, Object> message);
+  void assign(String variable, String expression, Map<String, Object> state);
 
   /**
-   * Execute a Stellar expression and return the result.
+   * Execute a Stellar expression and return the result.  The internal state of the executor
+   * is not modified.
    *
    * @param expression The expression to execute.
-   * @param message A map of values, most often the JSON message itself, that is accessible within Stellar.
-   * @param clazz The expected class of the expression's result.
-   * @param <T> The expected class of the expression's result.
+   * @param state      Additional state available to the expression.  This most often represents
+   *                   the values available to the expression from an individual message. The state
+   *                   maps a variable name to a variable's value.
+   * @param clazz      The expected type of the expression's result.
+   * @param <T>        The expected type of the expression's result.
    */
-  <T> T execute(String expression, Map<String, Object> message, Class<T> clazz);
+  <T> T execute(String expression, Map<String, Object> state, Class<T> clazz);
 
   /**
    * The current state of the Stellar execution environment.
@@ -66,6 +67,7 @@ public interface StellarExecutor {
   /**
    * Sets the Context for the Stellar execution environment.  This provides global data used
    * to initialize Stellar functions.
+   *
    * @param context The Stellar context.
    */
   void setContext(Context context);

--- a/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/stellar/DefaultStellarExecutorTest.java
+++ b/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/stellar/DefaultStellarExecutorTest.java
@@ -28,6 +28,11 @@ import org.json.simple.parser.ParseException;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -157,5 +162,19 @@ public class DefaultStellarExecutorTest {
     executor.execute("2", message, Float.class);
     executor.execute("2", message, Short.class);
     executor.execute("2", message, Long.class);
+  }
+
+  /**
+   * The executor must be serializable.
+   */
+  @Test
+  public void testSerializable() throws Exception {
+
+    // serialize
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    new ObjectOutputStream(bytes).writeObject(executor);
+
+    // deserialize - success when no exceptions
+    new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray())).readObject();
   }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/Context.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/Context.java
@@ -32,9 +32,7 @@ public class Context implements Serializable {
     HBASE_PROVIDER,
     ZOOKEEPER_CLIENT,
     SERVICE_DISCOVERER,
-    PROFILER_HBASE_TABLE,
-    PROFILER_ROW_KEY_BUILDER,
-    PROFILER_COLUMN_BUILDER
+    GLOBAL_CONFIG
   }
 
   public static class Builder {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/Context.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/Context.java
@@ -31,7 +31,10 @@ public class Context implements Serializable {
   public enum Capabilities {
     HBASE_PROVIDER,
     ZOOKEEPER_CLIENT,
-    SERVICE_DISCOVERER
+    SERVICE_DISCOVERER,
+    PROFILER_HBASE_TABLE,
+    PROFILER_ROW_KEY_BUILDER,
+    PROFILER_COLUMN_BUILDER
   }
 
   public static class Builder {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/FunctionResolver.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/FunctionResolver.java
@@ -19,8 +19,31 @@ package org.apache.metron.common.dsl;
 
 import java.util.function.Function;
 
+/**
+ * Responsible for function resolution in Stellar.
+ */
 public interface FunctionResolver extends Function<String, StellarFunction> {
+
+  /**
+   * Provides metadata about each Stellar function that is resolvable.
+   */
   Iterable<StellarFunctionInfo> getFunctionInfo();
+
+  /**
+   * The names of all Stellar functions that are resolvable.
+   */
   Iterable<String> getFunctions();
+
+  /**
+   * Initialize the function resolver.
+   * @param context Context used to initialize.
+   */
   void initialize(Context context);
+
+  /**
+   * A 'factory reset' of the function resolver.
+   *
+   * Useful primarily for testing purposes only.
+   */
+  void reset();
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/FunctionResolverSingleton.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/FunctionResolverSingleton.java
@@ -43,22 +43,46 @@ public class FunctionResolverSingleton implements FunctionResolver {
     return INSTANCE;
   }
 
-
-
+  /**
+   * Provides metadata about each Stellar function that is resolvable.
+   */
   @Override
   public Iterable<StellarFunctionInfo> getFunctionInfo() {
     return _getFunctions().values();
   }
 
+  /**
+   * The names of all Stellar functions that are resolvable.
+   */
   @Override
   public Iterable<String> getFunctions() {
     return _getFunctions().keySet();
   }
 
+  /**
+   * Initialize the function resolver.
+   * @param context Context used to initialize.
+   */
   @Override
   public void initialize(Context context) {
     //forces a load of the stellar functions.
     _getFunctions();
+  }
+
+  /**
+   * A 'factory reset' of the function resolver.
+   *
+   * Useful primarily for testing purposes only.
+   */
+  @Override
+  public void reset() {
+    lock.writeLock().lock();
+    try {
+      isInitialized.set(false);
+    }
+    finally {
+      lock.writeLock().unlock();
+    }
   }
 
   /**
@@ -147,8 +171,6 @@ public class FunctionResolverSingleton implements FunctionResolver {
   public static Collection<URL> effectiveClassPathUrls(ClassLoader... classLoaders) {
     return ClasspathHelper.forManifest(ClasspathHelper.forClassLoader(classLoaders));
   }
-
-
 
   private static Map.Entry<String, StellarFunctionInfo> create(Class<? extends StellarFunction> stellarClazz) {
     String fqn = getNameFromAnnotation(stellarClazz);

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/StellarFunctionInfo.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/StellarFunctionInfo.java
@@ -20,12 +20,36 @@ package org.apache.metron.common.dsl;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Describes a Stellar function.
+ */
 public class StellarFunctionInfo {
-  String description;
+
+  /**
+   * The name of the function.
+   */
   String name;
-  String[] params;
-  StellarFunction function;
+
+  /**
+   * A description of the function.  Used for documentation purposes.
+   */
+  String description;
+
+  /**
+   * A description of what the function returns.  Used for documentation purposes.
+   */
   String returns;
+
+  /**
+   * The function parameters.  Used for documentation purposes.
+   */
+  String[] params;
+
+  /**
+   * The actual function that can be executed.
+   */
+  StellarFunction function;
+
   public StellarFunctionInfo(String description, String name, String[] params, String returns, StellarFunction function) {
     this.description = description;
     this.name = name;
@@ -34,7 +58,9 @@ public class StellarFunctionInfo {
     this.returns = returns;
   }
 
-  public String getReturns() { return returns;}
+  public String getReturns() {
+    return returns;
+  }
 
   public String getDescription() {
     return description;
@@ -65,7 +91,6 @@ public class StellarFunctionInfo {
     // Probably incorrect - comparing Object[] arrays with Arrays.equals
     if (!Arrays.equals(getParams(), that.getParams())) return false;
     return getReturns() != null ? getReturns().equals(that.getReturns()) : that.getReturns() == null;
-
   }
 
   @Override

--- a/metron-platform/metron-integration-test/src/main/config/zookeeper/global.json
+++ b/metron-platform/metron-integration-test/src/main/config/zookeeper/global.json
@@ -3,14 +3,20 @@
   "es.ip": "localhost",
   "es.port": 9300,
   "es.date.format": "yyyy.MM.dd.HH",
+
   "solr.zookeeper": "localhost:2181",
   "solr.collection": "metron",
   "solr.numShards": 1,
   "solr.replicationFactor": 1,
+
   "fieldValidations" : [
     {
-       "input" : [ "src_ip_addr", "dst_ip_addr"]
-      ,"validation" : "IP"
+      "input" : [ "src_ip_addr", "dst_ip_addr"],
+      "validation" : "IP"
     }
-                       ]
+  ],
+
+  "profiler.hbase.table": "profiler",
+  "profiler.column.family": "P",
+  "profiler.hbase.table.provider": "org.apache.metron.hbase.HTableProvider"
 }


### PR DESCRIPTION
### [METRON-391](https://issues.apache.org/jira/browse/METRON-391)

A Java API was created as part of #236  to allow Profile data to be read during model scoring. A Stellar function(s) was created that uses this API to read the profile data. This would be used in conjunction with other Stellar functions like MODEL_APPLY.

#### Dependencies
This PR depends on a few other existing PRs that should be merged prior to this one.
- [x] #233 
- [x] #240
- [x] #236 
- [x] #237 

#### Examples

Retrieve all values for 'entity1' from 'profile1' over the past 4 hours.
```
PROFILE_GET('profile1', 'entity1', 4, 'HOURS')
```

Retrieve all values for 'entity1' from 'profile1' over the past 2 days.
```
PROFILE_GET('profile1', 'entity1', 2, 'DAYS')
```

Retrieve all values for 'entity1' from 'profile1' that occurred on 'weekdays' over the past month.
```
PROFILE_GET('profile1', 'entity1', 1, 'MONTHS', 'weekdays')
```


