### PR TITLE
METRON-455: Create stellar management functions to put, get and list data in HDFS

### DIFF
--- a/metron-platform/metron-management/README.md
+++ b/metron-platform/metron-management/README.md
@@ -19,10 +19,61 @@ project.
 
 The functions are split roughly into a few sections:
 * Shell functions - Functions surrounding interacting with the shell in either a nicer way or a more functional way.
+* File functions - Functions around interacting with local or HDFS files
 * Configuration functions - Functions surrounding pulling and pushing configs from zookeeper
 * Parser functions - Functions surrounding adding, viewing, and removing Parser functions.
 * Enrichment functions - Functions surrounding adding, viewing and removing Stellar enrichments as well as managing batch size and index names for the enrichment topology configuration
 * Threat Triage functions - Functions surrounding adding, viewing and removing threat triage functions.
+
+### File Functions
+
+* Local Files
+  * `FILE_LS`
+    * Description: Lists the contents of a directory.
+    * Input:
+      * path - The path of the file
+    * Returns: The contents of the directory in tabular form sorted by last modification date.
+  * `FILE_RM`
+    * Description: Removes the path
+    * Input:
+      * path - The path of the file or directory.
+      * recursive - Recursively remove or not (optional and defaulted to false)
+    * Returns: boolean - true if successful, false otherwise
+  * `FILE_GET`
+    * Description: Retrieves the contents as a string of a file.
+    * Input:
+      * path - The path of the file
+    * Returns: The contents of the file and null otherwise.
+  * `FILE_PUT`
+    * Description: Writes the contents of a string to a local file
+    * Input:
+      * content - The content to write out
+      * path - The path of the file
+    * Returns: true if the file was written and false otherwise.
+* HDFS Files
+  * `HDFS_LS`
+    * Description: Lists the contents of a directory in HDFS.
+    * Input:
+      * path - The path of the file
+    * Returns: The contents of the directory in tabular form sorted by last modification date.
+  * `HDFS_RM`
+    * Description: Removes the path in HDFS.
+    * Input:
+      * path - The path of the file or directory.
+      * recursive - Recursively remove or not (optional and defaulted to false)
+    * Returns: boolean - true if successful, false otherwise
+  * `HDFS_GET`
+    * Description: Retrieves the contents as a string of a file in HDFS.
+    * Input:
+      * path - The path of the file
+    * Returns: The contents of the file and null otherwise.
+  * `HDFS_PUT`
+    * Description: Writes the contents of a string to a HDFS file
+    * Input:
+      * content - The content to write out
+      * path - The path of the file
+    * Returns: true if the file was written and false otherwise.
+
 
 ### Shell Functions 
 

--- a/metron-platform/metron-management/README.md
+++ b/metron-platform/metron-management/README.md
@@ -44,6 +44,11 @@ The functions are split roughly into a few sections:
     * Input:
       * path - The path of the file
     * Returns: The contents of the file and null otherwise.
+  * `FILE_GET_LIST`
+    * Description: Retrieves the contents of a file as a list of strings.
+    * Input:
+      * path - The path of the file
+    * Returns: A list of lines
   * `FILE_PUT`
     * Description: Writes the contents of a string to a local file
     * Input:
@@ -67,6 +72,11 @@ The functions are split roughly into a few sections:
     * Input:
       * path - The path of the file
     * Returns: The contents of the file and null otherwise.
+  * `HDFS_GET_LIST`
+    * Description: Retrieves the contents of a HDFS file as a list of strings.
+    * Input:
+      * path - The path of the file
+    * Returns: A list of lines
   * `HDFS_PUT`
     * Description: Writes the contents of a string to a HDFS file
     * Input:

--- a/metron-platform/metron-management/README.md
+++ b/metron-platform/metron-management/README.md
@@ -28,28 +28,28 @@ The functions are split roughly into a few sections:
 ### File Functions
 
 * Local Files
-  * `FILE_LS`
+  * `LOCAL_LS`
     * Description: Lists the contents of a directory.
     * Input:
       * path - The path of the file
     * Returns: The contents of the directory in tabular form sorted by last modification date.
