### PR TITLE
METRON-472: add runAgain.sh to handle a proper vagrant provision

### DIFF
--- a/metron-deployment/vagrant/quick-dev-platform/runAgain.sh
+++ b/metron-deployment/vagrant/quick-dev-platform/runAgain.sh
@@ -17,9 +17,7 @@
 # limitations under the License.
 #
 
-echo "If run.sh fails, instead of just running vagrant provision, you should run ./runAgan.sh"
-
 vagrant \
   --ansible-tags="hdp-deploy,metron" \
   --ansible-skip-tags="solr" \
-  up
+  provision


### PR DESCRIPTION
When you fail after running run.sh in quickdev you will be told to run vagrant provision... but what you really want to do is run vagrant provision with the same parameters that you used for vagrant up inside run.sh.

runAgain.sh has that.

