### PR TITLE
METRON-434: JSON Parser

### DIFF
--- a/metron-platform/metron-integration-test/src/main/sample/data/jsonMap/parsed/jsonMapExampleParsed
+++ b/metron-platform/metron-integration-test/src/main/sample/data/jsonMap/parsed/jsonMapExampleParsed
@@ -1,0 +1,2 @@
+{ "string" : "bar", "number" : 2, "original_string":"{ \"string\" : \"bar\", \"number\" : 2, \"ignored\" : [ \"blah\" ] }", }
+{ "number" : 7 , "original_string" : "{ \"number\" : 7 }"

--- a/metron-platform/metron-integration-test/src/main/sample/data/jsonMap/raw/jsonMapExampleOutput
+++ b/metron-platform/metron-integration-test/src/main/sample/data/jsonMap/raw/jsonMapExampleOutput
@@ -1,0 +1,2 @@
+{ "string" : "bar", "number" : 2, "ignored" : [ "blah" ] }
+{ "number" : 7 }

--- a/metron-platform/metron-parsers/src/main/config/zookeeper/parsers/jsonMap.json
+++ b/metron-platform/metron-parsers/src/main/config/zookeeper/parsers/jsonMap.json
@@ -1,0 +1,4 @@
+{
+  "parserClassName":"org.apache.metron.parsers.json.JSONMapParser",
+  "sensorTopic":"jsonMap"
+}

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/json/JSONMapParser.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/json/JSONMapParser.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.metron.parsers.json;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/json/JSONMapParser.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/json/JSONMapParser.java
@@ -1,0 +1,73 @@
+package org.apache.metron.parsers.json;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableList;
+import org.apache.metron.common.utils.JSONUtils;
+import org.apache.metron.parsers.BasicParser;
+import org.json.simple.JSONObject;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class JSONMapParser extends BasicParser {
+
+  @Override
+  public void configure(Map<String, Object> config) {
+
+  }
+
+  /**
+   * Initialize the message parser.  This is done once.
+   */
+  @Override
+  public void init() {
+
+  }
+
+  /**
+   * Take raw data and convert it to a list of messages.
+   *
+   * @param rawMessage
+   * @return If null is returned, this is treated as an empty list.
+   */
+  @Override
+  public List<JSONObject> parse(byte[] rawMessage) {
+    try {
+      String originalString = new String(rawMessage);
+      //convert the JSON blob into a String -> Object map
+      Map<String, Object> rawMap = JSONUtils.INSTANCE.load(originalString, new TypeReference<Map<String, Object>>() {
+      });
+      JSONObject ret = normalizeJSON(rawMap);
+      ret.put("original_string", originalString );
+      if(!ret.containsKey("timestamp")) {
+        //we have to ensure that we have a timestamp.  This is one of the pre-requisites for the parser.
+        ret.put("timestamp", System.currentTimeMillis());
+      }
+      return ImmutableList.of(ret);
+    } catch (Throwable e) {
+      String message = "Unable to parse " + new String(rawMessage) + ": " + e.getMessage();
+      LOG.error(message, e);
+      throw new IllegalStateException(message, e);
+    }
+  }
+
+  /**
+   * Remove all collections as values.  We have standardized on one-dimensional maps as our data model..
+   *
+   * @param map
+   * @return
+   */
+  private JSONObject normalizeJSON(Map<String, Object> map) {
+    JSONObject ret = new JSONObject();
+    for(Map.Entry<String, Object> kv : map.entrySet()) {
+      if(kv.getValue() instanceof Collection) {
+        continue;
+      }
+      ret.put(kv.getKey(), kv.getValue());
+    }
+    return ret;
+  }
+
+}

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/JSONMapIntegrationTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/JSONMapIntegrationTest.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.metron.parsers.integration;
 
 import org.apache.metron.parsers.integration.validation.SampleDataValidation;

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/JSONMapIntegrationTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/JSONMapIntegrationTest.java
@@ -1,0 +1,20 @@
+package org.apache.metron.parsers.integration;
+
+import org.apache.metron.parsers.integration.validation.SampleDataValidation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JSONMapIntegrationTest extends ParserIntegrationTest {
+  @Override
+  String getSensorType() {
+    return "jsonMap";
+  }
+
+  @Override
+  List<ParserValidation> getValidations() {
+    return new ArrayList<ParserValidation>() {{
+      add(new SampleDataValidation());
+    }};
+  }
+}

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/json/JSONMapParserTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/json/JSONMapParserTest.java
@@ -77,15 +77,15 @@ public class JSONMapParserTest {
   @Test(expected=IllegalStateException.class)
   public void testCollectionHandlingError() {
     JSONMapParser parser = new JSONMapParser();
-    parser.configure(ImmutableMap.of("mapStrategy", "ERROR"));
-    List<JSONObject> output = parser.parse(collectionHandlingJSON.getBytes());
+    parser.configure(ImmutableMap.of(JSONMapParser.MAP_STRATEGY_CONFIG, JSONMapParser.MapStrategy.ERROR.name()));
+    parser.parse(collectionHandlingJSON.getBytes());
   }
 
 
   @Test
   public void testCollectionHandlingAllow() {
     JSONMapParser parser = new JSONMapParser();
-    parser.configure(ImmutableMap.of("mapStrategy", "ALLOW"));
+    parser.configure(ImmutableMap.of(JSONMapParser.MAP_STRATEGY_CONFIG, JSONMapParser.MapStrategy.ALLOW.name()));
     List<JSONObject> output = parser.parse(collectionHandlingJSON.getBytes());
     Assert.assertEquals(output.size(), 1);
     //don't forget the timestamp field!
@@ -98,7 +98,7 @@ public class JSONMapParserTest {
   @Test
   public void testCollectionHandlingUnfold() {
     JSONMapParser parser = new JSONMapParser();
-    parser.configure(ImmutableMap.of("mapStrategy", "UNFOLD"));
+    parser.configure(ImmutableMap.of(JSONMapParser.MAP_STRATEGY_CONFIG, JSONMapParser.MapStrategy.UNFOLD.name()));
     List<JSONObject> output = parser.parse(collectionHandlingJSON.getBytes());
     Assert.assertEquals(output.size(), 1);
     //don't forget the timestamp field!

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/json/JSONMapParserTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/json/JSONMapParserTest.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.metron.parsers.json;
 
 import com.google.common.collect.ImmutableMap;

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/json/JSONMapParserTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/json/JSONMapParserTest.java
@@ -1,0 +1,60 @@
+package org.apache.metron.parsers.json;
+
+import org.adrianwalker.multilinestring.Multiline;
+import org.json.simple.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class JSONMapParserTest {
+
+  /**
+   {
+     "foo" : "bar"
+    ,"blah" : "blah"
+    ,"number" : 2.0
+   }
+   */
+   @Multiline
+   static String happyPathJSON;
+
+  @Test
+  public void testHappyPath() {
+    JSONMapParser parser = new JSONMapParser();
+    List<JSONObject> output = parser.parse(happyPathJSON.getBytes());
+    Assert.assertEquals(output.size(), 1);
+    //don't forget the timestamp field!
+    Assert.assertEquals(output.get(0).size(), 5);
+    JSONObject message = output.get(0);
+    Assert.assertEquals("bar", message.get("foo"));
+    Assert.assertEquals("blah", message.get("blah"));
+    Assert.assertNotNull(message.get("timestamp"));
+    Assert.assertTrue(message.get("timestamp") instanceof Number);
+    Assert.assertNotNull(message.get("number"));
+    Assert.assertTrue(message.get("number") instanceof Number);
+  }
+
+  /**
+   {
+    "collection" : [ "blah" ]
+   }
+   */
+   @Multiline
+   static String collectionHandlingJSON;
+
+  @Test
+  public void testCollectionHandling() {
+    JSONMapParser parser = new JSONMapParser();
+    List<JSONObject> output = parser.parse(collectionHandlingJSON.getBytes());
+    Assert.assertEquals(output.size(), 1);
+    //don't forget the timestamp field!
+    Assert.assertEquals(output.get(0).size(), 2);
+    JSONObject message = output.get(0);
+    Assert.assertNotNull(message.get("timestamp"));
+    Assert.assertTrue(message.get("timestamp") instanceof Number);
+  }
+
+
+}


### PR DESCRIPTION
There are some situations where your data is already in JSON form and parsing should be as simple as passing the data through, adding `timestamp` and `original_message` along the way.  This JIRA will create a parser which will take a JSON map in.

Since we have standardized on one-dimensional maps, we must handle data which contains inner maps.  Inner maps should be handled pluggably by doing one of the following (configurably):
* doing nothing
* unfolding maps (e.g. `{ "foo" : { "bar" : 7 } }` is transformed into `{"foo.bar" : 7 }`)
* throwing an exception
* dropping the inner map
