### PR TITLE
METRON-456: Create stellar management functions to test grok statements

### DIFF
--- a/metron-platform/metron-management/README.md
+++ b/metron-platform/metron-management/README.md
@@ -192,9 +192,9 @@ Please note that functions are loading lazily in the background and will be unav
 [Stellar]>>> #   1475022938.661      0 127.0.0.1 NONE/400 3500 GET www.google.com - NONE/- text/html
 [Stellar]>>> # Note that flimflammadeupdomain.com and www.google.com did not resolve to IPs
 [Stellar]>>> # We can load up these messages from disk into a list of messages
-[Stellar]>>> messages := FILE_GET_LIST( '/var/log/squid/access.log')
-30943 [Thread-1] INFO  o.r.Reflections - Reflections took 29317 ms to scan 22 urls, producing 17906 keys and 121560 values 
-31169 [Thread-1] INFO  o.a.m.c.d.FunctionResolverSingleton - Found 97 Stellar Functions...
+[Stellar]>>> messages := LOCAL_READ_LINES( '/var/log/squid/access.log')
+27687 [Thread-1] INFO  o.r.Reflections - Reflections took 26542 ms to scan 22 urls, producing 17906 keys and 121560 values 
+27837 [Thread-1] INFO  o.a.m.c.d.FunctionResolverSingleton - Found 97 Stellar Functions...
 Functions loaded, you may refer to functions now...
 [Stellar]>>> # and evaluate the messages against our grok statement
 [Stellar]>>> GROK_EVAL(squid_grok_orig, messages)
@@ -254,7 +254,6 @@ WORD:UNWANTED}/(%{IP:ip_dst_addr})?'
 [Stellar]>>> # Ahh, that is much better.
 [Stellar]>>> 
 [Stellar]>>> 
