### PR TITLE
METRON-466: Full Dev Platform build sometimes fails

### DIFF
--- a/metron-deployment/extra_modules/ambari_cluster_state.py
+++ b/metron-deployment/extra_modules/ambari_cluster_state.py
@@ -181,7 +181,10 @@ def main():
 
             request = set_cluster_state(ambari_url, username, password, cluster_name, state)
             if wait_for_complete:
-                request_id = json.loads(request.content)['Requests']['id']
+                try:
+                    request_id = json.loads(request.content)['Requests']['id']
+                except ValueError:
+                    module.exit_json(changed=True, results=request.content)
                 status = wait_for_request_complete(ambari_url, username, password, cluster_name, request_id, 2)
                 if status != 'COMPLETED':
                     module.fail_json(msg="Request failed with status {0}".format(status))

--- a/metron-deployment/inventory/quick-dev-platform/group_vars/all
+++ b/metron-deployment/inventory/quick-dev-platform/group_vars/all
@@ -38,7 +38,6 @@ ambari_user: admin
 ambari_password: admin
 cluster_type: single_node_vm
 ambari_server_mem: 512
-java_home: /usr/jdk64/jdk1.8.0_77
 
 # hbase
 pcap_hbase_table: pcap

--- a/metron-deployment/inventory/quick-dev-platform/hosts
+++ b/metron-deployment/inventory/quick-dev-platform/hosts
@@ -1,0 +1,56 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+[ambari_master]
+node1
+
+[ambari_slave]
+node1
+
+[metron_hbase_tables]
+node1
+
+[metron_kafka_topics]
+node1
+
+[enrichment]
+node1
+
+[search]
+node1
+
+[web]
+node1
+
+[sensors]
+node1
+
+[pcap_server]
+node1
+
+[mysql]
+node1
+
+[metron:children]
+enrichment
+search
+web
+sensors
+mysql
+metron_kafka_topics
+metron_hbase_tables
+pcap_server

--- a/metron-deployment/vagrant/full-dev-platform/run.sh
+++ b/metron-deployment/vagrant/full-dev-platform/run.sh
@@ -17,4 +17,4 @@
 # limitations under the License.
 #
 
-vagrant --ansible-skip-tags="solr" up
+vagrant --ansible-skip-tags="solr,yaf" up

--- a/metron-deployment/vagrant/quick-dev-platform/Vagrantfile
+++ b/metron-deployment/vagrant/quick-dev-platform/Vagrantfile
@@ -87,7 +87,7 @@ Vagrant.configure(2) do |config|
         ansible.sudo = true
         ansible.tags = ansibleTags.split(",") if ansibleTags != ''
         ansible.skip_tags = ansibleSkipTags.split(",") if ansibleSkipTags != ''
-        ansible.inventory_path = "../../inventory/full-dev-platform"
+        ansible.inventory_path = "../../inventory/quick-dev-platform"
     end
   end
 

--- a/metron-deployment/vagrant/quick-dev-platform/run.sh
+++ b/metron-deployment/vagrant/quick-dev-platform/run.sh
@@ -19,5 +19,5 @@
 
 vagrant \
   --ansible-tags="hdp-deploy,metron" \
-  --ansible-skip-tags="solr" \
+  --ansible-skip-tags="solr,yaf" \
   up


### PR DESCRIPTION
Tested on Full Dev and Quick Dev.

Ambari seems to have changed their response in 2.4.0.1-1, if you request "START ALL" on a cluster where all services are already started, it doesn't actually make a request, so there is no request ID reported back.

I also suppressed starting of the Yaf probe (because we don't run the parser topology for Yaf) and bumped java_home so Snort would work.

I needed to separate the inventory directories for quick and full dev certain properties (in this case java_home) can lag between quick and full dev. 
 
Note- Full dev still doesn't come up cleanly after the build successfully completes due to what looks like insufficient memory. I've opened [METRON-467](https://issues.apache.org/jira/browse/METRON-467).