### PR TITLE
METRON-478: Add Michael Miklavcic, Justin Leet, Nick Allen, and David Lyle to Metron website community page

### DIFF
--- a/site/community/index.md
+++ b/site/community/index.md
@@ -67,7 +67,13 @@ title: Apache Metron Community
     <tr>
       <td style="text-align: left">Charles Porter</td> <td style="text-align: left">cporter</td> <td style="text-align: left">PMC</td> </tr>
     <tr>
+      <td style="text-align: left">David Lyle</td> <td style="text-align: left">lyle</td> <td style="text-align: left">PMC</td> </tr>
+    <tr>
+      <td style="text-align: left">Nick Allen</td> <td style="text-align: left">nickallen</td> <td style="text-align: left">PMC</td> </tr>
+    <tr>
       <td style="text-align: left">Michael Miklavcic</td> <td style="text-align: left">mmiklavcic</td> <td style="text-align: left">Committer</td> </tr>
+    <tr>
+      <td style="text-align: left">Justin Leet</td> <td style="text-align: left">leet</td> <td style="text-align: left">Committer</td> </tr>
     </tbody>
 </table>
 </section>

--- a/site/community/index.md
+++ b/site/community/index.md
@@ -66,6 +66,8 @@ title: Apache Metron Community
       <td style="text-align: left">Larry McCay</td> <td style="text-align: left">lmccay</td> <td style="text-align: left">PMC</td> </tr>
     <tr>
       <td style="text-align: left">Charles Porter</td> <td style="text-align: left">cporter</td> <td style="text-align: left">PMC</td> </tr>
+    <tr>
+      <td style="text-align: left">Michael Miklavcic</td> <td style="text-align: left">mmiklavcic</td> <td style="text-align: left">Committer</td> </tr>
     </tbody>
 </table>
 </section>


### PR DESCRIPTION
Addresses https://issues.apache.org/jira/browse/METRON-478

Confirmed via steps for running jekyll on the wiki - https://cwiki.apache.org/confluence/display/METRON/Website+PR+Merge

Checked page looks correct in Chrome, Firefox, and Safari.