-
 ```
 
 ### Manage Stellar Field Transformations

--- a/metron-platform/metron-management/README.md
+++ b/metron-platform/metron-management/README.md
@@ -24,6 +24,20 @@ The functions are split roughly into a few sections:
 * Enrichment functions - Functions surrounding adding, viewing and removing Stellar enrichments as well as managing batch size and index names for the enrichment topology configuration
 * Threat Triage functions - Functions surrounding adding, viewing and removing threat triage functions.
 
+### Grok Functions
+
+* `GROK_EVAL`
+  * Description: Evaluate a grok expression for a statement.
+  * Input:
+    * grokExpression - The grok expression to evaluate
+    * data - Either a data message or a list of data messages to evaluate using the grokExpression
+  * Returns: The Map associated with the grok expression being evaluated on the list of messages.
+* `GROK_PREDICT`
+  * Description: Discover a grok statement for an input doc
+  * Input:
+    * data - The data to discover a grok expression from
+  * Returns: A grok expression that should match the data.
+
 ### Shell Functions 
 
 * `SHELL_EDIT`
@@ -164,6 +178,84 @@ Deployment is as simple as dropping the jar created by this project into
 ## Examples
 Included for description and education purposes are a couple example Stellar REPL transcripts
 with helpful comments to illustrate some common operations.
+
+### Iterate in finding a valid Grok pattern
+```
+Stellar, Go!
+Please note that functions are loading lazily in the background and will be unavailable until loaded fully.
+[Stellar]>>> # We are going to debug a squid grok statement with a bug in it
+[Stellar]>>> squid_grok_orig := '%{NUMBER:timestamp} %{SPACE:UNWANTED}  %{INT:elapsed} %{IP:ip_src_addr} %{WORD:action}/%{NUMBER:code} %{NUMBER:bytes} %{WORD:method} %{NOTSPACE:url} 
+ - %{WORD:UNWANTED}/%{IP:ip_dst_addr} %{WORD:UNWANTED}/%{WORD:UNWANTED}'
+[Stellar]>>> # We have gone ot a couple of domains in squid:
+[Stellar]>>> #   1475022887.362    256 127.0.0.1 TCP_MISS/301 803 GET http://www.youtube.com/ - DIRECT/216.58.216.238 text/html
+[Stellar]>>> #   1475022915.731      1 127.0.0.1 NONE/400 3520 GET flimflammadeupdomain.com - NONE/- text/html
+[Stellar]>>> #   1475022938.661      0 127.0.0.1 NONE/400 3500 GET www.google.com - NONE/- text/html
+[Stellar]>>> # Note that flimflammadeupdomain.com and www.google.com did not resolve to IPs
+[Stellar]>>> # We can load up these messages from disk into a list of messages
+[Stellar]>>> messages := FILE_GET_LIST( '/var/log/squid/access.log')
+30943 [Thread-1] INFO  o.r.Reflections - Reflections took 29317 ms to scan 22 urls, producing 17906 keys and 121560 values 
+31169 [Thread-1] INFO  o.a.m.c.d.FunctionResolverSingleton - Found 97 Stellar Functions...
+Functions loaded, you may refer to functions now...
+[Stellar]>>> # and evaluate the messages against our grok statement
+[Stellar]>>> GROK_EVAL(squid_grok_orig, messages)
+╔══════════╤═════════╤═════════╤═════════╤════════════════╤═════════════╤═════════╤════════════════╤═════════════════════════╗
+║ action   │ bytes   │ code    │ elapsed │ ip_dst_addr    │ ip_src_addr │ method  │ timestamp      │ url                     ║
+╠══════════╪═════════╪═════════╪═════════╪════════════════╪═════════════╪═════════╪════════════════╪═════════════════════════╣
+║ TCP_MISS │ 803     │ 301     │ 256     │ 216.58.216.238 │ 127.0.0.1   │ GET     │ 1475022887.362 │ http://www.youtube.com/ ║
+╟──────────┼─────────┼─────────┼─────────┼────────────────┼─────────────┼─────────┼────────────────┼─────────────────────────╢
+║ MISSING  │ MISSING │ MISSING │ MISSING │ MISSING        │ MISSING     │ MISSING │ MISSING        │ MISSING                 ║
+╟──────────┼─────────┼─────────┼─────────┼────────────────┼─────────────┼─────────┼────────────────┼─────────────────────────╢
+║ MISSING  │ MISSING │ MISSING │ MISSING │ MISSING        │ MISSING     │ MISSING │ MISSING        │ MISSING                 ║
+╚══════════╧═════════╧═════════╧═════════╧════════════════╧═════════════╧═════════╧════════════════╧═════════════════════════╝
+
+[Stellar]>>> # Uh oh, looks like the messages without destination IPs do not parse
+[Stellar]>>> # We can start peeling off groups from the end of the message until things parse
+[Stellar]>>> squid_grok := '%{NUMBER:timestamp} %{SPACE:UNWANTED}  %{INT:elapsed} %{IP:ip_src_addr} %{WORD:action}/%{NUMBER:code} %{NUMBER:bytes} %{WORD:method} %{NOTSPACE:url} - %{ 
+WORD:UNWANTED}/%{IP:ip_dst_addr}'
+[Stellar]>>> GROK_EVAL(squid_grok, messages)
+╔══════════╤═════════╤═════════╤═════════╤════════════════╤═════════════╤═════════╤════════════════╤═════════════════════════╗
+║ action   │ bytes   │ code    │ elapsed │ ip_dst_addr    │ ip_src_addr │ method  │ timestamp      │ url                     ║
+╠══════════╪═════════╪═════════╪═════════╪════════════════╪═════════════╪═════════╪════════════════╪═════════════════════════╣
+║ TCP_MISS │ 803     │ 301     │ 256     │ 216.58.216.238 │ 127.0.0.1   │ GET     │ 1475022887.362 │ http://www.youtube.com/ ║
+╟──────────┼─────────┼─────────┼─────────┼────────────────┼─────────────┼─────────┼────────────────┼─────────────────────────╢
+║ MISSING  │ MISSING │ MISSING │ MISSING │ MISSING        │ MISSING     │ MISSING │ MISSING        │ MISSING                 ║
+╟──────────┼─────────┼─────────┼─────────┼────────────────┼─────────────┼─────────┼────────────────┼─────────────────────────╢
+║ MISSING  │ MISSING │ MISSING │ MISSING │ MISSING        │ MISSING     │ MISSING │ MISSING        │ MISSING                 ║
+╚══════════╧═════════╧═════════╧═════════╧════════════════╧═════════════╧═════════╧════════════════╧═════════════════════════╝
+
+[Stellar]>>> # Still looks like it is having issues...
+[Stellar]>>> squid_grok := '%{NUMBER:timestamp} %{SPACE:UNWANTED}  %{INT:elapsed} %{IP:ip_src_addr} %{WORD:action}/%{NUMBER:code} %{NUMBER:bytes} %{WORD:method} %{NOTSPACE:url} - %{ 
+WORD:UNWANTED}/%{IP:ip_dst_addr}'
+[Stellar]>>> GROK_EVAL(squid_grok, messages)
+╔══════════╤═════════╤═════════╤═════════╤════════════════╤═════════════╤═════════╤════════════════╤═════════════════════════╗
+║ action   │ bytes   │ code    │ elapsed │ ip_dst_addr    │ ip_src_addr │ method  │ timestamp      │ url                     ║
+╠══════════╪═════════╪═════════╪═════════╪════════════════╪═════════════╪═════════╪════════════════╪═════════════════════════╣
+║ TCP_MISS │ 803     │ 301     │ 256     │ 216.58.216.238 │ 127.0.0.1   │ GET     │ 1475022887.362 │ http://www.youtube.com/ ║
+╟──────────┼─────────┼─────────┼─────────┼────────────────┼─────────────┼─────────┼────────────────┼─────────────────────────╢
+║ MISSING  │ MISSING │ MISSING │ MISSING │ MISSING        │ MISSING     │ MISSING │ MISSING        │ MISSING                 ║
+╟──────────┼─────────┼─────────┼─────────┼────────────────┼─────────────┼─────────┼────────────────┼─────────────────────────╢
+║ MISSING  │ MISSING │ MISSING │ MISSING │ MISSING        │ MISSING     │ MISSING │ MISSING        │ MISSING                 ║
+╚══════════╧═════════╧═════════╧═════════╧════════════════╧═════════════╧═════════╧════════════════╧═════════════════════════╝
+
+[Stellar]>>> # Still looks wrong.  Hmm, I bet it is due to that dst_addr not being there; we can make it optional
+[Stellar]>>> squid_grok := '%{NUMBER:timestamp} %{SPACE:UNWANTED}  %{INT:elapsed} %{IP:ip_src_addr} %{WORD:action}/%{NUMBER:code} %{NUMBER:bytes} %{WORD:method} %{NOTSPACE:url} - %{ 
+WORD:UNWANTED}/(%{IP:ip_dst_addr})?'
+[Stellar]>>> GROK_EVAL(squid_grok, messages)
+╔══════════╤═══════╤══════╤═════════╤════════════════╤═════════════╤════════╤════════════════╤══════════════════════════╗
+║ action   │ bytes │ code │ elapsed │ ip_dst_addr    │ ip_src_addr │ method │ timestamp      │ url                      ║
+╠══════════╪═══════╪══════╪═════════╪════════════════╪═════════════╪════════╪════════════════╪══════════════════════════╣
+║ TCP_MISS │ 803   │ 301  │ 256     │ 216.58.216.238 │ 127.0.0.1   │ GET    │ 1475022887.362 │ http://www.youtube.com/  ║
+╟──────────┼───────┼──────┼─────────┼────────────────┼─────────────┼────────┼────────────────┼──────────────────────────╢
+║ NONE     │ 3520  │ 400  │ 1       │ null           │ 127.0.0.1   │ GET    │ 1475022915.731 │ flimflammadeupdomain.com ║
+╟──────────┼───────┼──────┼─────────┼────────────────┼─────────────┼────────┼────────────────┼──────────────────────────╢
+║ NONE     │ 3500  │ 400  │ 0       │ null           │ 127.0.0.1   │ GET    │ 1475022938.661 │ www.google.com           ║
+╚══════════╧═══════╧══════╧═════════╧════════════════╧═════════════╧════════╧════════════════╧══════════════════════════╝
+
+[Stellar]>>> # Ahh, that is much better.
+[Stellar]>>> 
+[Stellar]>>> 
+
+```
 
 ### Manage Stellar Field Transformations
 

--- a/metron-platform/metron-management/pom.xml
+++ b/metron-platform/metron-management/pom.xml
@@ -30,18 +30,30 @@
         <antlr.version>4.5</antlr.version>
     </properties>
     <dependencies>
-      <dependency>
-        <groupId>org.apache.metron</groupId>
-        <artifactId>metron-common</artifactId>
-        <version>${project.parent.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.jakewharton.fliptables</groupId>
-        <artifactId>fliptables</artifactId>
-        <version>1.0.2</version>
-      </dependency>
-      <dependency>
+        <dependency>
+            <groupId>org.apache.metron</groupId>
+            <artifactId>metron-common</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.metron</groupId>
+            <artifactId>metron-parsers</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jakewharton.fliptables</groupId>
+            <artifactId>fliptables</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.thekraken</groupId>
+            <artifactId>grok</artifactId>
+            <version>0.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${global_guava_version}</version>

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/GrokFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/GrokFunctions.java
@@ -49,9 +49,9 @@ public class GrokFunctions {
           , description = "Evaluate a grok expression for a statement"
           , params = {
                 "grokExpression - The grok expression to evaluate"
-               ,"data - The data to evaluate using the grokExpression"
+               ,"data - Either a data message or a list of data messages to evaluate using the grokExpression"
                      }
-          ,returns="The Map associated with the grok expression being evaluated or null if no match."
+          ,returns="The Map associated with the grok expression being evaluated on the list of messages."
   )
   public static class Evaluate implements StellarFunction {
 

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/GrokFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/GrokFunctions.java
@@ -1,0 +1,168 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.management;
+
+import com.jakewharton.fliptables.FlipTable;
+import oi.thekraken.grok.api.Grok;
+import oi.thekraken.grok.api.Match;
+import oi.thekraken.grok.api.exception.GrokException;
+import org.apache.log4j.Logger;
+import org.apache.metron.common.dsl.Context;
+import org.apache.metron.common.dsl.ParseException;
+import org.apache.metron.common.dsl.Stellar;
+import org.apache.metron.common.dsl.StellarFunction;
+
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.util.*;
+
+public class GrokFunctions {
+
+  private static final Logger LOG = Logger.getLogger(GrokFunctions.class);
+  private static Grok getGrok(String grokExpr) throws GrokException {
+    Grok grok = new Grok();
+    grok.addPatternFromReader(new InputStreamReader(GrokFunctions.class.getResourceAsStream("/patterns/common")));
+    if(grokExpr != null) {
+      grok.addPatternFromReader(new StringReader("pattern " + grokExpr));
+      grok.compile("%{pattern}");
+    }
+    return grok;
+  }
+
+  @Stellar( namespace="GROK"
+          , name="EVAL"
+          , description = "Evaluate a grok expression for a statement"
+          , params = {
+                "grokExpression - The grok expression to evaluate"
+               ,"data - The data to evaluate using the grokExpression"
+                     }
+          ,returns="The Map associated with the grok expression being evaluated or null if no match."
+  )
+  public static class Evaluate implements StellarFunction {
+
+    @Override
+    public Object apply(List<Object> args, Context context) throws ParseException {
+      String grokExpression = (String) args.get(0);
+      Object arg =  args.get(1);
+      if(grokExpression == null || arg == null) {
+        return null;
+      }
+      List<String> strs = null;
+      if(arg instanceof List) {
+        strs = (List<String>) arg;
+      }
+      else if(arg instanceof String) {
+        strs = new ArrayList<>();
+        strs.add((String)arg);
+      }
+      else {
+        return null;
+      }
+      Grok grok = null;
+      try {
+        grok = getGrok(grokExpression);
+      } catch (GrokException e) {
+        LOG.error("unable to parse " + grokExpression + ": " + e.getMessage(), e);
+        return null;
+      }
+      List<Map<String, Object>> outputMap = new ArrayList<>();
+      Set<String> keys = new TreeSet<>();
+      for(String str : strs) {
+        Match m = grok.match(str);
+        m.captures();
+        Map<String, Object> ret = m.toMap();
+        if (ret != null && ret.isEmpty()) {
+          outputMap.add(new HashMap<>());
+        } else {
+          ret.remove("pattern");
+          keys.addAll(ret.keySet());
+          outputMap.add(ret);
+        }
+      }
+      if(keys.isEmpty()){
+        return "NO MATCH";
+      }
+      String[] headers = new String[keys.size()];
+      String[][] data = new String[outputMap.size()][keys.size()];
+      {
+        int i = 0;
+        for (String key : keys) {
+          headers[i++] = key;
+        }
+      }
+      int rowNum = 0;
+      for(Map<String, Object> output : outputMap) {
+        String[] row = new String[keys.size()];
+        int colNum = 0;
+        for(String key : keys) {
+          row[colNum++] = "" + output.getOrDefault(key, "MISSING");
+        }
+        data[rowNum++] = row;
+      }
+      return FlipTable.of(headers, data);
+    }
+
+    @Override
+    public void initialize(Context context) {
+
+    }
+
+    @Override
+    public boolean isInitialized() {
+      return true;
+    }
+  }
+
+  @Stellar( namespace="GROK"
+          , name="PREDICT"
+          , description = "Discover a grok statement for an input doc"
+          , params = {
+               "data - The data to discover a grok expression from"
+                     }
+          ,returns="A grok expression that should match the data."
+  )
+  public static class Predict implements StellarFunction {
+
+    @Override
+    public Object apply(List<Object> args, Context context) throws ParseException {
+      String str = (String) args.get(0);
+      if(str == null) {
+        return null;
+      }
+      Grok grok = null;
+      try {
+        grok = getGrok(null);
+      } catch (GrokException e) {
+        LOG.error("unable to construct grok object: " + e.getMessage(), e);
+        return null;
+      }
+      return grok.discover(str);
+    }
+
+    @Override
+    public void initialize(Context context) {
+
+    }
+
+    @Override
+    public boolean isInitialized() {
+      return true;
+    }
+  }
+
+}


### PR DESCRIPTION
Create two stellar management functions:
* GROK_EVAL - Test grok statements
* GROK_PREDICT - Given a string, predict a grok statement that matches it.

A section in the `metron-management` README.md has been added to show these functions' as well as the functions provided by #277 to debug and create grok statements.