### PR TITLE
METRON-418 Set TTL on HBase Puts

### DIFF
--- a/metron-analytics/metron-profiler-client/src/test/java/org/apache/metron/profiler/client/ProfileWriter.java
+++ b/metron-analytics/metron-profiler-client/src/test/java/org/apache/metron/profiler/client/ProfileWriter.java
@@ -92,8 +92,8 @@ public class ProfileWriter {
     byte[] rowKey = rowKeyBuilder.rowKey(m, groups);
     ColumnList cols = columnBuilder.columns(m);
 
-    List<Mutation> mutations = hbaseClient.constructMutationReq(rowKey, cols, Durability.SKIP_WAL);
-    hbaseClient.batchMutate(mutations);
+    hbaseClient.addMutation(rowKey, cols, Durability.SKIP_WAL);
+    hbaseClient.mutate();
   }
 
 }

--- a/metron-platform/metron-hbase/src/test/java/org/apache/metron/hbase/Widget.java
+++ b/metron-platform/metron-hbase/src/test/java/org/apache/metron/hbase/Widget.java
@@ -62,7 +62,6 @@ public class Widget {
     if (o == null || getClass() != o.getClass()) return false;
 
     Widget widget = (Widget) o;
-
     if (cost != widget.cost) return false;
     return name != null ? name.equals(widget.name) : widget.name == null;
 
@@ -73,5 +72,13 @@ public class Widget {
     int result = name != null ? name.hashCode() : 0;
     result = 31 * result + cost;
     return result;
+  }
+
+  @Override
+  public String toString() {
+    return "Widget{" +
+            "name='" + name + '\'' +
+            ", cost=" + cost +
+            '}';
   }
 }

