### PR TITLE
METRON-408 Intermittent Failures of Profile Integration Tests

### DIFF
--- a/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/integration/ProfilerIntegrationTest.java
+++ b/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/integration/ProfilerIntegrationTest.java
@@ -280,8 +280,8 @@ public class ProfilerIntegrationTest extends BaseIntegrationTest {
     // upload profiler configuration to zookeeper
     ConfigUploadComponent configUploadComponent = new ConfigUploadComponent()
             .withTopologyProperties(topologyProperties)
-            .withGlobalConfigsPath(pathToConfig)
-            .withProfilerConfigsPath(pathToConfig);
+            .withGlobalConfiguration(pathToConfig)
+            .withProfilerConfiguration(pathToConfig);
 
     // load flux definition for the profiler topology
     fluxComponent = new FluxTopologyComponent.Builder()

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/ConfigurationsUtils.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/ConfigurationsUtils.java
@@ -24,7 +24,6 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.metron.common.Constants;
 import org.apache.metron.common.configuration.enrichment.SensorEnrichmentConfig;
-import org.apache.metron.common.configuration.profiler.ProfilerConfigurations;
 import org.apache.metron.common.utils.JSONUtils;
 import org.apache.zookeeper.KeeperException;
 
@@ -37,7 +36,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.metron.common.configuration.ConfigurationType.*;
+import static org.apache.metron.common.configuration.ConfigurationType.ENRICHMENT;
+import static org.apache.metron.common.configuration.ConfigurationType.GLOBAL;
+import static org.apache.metron.common.configuration.ConfigurationType.PARSER;
+import static org.apache.metron.common.configuration.ConfigurationType.PROFILER;
 
 public class ConfigurationsUtils {
 
@@ -156,10 +158,6 @@ public class ConfigurationsUtils {
     for(String sensorType: sensorTypes) {
       configurations.updateSensorEnrichmentConfig(sensorType, readSensorEnrichmentConfigBytesFromZookeeper(sensorType, client));
     }
-  }
-
-  public static void updateProfilerConfigsFromZookeeper(ProfilerConfigurations configurations, CuratorFramework client) throws Exception {
-    updateConfigsFromZookeeper(configurations, client);
   }
 
   public static SensorEnrichmentConfig readSensorEnrichmentConfigFromZookeeper(String sensorType, CuratorFramework client) throws Exception {

--- a/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/components/KafkaWithZKComponent.java
+++ b/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/components/KafkaWithZKComponent.java
@@ -157,12 +157,15 @@ public class KafkaWithZKComponent implements InMemoryComponent {
 
   @Override
   public void stop() {
-    kafkaServer.shutdown();
-    zkClient.close();
+    if(kafkaServer != null) {
+      kafkaServer.shutdown();
+    }
+    if(zkClient != null) {
+      zkClient.close();
+    }
     if(zkServer != null) {
       zkServer.shutdown();
     }
-
   }
 
   public List<byte[]> readMessages(String topic) {


### PR DESCRIPTION
[METRON-408](https://issues.apache.org/jira/browse/METRON-408)

The profiler configuration was not being updated from Zookeeper correctly in all cases.  After some period of time the configurations would be updated and the tests would work.  But if this period of time was greater than 90 seconds, the amount of time the profile integration tests wait, then the tests would fail.  

In all cases, messages were being sent through Storm prior to the bolt actually receiving the profiler configuration, which would cause the `ProfileSplitterBolt` to throw an exception indicating that the configuration could not be found. This message `Fatal: Unable to find valid profiler definition` was a symptom of the problem and occurred much more frequently than the tests actually failed.

Since this issue was intermittent, I cannot be sure it is completely gone, but I have been unable to replicate the problem after these changes.  I also am unable to replicate the `Fatal: Unable to find valid profiler definition` error after this fix.