### PR TITLE
METRON-476: Bump release version to 0.2.1BETA for Quick Dev

### DIFF
--- a/metron-deployment/inventory/quick-dev-platform/group_vars/all
+++ b/metron-deployment/inventory/quick-dev-platform/group_vars/all
@@ -46,7 +46,7 @@ threatintel_hbase_table: threatintel
 enrichment_hbase_table: enrichment
 
 # metron
-metron_version: 0.2.0BETA
+metron_version: 0.2.1BETA
 metron_directory: /usr/metron/{{ metron_version }}
 bro_version: "2.4.1"
 fixbuf_version: "1.7.1"


### PR DESCRIPTION
UPDATE: Testing passed.

Vagrant testing is in progress, I'll update when it completes.