### PR TITLE
METRON-435 Create Stellar REPL

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/README.md
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/README.md
@@ -1,0 +1,104 @@
+# Stellar Shell
+
+A REPL (Read Eval Print Loop) for the Stellar language that helps in debugging, troubleshooting and learning Stellar.  The Stellar DSL (domain specific language) is used to act upon streaming data within Apache Storm.  It is difficult to troubleshoot Stellar when it can only be executed within a Storm topology.  This REPL is intended to help mitigate that problem by allowing a user to replicate data encountered in production, isolate initialization errors, or understand function resolution problems.
+
+### Getting Started
+
+```
+$ /usr/metron/<version>/bin/stellar
+
+Stellar, Go!
+{es.clustername=metron, es.ip=node1, es.port=9300, es.date.format=yyyy.MM.dd.HH}
+
+>>> URL_TO_PORT('http://foo.com:2181')
+[=] 2181
+[?] save as: 
+
+>>> IS_EMAIL('user@metron.incubator.apache.org')
+[=] true
+[?] save as:
+
+>>> 2 + 2 + 4
+[=] 8.0
+[?] save as: foo
+>>> %vars
+foo = 8.0
+```
+
+### Command Line Options
+
+```
+$ /usr/metron/<version>/bin/stellar -h
+
+usage: stellar
+ -h,--help              Print help
+ -z,--zookeeper <arg>   Zookeeper URL
+```
+
+#### -z, --zookeeper
+
+*Optional*
+
+Attempts to connect to Zookeeper and read the Metron global configuration.  Stellar functions may require the global configuration to work properly.  If found, the global configuration values are printed to the console.
+
+```
+$ /usr/metron/<version>/bin/stellar -z node1:2181
+Stellar, Go!
+{es.clustername=metron, es.ip=node1, es.port=9300, es.date.format=yyyy.MM.dd.HH}
+>>> 
+```
+
+### Variable Assignment
+
+Stellar has no concept of variable assignment.  For testing and debugging purposes, it is important to be able to create variables that simulate data contained within incoming messages.  The REPL has created a means for a user to perform variable assignment outside of the core Stellar language.  
+
+After execution of a Stellar expression, the REPL will prompt for the name of a variable to save the expression result to.  If no name is provided, the result is not saved.
+
+```
+>>> 2+2
+[=] 4.0
+[?] save as: foo
+>>> %vars
+foo = 4.0
+>>> 
+```
+
+### Magic Commands
+
+The REPL has a set of magic commands that provide the REPL user with information about the Stellar execution environment.  A magic command begins with the '%' character.  The following magic commands are supported.
+
+#### `%functions`
+
+This command lists all functions resolvable in the Stellar environment.  Stellar searches the classpath for Stellar functions.  This can make it difficult in some cases to understand which functions are resolvable.  
+
+```
+>>> %functions
+BLOOM_ADD, BLOOM_EXISTS, BLOOM_INIT, BLOOM_MERGE, DAY_OF_MONTH, DAY_OF_WEEK, DAY_OF_YEAR, 
+DOMAIN_REMOVE_SUBDOMAINS, DOMAIN_REMOVE_TLD, DOMAIN_TO_TLD, ENDS_WITH, GET, GET_FIRST, 
+GET_LAST, IN_SUBNET, IS_DATE, IS_DOMAIN, IS_EMAIL, IS_EMPTY, IS_INTEGER, IS_IP, IS_URL, 
+JOIN, MAAS_GET_ENDPOINT, MAAS_MODEL_APPLY, MAP_EXISTS, MAP_GET, MONTH, PROTOCOL_TO_NAME, 
+REGEXP_MATCH, SPLIT, STARTS_WITH, STATS_ADD, STATS_COUNT, STATS_GEOMETRIC_MEAN, STATS_INIT, 
+STATS_KURTOSIS, STATS_MAX, STATS_MEAN, STATS_MERGE, STATS_MIN, STATS_PERCENTILE, 
+STATS_POPULATION_VARIANCE, STATS_QUADRATIC_MEAN, STATS_SD, STATS_SKEWNESS, STATS_SUM, 
+STATS_SUM_LOGS, STATS_SUM_SQUARES, STATS_VARIANCE, TO_DOUBLE, TO_EPOCH_TIMESTAMP, 
+TO_INTEGER, TO_LOWER, TO_STRING, TO_UPPER, TRIM, URL_TO_HOST, URL_TO_PATH, URL_TO_PORT, 
+URL_TO_PROTOCOL, WEEK_OF_MONTH, WEEK_OF_YEAR, YEAR
+>>> 
+```
+
+#### `%vars` 
+
+Lists all variables in the Stellar environment.
+
+```
+Stellar, Go!
+{es.clustername=metron, es.ip=node1, es.port=9300, es.date.format=yyyy.MM.dd.HH}
+>>> %vars
+>>> 2+2
+[=] 4.0
+[?] save as: foo
+>>> %vars
+foo = 4.0
+>>> 
+```
+

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/README.md
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/README.md
@@ -10,19 +10,24 @@ $ /usr/metron/<version>/bin/stellar
 Stellar, Go!
 {es.clustername=metron, es.ip=node1, es.port=9300, es.date.format=yyyy.MM.dd.HH}
 
