### PR TITLE
METRON-437 The Profile Definition's inputTopic field is Extraneous

### DIFF
--- a/metron-analytics/metron-profiler/README.md
+++ b/metron-analytics/metron-profiler/README.md
@@ -125,7 +125,6 @@ The total number of bytes of HTTP data for each host. The following configuratio
 
 ```
 {
-  "inputTopic": "indexing",
   "profiles": [
     {
       "profile": "example1",
@@ -159,7 +158,6 @@ The ratio of DNS traffic to HTTP traffic for each host. The following configurat
 
 ```
 {
-  "inputTopic": "indexing",
   "profiles": [
     {
       "profile": "example2",
@@ -193,7 +191,6 @@ The average of the `length` field of HTTP traffic. The following configuration w
 
 ```
 {
-  "inputTopic": "indexing",
   "profiles": [
     {
       "profile": "example3",
@@ -261,7 +258,6 @@ This section will describe the steps required to get your first profile running.
 5. Create the Profiler definition in a file located at `/usr/metron/0.2.0BETA/config/zookeeper/profiler.json`.  The following JSON will create a profile that simply counts the number of messages.
     ```
     {
-      "inputTopic": "indexing",
       "profiles": [
         {
           "profile": "test",

--- a/metron-analytics/metron-profiler/src/test/config/zookeeper/percentiles/profiler.json
+++ b/metron-analytics/metron-profiler/src/test/config/zookeeper/percentiles/profiler.json
@@ -1,5 +1,4 @@
 {
-  "inputTopic": "indexing",
   "profiles": [
     {
       "profile": "percentiles",

--- a/metron-analytics/metron-profiler/src/test/config/zookeeper/readme-example-1/profiler.json
+++ b/metron-analytics/metron-profiler/src/test/config/zookeeper/readme-example-1/profiler.json
@@ -1,5 +1,4 @@
 {
-  "inputTopic": "indexing",
   "profiles": [
     {
       "profile": "example1",

--- a/metron-analytics/metron-profiler/src/test/config/zookeeper/readme-example-2/profiler.json
+++ b/metron-analytics/metron-profiler/src/test/config/zookeeper/readme-example-2/profiler.json
@@ -1,5 +1,4 @@
 {
-  "inputTopic": "indexing",
   "profiles": [
     {
       "profile": "example2",

--- a/metron-analytics/metron-profiler/src/test/config/zookeeper/readme-example-3/profiler.json
+++ b/metron-analytics/metron-profiler/src/test/config/zookeeper/readme-example-3/profiler.json
@@ -1,5 +1,4 @@
 {
-  "inputTopic": "indexing",
   "profiles": [
     {
       "profile": "example3",

--- a/metron-analytics/metron-profiler/src/test/config/zookeeper/write-integer/profiler.json
+++ b/metron-analytics/metron-profiler/src/test/config/zookeeper/write-integer/profiler.json
@@ -1,5 +1,4 @@
 {
-  "inputTopic": "indexing",
   "profiles": [
     {
       "profile": "example1",

--- a/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileSplitterBoltTest.java
+++ b/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/bolt/ProfileSplitterBoltTest.java
@@ -56,7 +56,6 @@ public class ProfileSplitterBoltTest extends BaseBoltTest {
 
   /**
    * {
-   *   "inputTopic": "enrichment",
    *   "profiles": [
    *      {
    *        "profile": "test",
@@ -74,7 +73,6 @@ public class ProfileSplitterBoltTest extends BaseBoltTest {
 
   /**
    * {
-   *   "inputTopic": "enrichment",
    *   "profiles": [
    *      {
    *        "profile": "test",
@@ -92,7 +90,6 @@ public class ProfileSplitterBoltTest extends BaseBoltTest {
 
   /**
    * {
-   *   "inputTopic": "enrichment",
    *   "profiles": [
    *      {
    *        "profile": "test",
@@ -109,7 +106,6 @@ public class ProfileSplitterBoltTest extends BaseBoltTest {
 
   /**
    * {
-   *   "inputTopic": "enrichment",
    *   "profiles": [
    *      {
    *        "profile": "test",

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfilerConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/profiler/ProfilerConfig.java
@@ -27,22 +27,9 @@ import java.util.List;
 public class ProfilerConfig implements Serializable {
 
   /**
-   * The input topic from which messages will be read.
-   */
-  private String inputTopic;
-
-  /**
    * One or more profile definitions.
    */
   private List<ProfileConfig> profiles = new ArrayList<>();
-
-  public String getInputTopic() {
-    return inputTopic;
-  }
-
-  public void setInputTopic(String inputTopic) {
-    this.inputTopic = inputTopic;
-  }
 
   public List<ProfileConfig> getProfiles() {
     return profiles;
@@ -58,16 +45,11 @@ public class ProfilerConfig implements Serializable {
     if (o == null || getClass() != o.getClass()) return false;
 
     ProfilerConfig that = (ProfilerConfig) o;
-
-    if (inputTopic != null ? !inputTopic.equals(that.inputTopic) : that.inputTopic != null) return false;
     return profiles != null ? profiles.equals(that.profiles) : that.profiles == null;
-
   }
 
   @Override
   public int hashCode() {
-    int result = inputTopic != null ? inputTopic.hashCode() : 0;
-    result = 31 * result + (profiles != null ? profiles.hashCode() : 0);
-    return result;
+    return profiles != null ? profiles.hashCode() : 0;
   }
 }


### PR DESCRIPTION
The `inputTopic` field that is part of the Profiler definition (aka `ProfilerConfig`) is not used.  The input topic is defined by the topology configuration contained within the static `profiler.properties` file.  The `inputTopic` field should be removed from the Profiler definition as it is misleading.

All integration tests have been updated to reflect and test this change.