### PR TITLE
METRON-449 JSONMapParser should unfold maps to arbitrary depths

### DIFF
--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/json/JSONMapParserTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/json/JSONMapParserTest.java
@@ -56,7 +56,7 @@ public class JSONMapParserTest {
 
   /**
    {
-    "collection" : { "blah" : 7, "blah2" : "foo" }
+    "collection" : { "blah" : 7, "blah2" : "foo", "bigblah" : { "innerBlah" : "baz", "reallyInnerBlah" : { "color" : "grey" }}}
    }
    */
    @Multiline
@@ -102,10 +102,12 @@ public class JSONMapParserTest {
     List<JSONObject> output = parser.parse(collectionHandlingJSON.getBytes());
     Assert.assertEquals(output.size(), 1);
     //don't forget the timestamp field!
-    Assert.assertEquals(output.get(0).size(), 4);
+    Assert.assertEquals(output.get(0).size(), 6);
     JSONObject message = output.get(0);
     Assert.assertEquals(message.get("collection.blah"), 7);
     Assert.assertEquals(message.get("collection.blah2"), "foo");
+    Assert.assertEquals(message.get("collection.bigblah.innerBlah"),"baz");
+    Assert.assertEquals(message.get("collection.bigblah.reallyInnerBlah.color"),"grey");
     Assert.assertNotNull(message.get("timestamp"));
     Assert.assertTrue(message.get("timestamp") instanceof Number);
   }

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/json/JSONMapParserTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/json/JSONMapParserTest.java
@@ -62,6 +62,17 @@ public class JSONMapParserTest {
    @Multiline
    static String collectionHandlingJSON;
 
+  /**
+    {
+     "collection" : {
+        "key" : "value"
+      },
+     "key" : "value"
+    }
+   */
+  @Multiline
+  static String mixCollectionHandlingJSON;
+
   @Test
   public void testCollectionHandlingDrop() {
     JSONMapParser parser = new JSONMapParser();
@@ -110,5 +121,18 @@ public class JSONMapParserTest {
     Assert.assertEquals(message.get("collection.bigblah.reallyInnerBlah.color"),"grey");
     Assert.assertNotNull(message.get("timestamp"));
     Assert.assertTrue(message.get("timestamp") instanceof Number);
+  }
+
+  @Test
+  public void testMixedCollectionHandlingUnfold() {
+    JSONMapParser parser = new JSONMapParser();
+    parser.configure(ImmutableMap.of(JSONMapParser.MAP_STRATEGY_CONFIG,JSONMapParser.MapStrategy.UNFOLD.name()));
+    List<JSONObject> output = parser.parse(mixCollectionHandlingJSON.getBytes());
+    Assert.assertEquals(output.get(0).size(), 4);
+    JSONObject message = output.get(0);
+    Assert.assertEquals(message.get("collection.key"), "value");
+    Assert.assertEquals(message.get("key"),"value");
+    Assert.assertNotNull(message.get("timestamp"));
+    Assert.assertTrue(message.get("timestamp") instanceof Number );
   }
 }


### PR DESCRIPTION
The JSON Parser currently only unfolds maps at the root level.  The parser would support a wider range of sources is it supported unfolding maps at any depth of the document.

METRON-449 adds a recursive function to unfold Maps as they are encountered when parsing.  A new function was added because the enum lambdas cannot reference themselves.