->>> URL_TO_PORT('http://foo.com:2181')
-[=] 2181
-[?] save as: 
+>>> %functions
+BLOOM_ADD, BLOOM_EXISTS, BLOOM_INIT, BLOOM_MERGE, DAY_OF_MONTH, DAY_OF_WEEK, DAY_OF_YEAR, ...
 
->>> IS_EMAIL('user@metron.incubator.apache.org')
-[=] true
-[?] save as:
+>>> ?PROTOCOL_TO_NAME
+PROTOCOL_TO_NAME
+ desc: Convert the IANA protocol number to the protocol name       
+ args: IANA Number                                                 
+  ret: The protocol name associated with the IANA number.          
 
->>> 2 + 2 + 4
-[=] 8.0
-[?] save as: foo
+>>> 6
+[=] 6
+[?] save as: ip.protocol
+
 >>> %vars
-foo = 8.0
+ip.protocol = 6
+
+>>> PROTOCOL_TO_NAME(ip.protocol)
+[=] TCP
 ```
 
 ### Command Line Options
@@ -65,7 +70,7 @@ foo = 4.0
 
 ### Magic Commands
 
-The REPL has a set of magic commands that provide the REPL user with information about the Stellar execution environment.  A magic command begins with the '%' character.  The following magic commands are supported.
+The REPL has a set of magic commands that provide the REPL user with information about the Stellar execution environment.  The following magic commands are supported.
 
 #### `%functions`
 
@@ -102,3 +107,20 @@ foo = 4.0
 >>> 
 ```
 
