### PR TITLE
METRON-407: We currently do not provide defaults if the Stix Observable does not specify a condition

### DIFF
--- a/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/extractor/stix/StixExtractor.java
+++ b/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/extractor/stix/StixExtractor.java
@@ -90,7 +90,7 @@ public class StixExtractor implements Extractor {
     }
 
     public static Iterable<String> split(StringObjectPropertyType value) {
-        final ConditionTypeEnum condition = value.getCondition();
+        final ConditionTypeEnum condition = value.getCondition() == null?ConditionTypeEnum.EQUALS:value.getCondition();
         final ConditionApplicationEnum applyCondition = value.getApplyCondition();
         List<String> tokens = new ArrayList<>();
         if(condition == ConditionTypeEnum.EQUALS && applyCondition == ConditionApplicationEnum.ANY) {

--- a/metron-platform/metron-data-management/src/test/java/org/apache/metron/dataloads/extractor/stix/StixExtractorTest.java
+++ b/metron-platform/metron-data-management/src/test/java/org/apache/metron/dataloads/extractor/stix/StixExtractorTest.java
@@ -27,116 +27,179 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class StixExtractorTest {
-    /**
-         <!--
-         STIX IP Watchlist Example
+  /**
+   <!--
+   STIX IP Watchlist Example
 
-         Copyright (c) 2015, The MITRE Corporation. All rights reserved.
-         The contents of this file are subject to the terms of the STIX License located at http://stix.mitre.org/about/termsofuse.html.
+   Copyright (c) 2015, The MITRE Corporation. All rights reserved.
+   The contents of this file are subject to the terms of the STIX License located at http://stix.mitre.org/about/termsofuse.html.
 
-         This example demonstrates a simple usage of STIX to represent a list of IP address indicators (watchlist of IP addresses). Cyber operations and malware analysis centers often share a list of suspected malicious IP addresses with information about what those IPs might indicate. This STIX package represents a list of three IP addresses with a short dummy description of what they represent.
+   This example demonstrates a simple usage of STIX to represent a list of IP address indicators (watchlist of IP addresses). Cyber operations and malware analysis centers often share a list of suspected malicious IP addresses with information about what those IPs might indicate. This STIX package represents a list of three IP addresses with a short dummy description of what they represent.
 
-         It demonstrates the use of:
+   It demonstrates the use of:
 
-         * STIX Indicators
-         * CybOX within STIX
-         * The CybOX Address Object (IP)
-         * CybOX Patterns (apply_condition="ANY")
-         * Controlled vocabularies
+   * STIX Indicators
+   * CybOX within STIX
+   * The CybOX Address Object (IP)
+   * CybOX Patterns (apply_condition="ANY")
+   * Controlled vocabularies
 
-         Created by Mark Davidson
-         -->
-         <stix:STIX_Package
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns:stix="http://stix.mitre.org/stix-1"
-         xmlns:indicator="http://stix.mitre.org/Indicator-2"
-         xmlns:cybox="http://cybox.mitre.org/cybox-2"
-         xmlns:AddressObject="http://cybox.mitre.org/objects#AddressObject-2"
-         xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
-         xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
-         xmlns:example="http://example.com/"
-         id="example:STIXPackage-33fe3b22-0201-47cf-85d0-97c02164528d"
-         timestamp="2014-05-08T09:00:00.000000Z"
-         version="1.2">
-         <stix:STIX_Header>
-         <stix:Title>Example watchlist that contains IP information.</stix:Title>
-         <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Indicators - Watchlist</stix:Package_Intent>
-         </stix:STIX_Header>
-         <stix:Indicators>
-         <stix:Indicator xsi:type="indicator:IndicatorType" id="example:Indicator-33fe3b22-0201-47cf-85d0-97c02164528d" timestamp="2014-05-08T09:00:00.000000Z">
-         <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
-         <indicator:Description>Sample IP Address Indicator for this watchlist. This contains one indicator with a set of three IP addresses in the watchlist.</indicator:Description>
-         <indicator:Observable  id="example:Observable-1c798262-a4cd-434d-a958-884d6980c459">
-         <cybox:Object id="example:Object-1980ce43-8e03-490b-863a-ea404d12242e">
-         <cybox:Properties xsi:type="AddressObject:AddressObjectType" category="ipv4-addr">
-         <AddressObject:Address_Value condition="Equals" apply_condition="ANY">10.0.0.0##comma##10.0.0.1##comma##10.0.0.2</AddressObject:Address_Value>
-         </cybox:Properties>
-         </cybox:Object>
-         </indicator:Observable>
-         </stix:Indicator>
-         </stix:Indicators>
-         </stix:STIX_Package>
-         */
-    @Multiline
-    private static String stixDoc;
+   Created by Mark Davidson
+   -->
+   <stix:STIX_Package
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xmlns:stix="http://stix.mitre.org/stix-1"
+   xmlns:indicator="http://stix.mitre.org/Indicator-2"
+   xmlns:cybox="http://cybox.mitre.org/cybox-2"
+   xmlns:AddressObject="http://cybox.mitre.org/objects#AddressObject-2"
+   xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
+   xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
+   xmlns:example="http://example.com/"
+   id="example:STIXPackage-33fe3b22-0201-47cf-85d0-97c02164528d"
+   timestamp="2014-05-08T09:00:00.000000Z"
+   version="1.2">
+   <stix:STIX_Header>
+   <stix:Title>Example watchlist that contains IP information.</stix:Title>
+   <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Indicators - Watchlist</stix:Package_Intent>
+   </stix:STIX_Header>
+   <stix:Indicators>
+   <stix:Indicator xsi:type="indicator:IndicatorType" id="example:Indicator-33fe3b22-0201-47cf-85d0-97c02164528d" timestamp="2014-05-08T09:00:00.000000Z">
+   <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
+   <indicator:Description>Sample IP Address Indicator for this watchlist. This contains one indicator with a set of three IP addresses in the watchlist.</indicator:Description>
+   <indicator:Observable  id="example:Observable-1c798262-a4cd-434d-a958-884d6980c459">
+   <cybox:Object id="example:Object-1980ce43-8e03-490b-863a-ea404d12242e">
+   <cybox:Properties xsi:type="AddressObject:AddressObjectType" category="ipv4-addr">
+   <AddressObject:Address_Value condition="Equals" apply_condition="ANY">10.0.0.0##comma##10.0.0.1##comma##10.0.0.2</AddressObject:Address_Value>
+   </cybox:Properties>
+   </cybox:Object>
+   </indicator:Observable>
+   </stix:Indicator>
+   </stix:Indicators>
+   </stix:STIX_Package>
+   */
+  @Multiline
+  private static String stixDoc;
 
-    /**
+  /**
+   <!--
+   STIX IP Watchlist Example
+
+   Copyright (c) 2015, The MITRE Corporation. All rights reserved.
+   The contents of this file are subject to the terms of the STIX License located at http://stix.mitre.org/about/termsofuse.html.
+
+   This example demonstrates a simple usage of STIX to represent a list of IP address indicators (watchlist of IP addresses). Cyber operations and malware analysis centers often share a list of suspected malicious IP addresses with information about what those IPs might indicate. This STIX package represents a list of three IP addresses with a short dummy description of what they represent.
+
+   It demonstrates the use of:
+
+   * STIX Indicators
+   * CybOX within STIX
+   * The CybOX Address Object (IP)
+   * CybOX Patterns (apply_condition="ANY")
+   * Controlled vocabularies
+
+   Created by Mark Davidson
+   -->
+   <stix:STIX_Package
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xmlns:stix="http://stix.mitre.org/stix-1"
+   xmlns:indicator="http://stix.mitre.org/Indicator-2"
+   xmlns:cybox="http://cybox.mitre.org/cybox-2"
+   xmlns:AddressObject="http://cybox.mitre.org/objects#AddressObject-2"
+   xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
+   xmlns:stixVocabs="http://stix.mitre.org/default_vocabularies-1"
+   xmlns:example="http://example.com/"
+   id="example:STIXPackage-33fe3b22-0201-47cf-85d0-97c02164528d"
+   timestamp="2014-05-08T09:00:00.000000Z"
+   version="1.2">
+   <stix:STIX_Header>
+   <stix:Title>Example watchlist that contains IP information.</stix:Title>
+   <stix:Package_Intent xsi:type="stixVocabs:PackageIntentVocab-1.0">Indicators - Watchlist</stix:Package_Intent>
+   </stix:STIX_Header>
+   <stix:Indicators>
+   <stix:Indicator xsi:type="indicator:IndicatorType" id="example:Indicator-33fe3b22-0201-47cf-85d0-97c02164528d" timestamp="2014-05-08T09:00:00.000000Z">
+   <indicator:Type xsi:type="stixVocabs:IndicatorTypeVocab-1.1">IP Watchlist</indicator:Type>
+   <indicator:Description>Sample IP Address Indicator for this watchlist. This contains one indicator with a set of three IP addresses in the watchlist.</indicator:Description>
+   <indicator:Observable  id="example:Observable-1c798262-a4cd-434d-a958-884d6980c459">
+   <cybox:Object id="example:Object-1980ce43-8e03-490b-863a-ea404d12242e">
+   <cybox:Properties xsi:type="AddressObject:AddressObjectType" category="ipv4-addr">
+   <AddressObject:Address_Value condition="Equals" apply_condition="ANY">10.0.0.0##comma##10.0.0.1##comma##10.0.0.2</AddressObject:Address_Value>
+   </cybox:Properties>
+   </cybox:Object>
+   </indicator:Observable>
+   </stix:Indicator>
+   </stix:Indicators>
+   </stix:STIX_Package>
+   */
+  @Multiline
+  private static String stixDocWithoutCondition;
+
+  /**
+   {
+   "config" : {
+   "stix_address_categories" : "IPV_4_ADDR"
+   }
+   ,"extractor" : "STIX"
+   }
+   */
+  @Multiline
+  private static String stixConfigOnlyIPV4;
+  /**
+   {
+   "config" : {
+   "stix_address_categories" : "IPV_6_ADDR"
+   }
+   ,"extractor" : "STIX"
+   }
+   */
+  @Multiline
+  private static String stixConfigOnlyIPV6;
+  /**
+   {
+   "config" : {
+   }
+   ,"extractor" : "STIX"
+   }
+   */
+  @Multiline
+  private static String stixConfig;
+
+  @Test
+  public void testStixAddressesWithCondition() throws Exception {
+    testStixAddresses(stixDoc);
+  }
+
+  @Test
+  public void testStixAddressesWithoutCondition() throws Exception {
+    testStixAddresses(stixDocWithoutCondition);
+  }
+
+  public void testStixAddresses(String stixDoc) throws Exception {
     {
-        "config" : {
-             "stix_address_categories" : "IPV_4_ADDR"
-        }
-        ,"extractor" : "STIX"
+      ExtractorHandler handler = ExtractorHandler.load(stixConfigOnlyIPV4);
+      Extractor extractor = handler.getExtractor();
+      Iterable<LookupKV> results = extractor.extract(stixDoc);
+
+      Assert.assertEquals(3, Iterables.size(results));
+      Assert.assertEquals("10.0.0.0", ((EnrichmentKey)(Iterables.get(results, 0).getKey())).indicator);
+      Assert.assertEquals("10.0.0.1", ((EnrichmentKey)(Iterables.get(results, 1).getKey())).indicator);
+      Assert.assertEquals("10.0.0.2", ((EnrichmentKey)(Iterables.get(results, 2).getKey())).indicator);
     }
-    */
-    @Multiline
-    private static String stixConfigOnlyIPV4;
-    /**
     {
-        "config" : {
-             "stix_address_categories" : "IPV_6_ADDR"
-        }
-        ,"extractor" : "STIX"
+
+      ExtractorHandler handler = ExtractorHandler.load(stixConfig);
+      Extractor extractor = handler.getExtractor();
+      Iterable<LookupKV> results = extractor.extract(stixDoc);
+      Assert.assertEquals(3, Iterables.size(results));
+      Assert.assertEquals("10.0.0.0", ((EnrichmentKey)(Iterables.get(results, 0).getKey())).indicator);
+      Assert.assertEquals("10.0.0.1", ((EnrichmentKey)(Iterables.get(results, 1).getKey())).indicator);
+      Assert.assertEquals("10.0.0.2", ((EnrichmentKey)(Iterables.get(results, 2).getKey())).indicator);
     }
-    */
-    @Multiline
-    private static String stixConfigOnlyIPV6;
-    /**
     {
-        "config" : {
-        }
-        ,"extractor" : "STIX"
+
+      ExtractorHandler handler = ExtractorHandler.load(stixConfigOnlyIPV6);
+      Extractor extractor = handler.getExtractor();
+      Iterable<LookupKV> results = extractor.extract(stixDoc);
+      Assert.assertEquals(0, Iterables.size(results));
     }
-    */
-    @Multiline
-    private static String stixConfig;
-    @Test
-    public void testStixAddresses() throws Exception {
-        {
-            ExtractorHandler handler = ExtractorHandler.load(stixConfigOnlyIPV4);
-            Extractor extractor = handler.getExtractor();
-            Iterable<LookupKV> results = extractor.extract(stixDoc);
-
-            Assert.assertEquals(3, Iterables.size(results));
-            Assert.assertEquals("10.0.0.0", ((EnrichmentKey)(Iterables.get(results, 0).getKey())).indicator);
-            Assert.assertEquals("10.0.0.1", ((EnrichmentKey)(Iterables.get(results, 1).getKey())).indicator);
-            Assert.assertEquals("10.0.0.2", ((EnrichmentKey)(Iterables.get(results, 2).getKey())).indicator);
-        }
-        {
-
-            ExtractorHandler handler = ExtractorHandler.load(stixConfig);
-            Extractor extractor = handler.getExtractor();
-            Iterable<LookupKV> results = extractor.extract(stixDoc);
-            Assert.assertEquals(3, Iterables.size(results));
-            Assert.assertEquals("10.0.0.0", ((EnrichmentKey)(Iterables.get(results, 0).getKey())).indicator);
-            Assert.assertEquals("10.0.0.1", ((EnrichmentKey)(Iterables.get(results, 1).getKey())).indicator);
-            Assert.assertEquals("10.0.0.2", ((EnrichmentKey)(Iterables.get(results, 2).getKey())).indicator);
-        }
-        {
-
-            ExtractorHandler handler = ExtractorHandler.load(stixConfigOnlyIPV6);
-            Extractor extractor = handler.getExtractor();
-            Iterable<LookupKV> results = extractor.extract(stixDoc);
-            Assert.assertEquals(0, Iterables.size(results));
-        }
-    }
+  }
 }


### PR DESCRIPTION
When manually creating indicators in Soltra, the condition for the observable is not specifiable via the Soltra UI. As such, Soltra does not specify this condition explicitly, expecting the default to be "equals" if unspecified.
We should, if the condition is unspecified, assume equality.

This is currently tested via unit tests.  I will spin it up in vagrant and update the PR.