### PR TITLE
METRON-414: Kibana Ansible Install Fails with SSL Error

### DIFF
--- a/metron-deployment/roles/kibana/tasks/elasticdump.yml
+++ b/metron-deployment/roles/kibana/tasks/elasticdump.yml
@@ -16,7 +16,10 @@
 #
 ---
 - name: Download Nodesource Yum Repository Setup
-  get_url: url={{ nodesource_repo_setup }} dest=/tmp/nodesource_setup_4.x
+  shell:
+    cmd: curl -s {{ nodesource_repo_setup }} -o /tmp/nodesource_setup_4.x
+    creates: /tmp/nodesource_setup_4.x
+    warn: false
 
 - name: Setup Nodesource Yum Repository
   shell: bash /tmp/nodesource_setup_4.x


### PR DESCRIPTION
It looks as if nodesource introduced SNI over the weekend. Curl 7.18.1 supports this, so I've switched to curl for the nodesource repo download.

Tested on Quickdev Vagrant.