+#### `?<function>`
+
+Returns formatted documentation of the Stellar function.  Provides the description of the function along with the expected arguments.
+
+```
+>>> ?BLOOM_ADD
+BLOOM_ADD
+ desc: Adds an element to the bloom filter passed in               
+ args: bloom - The bloom filter, value* - The values to add        
+  ret: Bloom Filter                                                
+>>> ?IS_EMAIL
+IS_EMAIL
+ desc: Tests if a string is a valid email address                  
+ args: address - The String to test                                
+  ret: True if the string is a valid email address and false otherwise.
+>>> 
+```

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/StellarExecutor.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/StellarExecutor.java
@@ -1,0 +1,130 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.metron.common.stellar.shell;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.commons.lang.StringUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.metron.common.configuration.ConfigurationsUtils;
+import org.apache.metron.common.dsl.Context;
+import org.apache.metron.common.dsl.FunctionResolver;
+import org.apache.metron.common.dsl.MapVariableResolver;
+import org.apache.metron.common.dsl.StellarFunctions;
+import org.apache.metron.common.dsl.VariableResolver;
+import org.apache.metron.common.stellar.StellarProcessor;
+import org.apache.metron.common.utils.JSONUtils;
+
+import java.io.ByteArrayInputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.metron.common.configuration.ConfigurationsUtils.readGlobalConfigBytesFromZookeeper;
+
+/**
+ * Executes Stellar expressions and maintains state across multiple invocations.
+ */
+public class StellarExecutor {
+
+  /**
+   * The variables known by Stellar.
+   */
+  private Map<String, Object> variables;
+
+  /**
+   * The function resolver.
+   */
+  private FunctionResolver functionResolver ;
+
+  /**
+   * The context
+   */
+  private Context context;
+
+  public StellarExecutor() throws Exception {
+    this(null);
+  }
+
+  public StellarExecutor(String zookeeperUrl) throws Exception {
+    this.variables = new HashMap<>();
+    this.functionResolver = new StellarFunctions().FUNCTION_RESOLVER();
+    this.context = getContext(zookeeperUrl);
+  }
+
+  /**
+   * Creates a Context initialized with configuration stored in Zookeeper.
+   * @param zookeeperUrl The Zookeeper URL.
+   */
+  private Context getContext(String zookeeperUrl) throws Exception {
+    Context context = Context.EMPTY_CONTEXT();
+
+    // load global configuration from zookeeper
+    if(StringUtils.isNotBlank(zookeeperUrl)) {
+      try (CuratorFramework client = ConfigurationsUtils.getClient(zookeeperUrl)) {
+        client.start();
+
+        Map<String, Object> global = JSONUtils.INSTANCE.load(
+                new ByteArrayInputStream(readGlobalConfigBytesFromZookeeper(client)),
+                new TypeReference<Map<String, Object>>() {
+                });
+
+        context = new Context.Builder()
+                .with(Context.Capabilities.GLOBAL_CONFIG, () -> global)
+                .build();
+      }
+    }
+
+    return context;
+  }
+
+  /**
+   * Executes the Stellar expression and returns the result.
+   * @param expression The Stellar expression to execute.
+   * @return The result of the expression.
+   */
+  public Object execute(String expression) {
+    VariableResolver variableResolver = new MapVariableResolver(variables, Collections.emptyMap());
+    StellarProcessor processor = new StellarProcessor();
+    return processor.parse(expression, variableResolver, functionResolver, context);
+  }
+
+  /**
+   * Assigns a value to a variable.
+   * @param variable The name of the variable.
+   * @param value The value of the variable
+   */
+  public void assign(String variable, Object value) {
+    this.variables.put(variable, value);
+  }
+
+  public Map<String, Object> getVariables() {
+    return this.variables;
+  }
+
+  public FunctionResolver getFunctionResolver() {
+    return functionResolver;
+  }
+
+  public Context getContext() {
+    return context;
+  }
+}
+

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/StellarShell.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/StellarShell.java
@@ -1,0 +1,215 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.metron.common.stellar.shell;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.PosixParser;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.metron.common.dsl.Context;
+
+import java.util.Scanner;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static java.lang.String.format;
+
+/**
+ * A REPL environment for Stellar.
+ *
+ * Useful for debugging Stellar expressions.
+ */
+public class StellarShell {
+
+  private static final String WELCOME = "Stellar, Go!";
+  private static final String EXPRESSION_PROMPT = ">>> ";
+  private static final String RESULT_PROMPT = "[=] ";
+  private static final String ERROR_PROMPT = "[!] ";
+  private static final String ASSIGN_PROMPT = "[?] save as: ";
+  private static final String MAGIC_PREFIX = "%";
+  private static final String MAGIC_FUNCTIONS = "%functions";
+  private static final String MAGIC_VARS = "%vars";
+
+  private StellarExecutor executor;
+
+  /**
+   * Execute the Stellar REPL.
+   */
+  public static void main(String[] args) throws Exception {
+    StellarShell shell = new StellarShell(args);
+    shell.execute();
+  }
+
+  /**
+   * Create a Stellar REPL.
+   * @param args The commmand-line arguments.
+   */
+  public StellarShell(String[] args) throws Exception {
+
+    // define valid command-line options
+    Options options = new Options();
+    options.addOption("z", "zookeeper", true, "Zookeeper URL");
+    options.addOption("h", "help", false, "Print help");
+
+    CommandLineParser parser = new PosixParser();
+    CommandLine commandLine = parser.parse(options, args);
+
+    // print help
+    if(commandLine.hasOption("h")) {
+      HelpFormatter formatter = new HelpFormatter();
+      formatter.printHelp("stellar", options);
+      System.exit(0);
+    }
+
+    // create the executor
+    if(commandLine.hasOption("z")) {
+      String zookeeperUrl = commandLine.getOptionValue("z");
+      executor = new StellarExecutor(zookeeperUrl);
+
+    } else {
+      executor = new StellarExecutor();
+    }
+  }
+
+  /**
+   * Handles the main loop for the REPL.
+   */
+  public void execute() {
+
+    // welcome message
+    writeLine(WELCOME);
+    executor.getContext()
+            .getCapability(Context.Capabilities.GLOBAL_CONFIG)
+            .ifPresent(conf -> writeLine(conf.toString()));
+
+    Scanner scanner = new Scanner(System.in);
+    boolean done = false;
+    while(!done) {
+
+      // prompt the user for an expression
+      write(EXPRESSION_PROMPT);
+      String expression = scanner.nextLine();
+      if(StringUtils.isNotBlank(expression)) {
+
+        if(isMagic(expression)) {
+          handleMagic(scanner, expression);
+
+        } else {
+          handleStellar(scanner, expression);
+        }
+
+      } else {
+        // if no expression, show all variables
+        writeLine(format("%d variable(s) defined", executor.getVariables().size()));
+        executor.getVariables()
+                .forEach((k,v) -> writeLine(format("%s = %s", k, v)));
+      }
+    }
+  }
+
+  /**
+   * Handles user interaction when executing a Stellar expression.
+   * @param scanner The scanner used to read user input.
+   * @param expression The expression to execute.
+   */
+  private void handleStellar(Scanner scanner, String expression) {
+
+    Object result = executeStellar(expression);
+    if(result != null) {
+
+      // echo the result
+      write(RESULT_PROMPT);
+      writeLine(result.toString());
+
+      // assign the result to a variable?
+      write(ASSIGN_PROMPT);
+      String variable = scanner.nextLine();
+      if(StringUtils.isNotBlank(variable)) {
+        executor.assign(variable, result);
+      }
+    }
+  }
+
+  /**
+   * Handles user interaction when executing a Magic command.
+   * @param scanner The scanner used to read user input.
+   * @param expression The expression to execute.
+   */
+  private void handleMagic(Scanner scanner, String expression) {
+
+    if(MAGIC_FUNCTIONS.equals(expression)) {
+
+      // list all functions
+      String functions = StreamSupport
+              .stream(executor.getFunctionResolver().getFunctions().spliterator(), false)
+              .sorted()
+              .collect(Collectors.joining(", "));
+      writeLine(functions);
+
+    } else if(MAGIC_VARS.equals(expression)) {
+
+      // list all variables
+      executor.getVariables()
+              .forEach((k,v) -> writeLine(format("%s = %s", k, v)));
+
+    } else {
+      writeLine(ERROR_PROMPT + "undefined magic command: " + expression);
+    }
+  }
+
+  /**
+   * Is a given expression a built-in magic?
+   * @param expression The expression.
+   * @return
+   */
+  private boolean isMagic(String expression) {
+    return StringUtils.startsWith(expression, MAGIC_PREFIX);
+  }
+
+  /**
+   * Executes a Stellar expression.
+   * @param expression The expression to execute.
+   * @return The result of the expression.
+   */
+  private Object executeStellar(String expression) {
+    Object result = null;
+
+    try {
+      result = executor.execute(expression);
+
+    } catch(Throwable t) {
+      writeLine(ERROR_PROMPT + t.getMessage());
+      t.printStackTrace();
+    }
+
+    return result;
+  }
+
+  private void write(String out) {
+    System.out.print(out);
+  }
+
+  private void writeLine(String out) {
+    System.out.println(out);
+  }
+}

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/StellarShell.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/StellarShell.java
@@ -96,7 +96,7 @@ public class StellarShell {
    */
   public void execute() {
 
-    // welcome message
+    // welcome message and print globals
     writeLine(WELCOME);
     executor.getContext()
             .getCapability(Context.Capabilities.GLOBAL_CONFIG)
@@ -117,12 +117,6 @@ public class StellarShell {
         } else {
           handleStellar(scanner, expression);
         }
-
-      } else {
-        // if no expression, show all variables
-        writeLine(format("%d variable(s) defined", executor.getVariables().size()));
-        executor.getVariables()
-                .forEach((k,v) -> writeLine(format("%s = %s", k, v)));
       }
     }
   }
