### PR TITLE
METRON-428: Allow a kafka offset to be passed to the ParserTopology CLI

### DIFF
--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/topology/ParserTopologyCLI.java
@@ -183,6 +183,13 @@ public class ParserTopologyCLI {
       o.setRequired(false);
       return o;
     })
+    ,KAFKA_OFFSET("koff", code ->
+    {
+      Option o = new Option("koff", "kafka_offset", true, "Kafka offset");
+      o.setArgName("BEGINNING|WHERE_I_LEFT_OFF");
+      o.setRequired(false);
+      return o;
+    })
     ;
     Option option;
     String shortCode;
@@ -285,6 +292,9 @@ public class ParserTopologyCLI {
         spoutConfig = readSpoutConfig(new File(ParserOptions.SPOUT_CONFIG.get(cmd)));
       }
       SpoutConfig.Offset offset = cmd.hasOption("t") ? SpoutConfig.Offset.BEGINNING : SpoutConfig.Offset.WHERE_I_LEFT_OFF;
+      if(cmd.hasOption("koff")) {
+        offset = SpoutConfig.Offset.valueOf(cmd.getOptionValue("koff"));
+      }
       TopologyBuilder builder = ParserTopologyBuilder.build(zookeeperUrl,
               brokerUrl,
               sensorType,

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/topology/ParserTopologyCLITest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/topology/ParserTopologyCLITest.java
@@ -74,6 +74,22 @@ public class ParserTopologyCLITest {
 
 
   @Test
+  public void testKafkaOffset_happyPath() throws ParseException {
+    kafkaOffset(true);
+    kafkaOffset(false);
+  }
+  public void kafkaOffset(boolean longOpt) throws ParseException {
+    CommandLine cli = new CLIBuilder().with(ParserTopologyCLI.ParserOptions.BROKER_URL, "mybroker")
+                                      .with(ParserTopologyCLI.ParserOptions.ZK_QUORUM, "myzk")
+                                      .with(ParserTopologyCLI.ParserOptions.SENSOR_TYPE, "mysensor")
+                                      .with(ParserTopologyCLI.ParserOptions.KAFKA_OFFSET, "BEGINNING")
+                                      .build(longOpt);
+    Assert.assertEquals("myzk", ParserTopologyCLI.ParserOptions.ZK_QUORUM.get(cli));
+    Assert.assertEquals("mybroker", ParserTopologyCLI.ParserOptions.BROKER_URL.get(cli));
+    Assert.assertEquals("mysensor", ParserTopologyCLI.ParserOptions.SENSOR_TYPE.get(cli));
+    Assert.assertEquals("BEGINNING", ParserTopologyCLI.ParserOptions.KAFKA_OFFSET.get(cli));
+  }
+  @Test
   public void testCLI_happyPath() throws ParseException {
     happyPath(true);
     happyPath(false);


### PR DESCRIPTION
Currently the parser start utility does not support passing whether we want to start the topology at the beginning or where they left off.