-  * `FILE_RM`
+  * `LOCAL_RM`
     * Description: Removes the path
     * Input:
       * path - The path of the file or directory.
       * recursive - Recursively remove or not (optional and defaulted to false)
     * Returns: boolean - true if successful, false otherwise
-  * `FILE_GET`
+  * `LOCAL_READ`
     * Description: Retrieves the contents as a string of a file.
     * Input:
       * path - The path of the file
     * Returns: The contents of the file and null otherwise.
-  * `FILE_GET_LIST`
+  * `LOCAL_READ_LIST`
     * Description: Retrieves the contents of a file as a list of strings.
     * Input:
       * path - The path of the file
     * Returns: A list of lines
-  * `FILE_PUT`
+  * `LOCAL_WRITE`
     * Description: Writes the contents of a string to a local file
     * Input:
       * content - The content to write out
@@ -67,17 +67,17 @@ The functions are split roughly into a few sections:
       * path - The path of the file or directory.
       * recursive - Recursively remove or not (optional and defaulted to false)
     * Returns: boolean - true if successful, false otherwise
-  * `HDFS_GET`
+  * `HDFS_READ`
     * Description: Retrieves the contents as a string of a file in HDFS.
     * Input:
       * path - The path of the file
     * Returns: The contents of the file and null otherwise.
-  * `HDFS_GET_LIST`
+  * `HDFS_READ_LIST`
     * Description: Retrieves the contents of a HDFS file as a list of strings.
     * Input:
       * path - The path of the file
     * Returns: A list of lines
-  * `HDFS_PUT`
+  * `HDFS_WRITE`
     * Description: Writes the contents of a string to a HDFS file
     * Input:
       * content - The content to write out

--- a/metron-platform/metron-management/README.md
+++ b/metron-platform/metron-management/README.md
@@ -44,7 +44,7 @@ The functions are split roughly into a few sections:
     * Input:
       * path - The path of the file
     * Returns: The contents of the file and null otherwise.
-  * `LOCAL_READ_LIST`
+  * `LOCAL_READ_LINES`
     * Description: Retrieves the contents of a file as a list of strings.
     * Input:
       * path - The path of the file
@@ -72,7 +72,7 @@ The functions are split roughly into a few sections:
     * Input:
       * path - The path of the file
     * Returns: The contents of the file and null otherwise.
-  * `HDFS_READ_LIST`
+  * `HDFS_READ_LINES`
     * Description: Retrieves the contents of a HDFS file as a list of strings.
     * Input:
       * path - The path of the file