@@ -160,11 +154,11 @@ public class StellarShell {
     if(MAGIC_FUNCTIONS.equals(expression)) {
 
       // list all functions
-      String functions = StreamSupport
-              .stream(executor.getFunctionResolver().getFunctions().spliterator(), false)
+      StreamSupport
+              .stream(executor.getFunctionResolver().getFunctionInfo().spliterator(), false)
+              .map(info -> String.format("%s", info.getName()))
               .sorted()
-              .collect(Collectors.joining(", "));
-      writeLine(functions);
+              .forEach(line -> writeLine(line));
 
     } else if(MAGIC_VARS.equals(expression)) {
 

--- a/metron-platform/metron-common/src/main/scripts/stellar
+++ b/metron-platform/metron-common/src/main/scripts/stellar
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+BIGTOP_DEFAULTS_DIR=${BIGTOP_DEFAULTS_DIR-/etc/default}
+[ -n "${BIGTOP_DEFAULTS_DIR}" -a -r ${BIGTOP_DEFAULTS_DIR}/hbase ] && . ${BIGTOP_DEFAULTS_DIR}/hbase
+
+# Autodetect JAVA_HOME if not defined
+if [ -e /usr/libexec/bigtop-detect-javahome ]; then
+  . /usr/libexec/bigtop-detect-javahome
+elif [ -e /usr/lib/bigtop-utils/bigtop-detect-javahome ]; then
+  . /usr/lib/bigtop-utils/bigtop-detect-javahome
+fi
+
+export HBASE_CONFIGS=/etc/hbase/conf
+export METRON_VERSION=${project.version}
+export METRON_HOME=/usr/metron/$METRON_VERSION
+java -cp "$HBASE_CONFIGS:$METRON_HOME/lib/*" org.apache.metron.common.stellar.shell.StellarShell "$@"


### PR DESCRIPTION
Created this for debugging some issues I was having in running Stellar functions are on a live cluster.  Thought this would be generally useful on its own.

METRON-435

Create a REPL (Read Eval Print Loop) for the Stellar language that helps in debugging, troubleshooting and learning Stellar. The Stellar DSL (domain specific language) is used to act upon streaming data within Apache Storm. It is difficult to troubleshoot Stellar when it can only be executed within a Storm topology. This REPL is intended to help mitigate that problem by allowing a user to replicate data encountered in production, isolate initialization errors, or understand function resolution problems.