### PR TITLE
METRON-480: Kibana 4.5+ Requires http.cors.enabled set to false on ES

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-site.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-site.xml
@@ -47,7 +47,15 @@
         <name>path_data</name>
         <value>"/opt/lmm/es_data"</value>
         <description>Path to directory where to store index data allocated for this node. e.g. "/mnt/first", "/mnt/second"</description>
-    </property>    
+    </property>
+    <property>
+        <name>http_cors_enabled</name>
+        <value>"false"</value>
+        <description>Enable or disable cross-origin resource sharing, i.e. whether a browser on another origin can do requests to Elasticsearch. Defaults to false.</description>
+        <value-attributes>
+            <type>string</type>
+        </value-attributes>
+    </property>
     <!--  Discovery -->
     <property>
         <name>transport_tcp_port</name>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/params.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/params.py
@@ -45,6 +45,7 @@ cluster_name = config['configurations']['elastic-site']['cluster_name']
 zen_discovery_ping_unicast_hosts = config['configurations']['elastic-site']['zen_discovery_ping_unicast_hosts']
 
 path_data = config['configurations']['elastic-site']['path_data']
+http_cors_enabled = config['configurations']['elastic-site']['http_cors_enabled']
 http_port = config['configurations']['elastic-site']['http_port']
 transport_tcp_port = config['configurations']['elastic-site']['transport_tcp_port']
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/templates/elasticsearch.master.yaml.j2
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/templates/elasticsearch.master.yaml.j2
@@ -39,7 +39,7 @@ node:
 path:
   data: {{path_data}}
 
-http.cors.enabled: true
+http.cors.enabled: {{http_cors_enabled}}
 
 port: {{http_port}}
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/templates/elasticsearch.slave.yaml.j2
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/templates/elasticsearch.slave.yaml.j2
@@ -39,7 +39,7 @@ node:
 path:
   data: {{path_data}}
 
-http.cors.enabled: true
+http.cors.enabled: {{http_cors_enabled}}
 
 port: {{http_port}}
 


### PR DESCRIPTION
Tested with simulated Docker cluster.

Installed Elasticsearch and Kibana services together post-install and verified Kibana could initialize.