--- a/metron-platform/metron-hbase/src/test/java/org/apache/metron/hbase/bolt/HBaseBoltTest.java
+++ b/metron-platform/metron-hbase/src/test/java/org/apache/metron/hbase/bolt/HBaseBoltTest.java
@@ -97,7 +97,7 @@ public class HBaseBoltTest extends BaseBoltTest {
     bolt.execute(tuple2);
 
     // batch size is 2, received 2 tuples - flush the batch
-    verify(client, times(1)).batchMutate(any(List.class));
+    verify(client, times(1)).mutate();
   }
 
   /**
@@ -109,7 +109,7 @@ public class HBaseBoltTest extends BaseBoltTest {
     bolt.execute(tuple1);
 
     // batch size is 2, but only 1 tuple received - do not flush batch
-    verify(client, times(0)).batchMutate(any(List.class));
+    verify(client, times(0)).mutate();
   }
 
   /**
@@ -121,11 +121,11 @@ public class HBaseBoltTest extends BaseBoltTest {
 
     // the batch is not ready to write
     bolt.execute(tuple1);
-    verify(client, times(0)).batchMutate(any(List.class));
+    verify(client, times(0)).mutate();
 
     // the batch should be flushed after the tick tuple
     bolt.execute(mockTickTuple());
-    verify(client, times(1)).batchMutate(any(List.class));
+    verify(client, times(1)).mutate();
   }
 
   private static Tuple mockTuple(String componentId, String streamId) {

--- a/metron-platform/metron-hbase/src/test/java/org/apache/metron/hbase/client/HBaseClientTest.java
+++ b/metron-platform/metron-hbase/src/test/java/org/apache/metron/hbase/client/HBaseClientTest.java
@@ -25,9 +25,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.client.Durability;
-import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTableInterface;
-import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.metron.hbase.Widget;
@@ -44,12 +42,16 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.apache.metron.hbase.WidgetMapper.CF;
+import static org.apache.metron.hbase.WidgetMapper.QCOST;
+import static org.apache.metron.hbase.WidgetMapper.QNAME;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests the HBaseClient
@@ -63,6 +65,10 @@ public class HBaseClientTest {
   private HTableInterface table;
   private Tuple tuple1;
   private Tuple tuple2;
+  byte[] rowKey1;
+  byte[] rowKey2;
+  ColumnList cols1;
+  ColumnList cols2;
   private Widget widget1;
   private Widget widget2;
   private HBaseMapper mapper;
@@ -90,10 +96,16 @@ public class HBaseClientTest {
     tuple1 = mock(Tuple.class);
     when(tuple1.getValueByField(eq("widget"))).thenReturn(widget1);
 
+    rowKey1 = mapper.rowKey(tuple1);
+    cols1 = mapper.columns(tuple1);
+
     // setup the second tuple
     widget2 = new Widget("widget2", 200);
     tuple2 = mock(Tuple.class);
     when(tuple2.getValueByField(eq("widget"))).thenReturn(widget2);
+
+    rowKey2 = mapper.rowKey(tuple2);
+    cols2 = mapper.columns(tuple2);
   }
 
   @Before
@@ -104,6 +116,7 @@ public class HBaseClientTest {
 
     // create the table
     table = util.createTable(Bytes.toBytes(tableName), WidgetMapper.CF);
+    util.waitTableEnabled(table.getName());
 
     // setup the client
     client = new HBaseClient((c,t) -> table, table.getConfiguration(), tableName);
@@ -114,21 +127,22 @@ public class HBaseClientTest {
     util.deleteTable(tableName);
   }
 
+  /**
+   * Should be able to read/write a single Widget.
+   */
   @Test
   public void testWrite() throws Exception {
 
     // add a tuple to the batch
-    byte[] rowKey1 = mapper.rowKey(tuple1);
-    ColumnList cols1 = mapper.columns(tuple1);
-    List<Mutation> mutations1 = client.constructMutationReq(rowKey1, cols1, Durability.SYNC_WAL);
-    client.batchMutate(mutations1);
+    client.addMutation(rowKey1, cols1, Durability.SYNC_WAL);
+    client.mutate();
 
     HBaseProjectionCriteria criteria = new HBaseProjectionCriteria();
     criteria.addColumnFamily(WidgetMapper.CF_STRING);
 
     // read back the tuple
-    Get get1 = client.constructGetRequests(rowKey1, criteria);
-    Result[] results = client.batchGet(Arrays.asList(get1));
+    client.addGet(rowKey1, criteria);
+    Result[] results = client.getAll();
     Assert.assertEquals(1, results.length);
 
     // validate
@@ -136,36 +150,93 @@ public class HBaseClientTest {
     assertEquals(widget1, toWidget(results[0]));
   }
 
+  /**
+   * Should be able to read/write multiple Widgets in a batch.
+   */
   @Test
   public void testBatchWrite() throws Exception {
 
-    // add a tuple to the batch
-    byte[] rowKey1 = mapper.rowKey(tuple1);
-    ColumnList cols1 = mapper.columns(tuple1);
-    List<Mutation> mutations1 = client.constructMutationReq(rowKey1, cols1, Durability.SYNC_WAL);
-    client.batchMutate(mutations1);
-
-    // add another tuple to the batch
-    byte[] rowKey2 = mapper.rowKey(tuple1);
-    ColumnList cols2 = mapper.columns(tuple1);
-    List<Mutation> mutations2 = client.constructMutationReq(rowKey2, cols2, Durability.SYNC_WAL);
-    client.batchMutate(mutations2);
+    // add two mutations to the queue
+    client.addMutation(rowKey1, cols1, Durability.SYNC_WAL);
+    client.addMutation(rowKey2, cols2, Durability.SYNC_WAL);
+    client.mutate();
 
     HBaseProjectionCriteria criteria = new HBaseProjectionCriteria();
     criteria.addColumnFamily(WidgetMapper.CF_STRING);
 
     // read back both tuples
-    Get get1 = client.constructGetRequests(rowKey1, criteria);
-    Get get2 = client.constructGetRequests(rowKey2, criteria);
-    Result[] results = client.batchGet(Arrays.asList(get1, get2));
+    client.addGet(rowKey1, criteria);
+    client.addGet(rowKey2, criteria);
+    Result[] results = client.getAll();
 
     // validate
     assertEquals(2, results.length);
     List<Widget> expected = Arrays.asList(widget1, widget2);
     for(Result result : results) {
       Widget widget = toWidget(result);
-      Assert.assertThat(expected, hasItem(widget));
+      Assert.assertTrue(expected.contains(widget));
     }
+  }
+
+  /**
+   * Should be able to read back widgets that were written with a TTL 30 days out.
+   */
+  @Test
+  public void testWriteWithTimeToLive() throws Exception {
+    long timeToLive = TimeUnit.DAYS.toMillis(30);
+
+    // add two mutations to the queue
+    client.addMutation(rowKey1, cols1, Durability.SYNC_WAL, timeToLive);
+    client.addMutation(rowKey2, cols2, Durability.SYNC_WAL, timeToLive);
+    client.mutate();
+
+    HBaseProjectionCriteria criteria = new HBaseProjectionCriteria();
+    criteria.addColumnFamily(WidgetMapper.CF_STRING);
+
+    // read back both tuples
+    client.addGet(rowKey1, criteria);
+    client.addGet(rowKey2, criteria);
+    Result[] results = client.getAll();
+
+    // validate
+    assertEquals(2, results.length);
+    List<Widget> expected = Arrays.asList(widget1, widget2);
+    for(Result result : results) {
+      Widget widget = toWidget(result);
+      Assert.assertTrue(expected.contains(widget));
+    }
+  }
+
+  /**
+   * Should NOT be able to read widgets that are expired due to the TTL.
+   */
+  @Test
+  public void testExpiredWidgets() throws Exception {
+    long timeToLive = TimeUnit.MILLISECONDS.toMillis(1);
+
+    // add two mutations to the queue
+    client.addMutation(rowKey1, cols1, Durability.SYNC_WAL, timeToLive);
+    client.addMutation(rowKey2, cols2, Durability.SYNC_WAL, timeToLive);
+    client.mutate();
+
+    HBaseProjectionCriteria criteria = new HBaseProjectionCriteria();
+    criteria.addColumnFamily(WidgetMapper.CF_STRING);
+
+    // wait for a second to ensure the TTL has expired
+    Thread.sleep(TimeUnit.SECONDS.toMillis(2));
+
+    // read back both tuples
+    client.addGet(rowKey1, criteria);
+    client.addGet(rowKey2, criteria);
+    Result[] results = client.getAll();
+
+    // validate - the TTL should have expired all widgets
+    List<Widget> widgets = Arrays
+            .stream(results)
+            .map(r -> toWidget(r))
+            .filter(w -> w != null)
+            .collect(Collectors.toList());
+    assertEquals(0, widgets.size());
   }
 
   /**
@@ -174,8 +245,14 @@ public class HBaseClientTest {
    * @return The Widget.
    */
   private Widget toWidget(Result result) {
-    int cost = Bytes.toInt(result.getValue(WidgetMapper.CF, WidgetMapper.QCOST));
-    String name = Bytes.toString(result.getValue(WidgetMapper.CF, WidgetMapper.QNAME));
-    return new Widget(name, cost);
+    Widget widget = null;
+
+    if(result.containsColumn(CF, QCOST) && result.containsColumn(CF, QNAME)) {
+      String name = Bytes.toString(result.getValue(CF, QNAME));
+      int cost = Bytes.toInt(result.getValue(CF, QCOST));
+      widget = new Widget(name, cost);
+    }
+
+    return widget;
   }
 }


### PR DESCRIPTION
For METRON-417, the goal is to use HBase's TTL mechanism to expire or age-out Profile data.  This PR provides the mechanism to set TTL values on HBase Puts.  

The HBaseClient is used to write ProfileMeasurement values to HBase. The client was updated so that a TTL can be attached to each Put. This will allow us to attach a TTL to each ProfileMeasurement written by the Profiler.

Tests were added to validate successful reads/write to HBase with a TTL, along with successful expiration of data based on a TTL.

Depends on the following existing PRs...
- [x] #246 