--- a/metron-platform/metron-management/pom.xml
+++ b/metron-platform/metron-management/pom.xml
@@ -84,6 +84,12 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minicluster</artifactId>
+            <version>${global_hadoop_version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/metron-platform/metron-management/pom.xml
+++ b/metron-platform/metron-management/pom.xml
@@ -48,6 +48,24 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+            <version>${global_hadoop_version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>servlet-api</artifactId>
+                    <groupId>javax.servlet</groupId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${global_hadoop_version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <version>2.7.1</version>
@@ -66,7 +84,6 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <reporting>

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
@@ -209,15 +209,29 @@ public class FileSystemFunctions {
 
     @Override
     public Object apply(List<Object> args, Context context) throws ParseException {
-
-      String path = (String) args.get(0);
-      if(path == null) {
-        return false;
+      Path path = null;
+      if(args.size() == 0) {
+        path = fs.getHomeDirectory();
+      }
+      else {
+        String pathStr = (String) args.get(0);
+        if (path == null) {
+          return false;
+        }
+        else {
+          try {
+            path = new Path(pathStr);
+          }
+          catch(IllegalArgumentException iae) {
+            LOG.error("Unable to convert " + pathStr + " to a path: " + iae.getMessage(), iae);
+            return false;
+          }
+        }
       }
       try {
         String[] headers = new String[] {"PERMISSION", "OWNER", "GROUP", "SIZE", "LAST MOD TIME", "NAME"};
         List<String[]> dataList = new ArrayList<>();
-        for(FileStatus status : fs.listStatus(new Path(path))) {
+        for(FileStatus status : fs.listStatus(path)) {
           dataList.add(new String[] {
             status.getPermission().toString()
            ,status.getOwner()

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
@@ -254,7 +254,7 @@ public class FileSystemFunctions {
                 return ret;
               }
             } catch (java.text.ParseException e) {
-              String message = "Unable to parse " + o1 + " or " + o2 + ": " + e.getMessage();
+              String message = "Unable to parse " + o1 + " or " + o2 + " : " + e.getMessage();
               LOG.error(message, e);
               throw new IllegalStateException(message, e);
             }
@@ -265,7 +265,7 @@ public class FileSystemFunctions {
         }
         return FlipTable.of(headers, data);
       } catch (IOException e) {
-        String message = "Unable to list" + path + ": " + e.getMessage();
+        String message = "Unable to list" + path + " : " + e.getMessage();
         LOG.error(message, e);
         return FlipTable.of(headers, new String[][]{});
       }

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
@@ -210,13 +210,14 @@ public class FileSystemFunctions {
     @Override
     public Object apply(List<Object> args, Context context) throws ParseException {
       Path path = null;
+      String[] headers = new String[] {"PERMISSION", "OWNER", "GROUP", "SIZE", "LAST MOD TIME", "NAME"};
       if(args.size() == 0) {
         path = fs.getHomeDirectory();
       }
       else {
         String pathStr = (String) args.get(0);
-        if (path == null) {
-          return false;
+        if (pathStr == null) {
+          return FlipTable.of(headers, new String[][]{});
         }
         else {
           try {
@@ -224,12 +225,11 @@ public class FileSystemFunctions {
           }
           catch(IllegalArgumentException iae) {
             LOG.error("Unable to convert " + pathStr + " to a path: " + iae.getMessage(), iae);
-            return false;
+            return FlipTable.of(headers, new String[][]{});
           }
         }
       }
       try {
-        String[] headers = new String[] {"PERMISSION", "OWNER", "GROUP", "SIZE", "LAST MOD TIME", "NAME"};
         List<String[]> dataList = new ArrayList<>();
         for(FileStatus status : fs.listStatus(path)) {
           dataList.add(new String[] {
@@ -267,7 +267,7 @@ public class FileSystemFunctions {
       } catch (IOException e) {
         String message = "Unable to list" + path + ": " + e.getMessage();
         LOG.error(message, e);
-        return null;
+        return FlipTable.of(headers, new String[][]{});
       }
     }
   }

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
@@ -389,7 +389,7 @@ public class FileSystemFunctions {
   }
 
   @Stellar(namespace="HDFS"
-          ,name="READ_LIST"
+          ,name="READ_LINES"
           ,description="Retrieves the contents of a HDFS file as a list of strings."
           ,params = { "path - The path in HDFS of the file."}
           ,returns = "A list of lines"
@@ -402,7 +402,7 @@ public class FileSystemFunctions {
   }
 
   @Stellar(namespace="LOCAL"
-          ,name="READ_LIST"
+          ,name="READ_LINES"
           ,description="Retrieves the contents of a file as a list of strings."
           ,params = { "path - The path of the file."}
           ,returns = "A list of lines"

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
@@ -1,0 +1,307 @@
+package org.apache.metron.management;
+
+import com.jakewharton.fliptables.FlipTable;
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.*;
+import org.apache.log4j.Logger;
+import org.apache.metron.common.dsl.Context;
+import org.apache.metron.common.dsl.ParseException;
+import org.apache.metron.common.dsl.Stellar;
+import org.apache.metron.common.dsl.StellarFunction;
+import org.apache.metron.common.utils.ConversionUtils;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.util.*;
+
+public class FileSystemFunctions {
+  private static final Logger LOG = Logger.getLogger(FileSystemFunctions.class);
+
+  private static abstract class AbstractFileSystemFunction implements StellarFunction {
+    protected FileSystem fs;
+
+    @Override
+    public void initialize(Context context) {
+      try {
+        fs = getFs();
+      } catch (IOException e) {
+        String message = "Unable to get FileSystem: " + e.getMessage();
+        LOG.error(message, e);
+        throw new IllegalStateException(message, e);
+      }
+    }
+
+    @Override
+    public boolean isInitialized() {
+      return fs != null;
+    }
+
+    public abstract FileSystem getFs() throws IOException;
+  }
+
+  private static abstract class FileSystemGet extends AbstractFileSystemFunction {
+
+    @Override
+    public Object apply(List<Object> args, Context context) throws ParseException {
+      String path = (String) args.get(0);
+      if(path == null) {
+        return null;
+      }
+      try(FSDataInputStream is = fs.open(new Path(path))) {
+        return IOUtils.toString(is);
+      } catch (IOException e) {
+        String message = "Unable to read " + path + ": " + e.getMessage();
+        LOG.error(message, e);
+        return null;
+      }
+    }
+  }
+
+  public static abstract class FileSystemRm extends AbstractFileSystemFunction {
+
+    @Override
+    public Object apply(List<Object> args, Context context) throws ParseException {
+
+      String path = (String) args.get(0);
+      if(path == null) {
+        return false;
+      }
+
+      boolean recursive = false;
+      if(args.size() > 1) {
+        recursive = ConversionUtils.convert(args.get(1), Boolean.class);
+      }
+
+      try {
+        fs.delete(new Path(path), recursive);
+        return true;
+      } catch (IOException e) {
+        String message = "Unable to remove " + path + (recursive?" recursively":"") + ": " + e.getMessage();
+        LOG.error(message, e);
+        return false;
+      }
+    }
+  }
+
+  public static abstract class FileSystemPut extends AbstractFileSystemFunction {
+
+    @Override
+    public Object apply(List<Object> args, Context context) throws ParseException {
+      String content = (String)args.get(0);
+      if(content == null) {
+        return false;
+      }
+      String path = (String) args.get(1);
+      if(path == null) {
+        return false;
+      }
+
+      try(FSDataOutputStream os = fs.create(new Path(path))) {
+        os.writeChars(content);
+        os.flush();
+        return true;
+      } catch (IOException e) {
+        String message = "Unable to write " + path + ": " + e.getMessage();
+        LOG.error(message, e);
+        return false;
+      }
+    }
+  }
+
+  public static abstract class FileSystemLs extends AbstractFileSystemFunction {
+    private static ThreadLocal<DateFormat> dateFormat = new ThreadLocal<DateFormat>() {
+
+      @Override
+      protected DateFormat initialValue() {
+        return DateFormat.getDateTimeInstance(
+                DateFormat.DEFAULT,
+                DateFormat.DEFAULT,
+                Locale.getDefault()
+                );
+      }
+    };
+
+    @Override
+    public Object apply(List<Object> args, Context context) throws ParseException {
+
+      String path = (String) args.get(1);
+      if(path == null) {
+        return false;
+      }
+      try {
+        String[] headers = new String[] {"PERMISSION", "OWNER", "GROUP", "SIZE", "LAST MOD TIME", "NAME"};
+        List<String[]> dataList = new ArrayList<>();
+        for(RemoteIterator<LocatedFileStatus> it = fs.listFiles(new Path(path), false);it.hasNext();) {
+          final FileStatus status = it.next();
+          dataList.add(new String[] {
+            status.getPermission().toString()
+           ,status.getOwner()
+           ,status.getGroup()
+           ,status.getLen() + ""
+           ,dateFormat.get().format(new Date(status.getModificationTime()))
+           ,status.getPath().getName()
+          });
+        }
+        Collections.sort(dataList, (o1, o2) -> {
+            try {
+              Date left = dateFormat.get().parse(o1[4]);
+              Date right = dateFormat.get().parse(o2[4]);
+              int ret = left.compareTo(right);
+              //first sort by date, then by name.
+              if(ret == 0) {
+                return o1[5].compareTo(o2[5]);
+              }
+              else {
+                return ret;
+              }
+            } catch (java.text.ParseException e) {
+              String message = "Unable to parse " + o1 + " or " + o2 + ": " + e.getMessage();
+              LOG.error(message, e);
+              throw new IllegalStateException(message, e);
+            }
+        });
+        String[][] data = new String[dataList.size()][headers.length];
+        for(int i = 0;i < dataList.size();++i) {
+          data[i] = dataList.get(i);
+        }
+        return FlipTable.of(headers, data);
+      } catch (IOException e) {
+        String message = "Unable to list" + path + ": " + e.getMessage();
+        LOG.error(message, e);
+        return null;
+      }
+    }
+  }
+
+  @Stellar(namespace="FILE"
+          ,name="RM"
+          ,description="Removes the path"
+          ,params = { "path - The path of the file."
+                    , "recursive - Recursively remove or not (optional and defaulted to false)"
+                    }
+          ,returns = "boolean - true if successful, false otherwise."
+
+  )
+  public static class FileRm extends FileSystemRm {
+
+    @Override
+    public FileSystem getFs() throws IOException {
+      return new LocalFileSystem();
+    }
+  }
+
+  @Stellar(namespace="HDFS"
+          ,name="RM"
+          ,description="Removes the path"
+          ,params = { "path - The path in HDFS of the file."
+                    , "recursive - Recursively remove or not (optional and defaulted to false)"
+                    }
+          ,returns = "boolean - true if successful, false otherwise."
+
+  )
+  public static class HDFSRm extends FileSystemRm {
+
+    @Override
+    public FileSystem getFs() throws IOException {
+      return FileSystem.get(new Configuration());
+    }
+  }
+
+  @Stellar(namespace="FILE"
+          ,name="LS"
+          ,description="Lists the contents of a directory"
+          ,params = { "path - The path of the file."
+                    }
+          ,returns = "The contents of the directory in tabular form sorted by last modification date."
+
+  )
+  public static class FileLs extends FileSystemLs {
+
+    @Override
+    public FileSystem getFs() throws IOException {
+      return new LocalFileSystem();
+    }
+  }
+
+  @Stellar(namespace="HDFS"
+          ,name="LS"
+          ,description="Lists the contents of a directory"
+          ,params = { "path - The path in HDFS of the file."
+                    }
+          ,returns = "The contents of the directory in tabular form sorted by last modification date."
+
+  )
+  public static class HDFSLs extends FileSystemLs {
+
+    @Override
+    public FileSystem getFs() throws IOException {
+      return FileSystem.get(new Configuration());
+    }
+  }
+
+  @Stellar(namespace="HDFS"
+          ,name="PUT"
+          ,description="Writes the contents a string to a file in HDFS."
+          ,params = { "content - The content to write out"
+                    , "path - The path in HDFS of the file."
+                    }
+          ,returns = "true if the file was written and false otherwise."
+
+  )
+  public static class HDFSPut extends FileSystemPut {
+
+    @Override
+    public FileSystem getFs() throws IOException {
+      return FileSystem.get(new Configuration());
+    }
+  }
+
+  @Stellar(namespace="FILE"
+          ,name="PUT"
+          ,description="Writes the contents a string to a local file."
+          ,params = { "content - The content to write out"
+                    , "path - The path of the file."
+                    }
+          ,returns = "true if the file was written and false otherwise."
+
+  )
+  public static class FilePut extends FileSystemPut {
+
+    @Override
+    public FileSystem getFs() throws IOException {
+      return new LocalFileSystem();
+    }
+  }
+
+  @Stellar(namespace="HDFS"
+          ,name="GET"
+          ,description="Retrieves the contents as a string of a file in HDFS."
+          ,params = { "path - The path in HDFS of the file."}
+          ,returns = "The contents of the file in the path from HDFS and null otherwise."
+
+  )
+  public static class HDFSGet extends FileSystemGet {
+
+    @Override
+    public FileSystem getFs() throws IOException {
+      return FileSystem.get(new Configuration());
+    }
+  }
+
+  @Stellar(namespace="FILE"
+          ,name="GET"
+          ,description="Retrieves the contents as a string of a file on the local filesystem."
+          ,params = { "path - The path of the file."}
+          ,returns = "The contents of the file or null otherwise."
+
+  )
+  public static class FileGet extends FileSystemGet {
+
+    @Override
+    public FileSystem getFs() throws IOException {
+      return new LocalFileSystem();
+    }
+  }
+
+}

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
@@ -258,7 +258,7 @@ public class FileSystemFunctions {
     }
   }
 
-  @Stellar(namespace="FILE"
+  @Stellar(namespace="LOCAL"
           ,name="RM"
           ,description="Removes the path"
           ,params = { "path - The path of the file or directory."
@@ -288,7 +288,7 @@ public class FileSystemFunctions {
     }
   }
 
-  @Stellar(namespace="FILE"
+  @Stellar(namespace="LOCAL"
           ,name="LS"
           ,description="Lists the contents of a directory"
           ,params = { "path - The path of the file."
@@ -317,7 +317,7 @@ public class FileSystemFunctions {
   }
 
   @Stellar(namespace="HDFS"
-          ,name="PUT"
+          ,name="WRITE"
           ,description="Writes the contents a string to a file in HDFS."
           ,params = { "content - The content to write out"
                     , "path - The path in HDFS of the file."
@@ -333,8 +333,8 @@ public class FileSystemFunctions {
     }
   }
 
-  @Stellar(namespace="FILE"
-          ,name="PUT"
+  @Stellar(namespace="LOCAL"
+          ,name="WRITE"
           ,description="Writes the contents a string to a local file."
           ,params = { "content - The content to write out"
                     , "path - The path of the file."
@@ -349,7 +349,7 @@ public class FileSystemFunctions {
   }
 
   @Stellar(namespace="HDFS"
-          ,name="GET"
+          ,name="READ"
           ,description="Retrieves the contents as a string of a file in HDFS."
           ,params = { "path - The path in HDFS of the file."}
           ,returns = "The contents of the file in the path from HDFS and null otherwise."
@@ -361,8 +361,8 @@ public class FileSystemFunctions {
     }
   }
 
-  @Stellar(namespace="FILE"
-          ,name="GET"
+  @Stellar(namespace="LOCAL"
+          ,name="READ"
           ,description="Retrieves the contents as a string of a file on the local filesystem."
           ,params = { "path - The path of the file."}
           ,returns = "The contents of the file or null otherwise."
@@ -375,7 +375,7 @@ public class FileSystemFunctions {
   }
 
   @Stellar(namespace="HDFS"
-          ,name="GET_LIST"
+          ,name="READ_LIST"
           ,description="Retrieves the contents of a HDFS file as a list of strings."
           ,params = { "path - The path in HDFS of the file."}
           ,returns = "A list of lines"
@@ -387,8 +387,8 @@ public class FileSystemFunctions {
     }
   }
 
-  @Stellar(namespace="FILE"
-          ,name="GET_LIST"
+  @Stellar(namespace="LOCAL"
+          ,name="READ_LIST"
           ,description="Retrieves the contents of a file as a list of strings."
           ,params = { "path - The path of the file."}
           ,returns = "A list of lines"

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
@@ -100,10 +100,7 @@ public class FileSystemFunctions {
         return null;
       }
       try(FSDataInputStream is = fs.open(new Path(path))) {
-        List<String> out = new ArrayList<>();
-        Iterable<String> lines = Splitter.on("\n").split(IOUtils.toString(is));
-        Iterables.addAll(out, lines);
-        return out;
+        return IOUtils.readLines(is);
       } catch (IOException e) {
         String message = "Unable to read " + path + ": " + e.getMessage();
         LOG.error(message, e);

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/FileSystemFunctions.java
@@ -237,7 +237,7 @@ public class FileSystemFunctions {
   @Stellar(namespace="FILE"
           ,name="RM"
           ,description="Removes the path"
-          ,params = { "path - The path of the file."
+          ,params = { "path - The path of the file or directory."
                     , "recursive - Recursively remove or not (optional and defaulted to false)"
                     }
           ,returns = "boolean - true if successful, false otherwise."

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/FileSystemFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/FileSystemFunctionsTest.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.management;
+
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.metron.common.dsl.Context;
+import org.apache.metron.common.dsl.StellarFunctions;
+import org.apache.metron.common.stellar.StellarProcessor;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(Parameterized.class)
+public class FileSystemFunctionsTest {
+  private FileSystemFunctions.FS_TYPE type;
+  private FileSystemFunctions.FileSystemGetter fsGetter = null;
+  private File baseDir;
+  private MiniDFSCluster hdfsCluster;
+  private String prefix;
+  private Context context = null;
+  private FileSystemFunctions.FileSystemGet get;
+  private FileSystemFunctions.FileSystemLs ls;
+  private FileSystemFunctions.FileSystemPut put;
+  private FileSystemFunctions.FileSystemRm rm;
+
+  public FileSystemFunctionsTest(FileSystemFunctions.FS_TYPE type) {
+    this.type = type;
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> types() {
+    return Arrays.asList(new Object[][]{
+      {FileSystemFunctions.FS_TYPE.HDFS}
+    , {FileSystemFunctions.FS_TYPE.LOCAL}
+    });
+  }
+
+  @Before
+  public void setup() throws IOException {
+    if(type == FileSystemFunctions.FS_TYPE.HDFS) {
+      baseDir = Files.createTempDirectory("test_hdfs").toFile().getAbsoluteFile();
+      Configuration conf = new Configuration();
+      conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
+      MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);
+      hdfsCluster = builder.build();
+
+      fsGetter = () -> hdfsCluster.getFileSystem();
+      prefix = "/";
+    }
+    else {
+      fsGetter = FileSystemFunctions.FS_TYPE.LOCAL;
+      prefix = "target/fsTest/";
+      if(new File(prefix).exists()) {
+        new File(prefix).delete();
+      }
+      new File(prefix).mkdirs();
+    }
+
+    get = new FileSystemFunctions.FileSystemGet(fsGetter);
+    get.initialize(null);
+    ls = new FileSystemFunctions.FileSystemLs(fsGetter);
+    ls.initialize(null);
+    put = new FileSystemFunctions.FileSystemPut(fsGetter);
+    put.initialize(null);
+    rm  = new FileSystemFunctions.FileSystemRm(fsGetter);
+    rm.initialize(null);
+  }
+
+  @After
+  public void teardown() {
+    if(type == FileSystemFunctions.FS_TYPE.HDFS) {
+      hdfsCluster.shutdown();
+      FileUtil.fullyDelete(baseDir);
+    }
+    else {
+      new File(prefix).delete();
+    }
+  }
+
+  @Test
+  public void testHappyPath() {
+    Object putOut = put.apply(Arrays.asList("foo", prefix + "testPut.dat"), null);
+    Assert.assertTrue((Boolean) putOut);
+    String getOut = (String)get.apply(Arrays.asList(prefix + "testPut.dat"), null);
+    Assert.assertEquals("foo", getOut);
+    Boolean rmRet = (Boolean)rm.apply(Arrays.asList(prefix + "testPut.dat"), null);
+    Assert.assertTrue(rmRet);
+    String lsOut = (String) ls.apply(Arrays.asList(prefix), null);
+    Assert.assertTrue(lsOut.contains("(empty)"));
+  }
+
+  @Test
+  public void testPutMissingFile() {
+    Object o = put.apply(Arrays.asList("foo", null), null);
+    Assert.assertFalse((Boolean) o);
+    String lsOut = (String) ls.apply(Arrays.asList(prefix), null);
+    Assert.assertTrue(lsOut.contains("(empty)"));
+  }
+
+  @Test
+  public void testRmTwice() {
+    Object putOut = put.apply(Arrays.asList("foo", prefix + "testPut.dat"), null);
+    Assert.assertTrue((Boolean) putOut);
+    Boolean rmRet = (Boolean)rm.apply(Arrays.asList(prefix + "testPut.dat"), null);
+    Assert.assertTrue(rmRet);
+    rmRet = (Boolean)rm.apply(Arrays.asList(prefix + "testPut.dat"), null);
+    Assert.assertTrue(rmRet);
+    String lsOut = (String) ls.apply(Arrays.asList(prefix), null);
+    Assert.assertTrue(lsOut.contains("(empty)"));
+  }
+
+  @Test
+  public void testRecursiveRm() {
+    Object putOut = put.apply(Arrays.asList("foo", prefix + "blah/testPut.dat"), null);
+    Assert.assertTrue((Boolean) putOut);
+    putOut = put.apply(Arrays.asList("grok", prefix + "blah/testPut2.dat"), null);
+    Assert.assertTrue((Boolean) putOut);
+    Assert.assertEquals("foo", (String)get.apply(Arrays.asList(prefix + "blah/testPut.dat"), null));
+    Assert.assertEquals("grok", (String)get.apply(Arrays.asList(prefix + "blah/testPut2.dat"), null));
+    boolean rmRet = (Boolean)rm.apply(Arrays.asList(prefix + "blah", true), null);
+    Assert.assertTrue(rmRet);
+    String lsOut = (String) ls.apply(Arrays.asList(prefix), null);
+    Assert.assertTrue(lsOut.contains("(empty)"));
+  }
+
+}

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/FileSystemFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/FileSystemFunctionsTest.java
@@ -114,9 +114,11 @@ public class FileSystemFunctionsTest {
     Assert.assertTrue((Boolean) putOut);
     String getOut = (String)get.apply(Arrays.asList(prefix + "testPut.dat"), null);
     Assert.assertEquals("foo", getOut);
+    String lsOut = (String) ls.apply(Arrays.asList(prefix), null);
+    Assert.assertFalse(lsOut.contains("(empty)"));
     Boolean rmRet = (Boolean)rm.apply(Arrays.asList(prefix + "testPut.dat"), null);
     Assert.assertTrue(rmRet);
-    String lsOut = (String) ls.apply(Arrays.asList(prefix), null);
+    lsOut = (String) ls.apply(Arrays.asList(prefix), null);
     Assert.assertTrue(lsOut.contains("(empty)"));
   }
 

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/FileSystemFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/FileSystemFunctionsTest.java
@@ -36,10 +36,7 @@ import org.junit.runners.Parameterized;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 @RunWith(Parameterized.class)
 public class FileSystemFunctionsTest {
@@ -50,6 +47,7 @@ public class FileSystemFunctionsTest {
   private String prefix;
   private Context context = null;
   private FileSystemFunctions.FileSystemGet get;
+  private FileSystemFunctions.FileSystemGetList getList;
   private FileSystemFunctions.FileSystemLs ls;
   private FileSystemFunctions.FileSystemPut put;
   private FileSystemFunctions.FileSystemRm rm;
@@ -89,6 +87,8 @@ public class FileSystemFunctionsTest {
 
     get = new FileSystemFunctions.FileSystemGet(fsGetter);
     get.initialize(null);
+    getList = new FileSystemFunctions.FileSystemGetList(fsGetter);
+    getList.initialize(null);
     ls = new FileSystemFunctions.FileSystemLs(fsGetter);
     ls.initialize(null);
     put = new FileSystemFunctions.FileSystemPut(fsGetter);
@@ -120,6 +120,18 @@ public class FileSystemFunctionsTest {
     Assert.assertTrue(rmRet);
     lsOut = (String) ls.apply(Arrays.asList(prefix), null);
     Assert.assertTrue(lsOut.contains("(empty)"));
+  }
+
+  @Test
+  public void testGetList() {
+    Object putOut = put.apply(Arrays.asList("foo\nbar", prefix + "testPut.dat"), null);
+    Assert.assertTrue((Boolean) putOut);
+    String getOut = (String)get.apply(Arrays.asList(prefix + "testPut.dat"), null);
+    Assert.assertEquals("foo\nbar", getOut);
+    List<String> list = (List<String>) getList.apply(Arrays.asList(prefix + "testPut.dat"), null);
+    Assert.assertEquals(2,list.size());
+    Assert.assertEquals("foo",list.get(0));
+    Assert.assertEquals("bar",list.get(1));
   }
 
   @Test

--- a/metron-platform/metron-management/src/test/resources/log4j.properties
+++ b/metron-platform/metron-management/src/test/resources/log4j.properties
@@ -1,0 +1,19 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# log4j configuration used during build and unit tests
+
+log4j.rootLogger=error,stdout
+log4j.threshhold=ALL
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2} (%F:%M(%L)) - %m%n


### PR DESCRIPTION
Create functions around reading, writing and removing local and HDFS files.

Functions added:
* Interacting with HDFS
  * `HDFS_LS`
  * `HDFS_RM`
  * `HDFS_READ`
  * `HDFS_WRITE`
  * `HDFS_READ_LINES`
* Interacting with the local filesystem
  * `LOCAL_LS`
  * `LOCAL_RM`
  * `LOCAL_READ`
  * `LOCAL_WRITE`
  * `LOCAL_READ_LINES`

You can test these by deploying the management jar as per the instructions in `metron-management` and try them out in the Stellar REPL.