### PR TITLE
METRON-461: Install Metron Data Management tools

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/metainfo.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/metainfo.xml
@@ -198,6 +198,9 @@
               <name>metron-common</name>
             </package>
             <package>
+              <name>metron-data-management</name>
+            </package>
+            <package>
               <name>metron-parsers</name>
             </package>
             <package>
@@ -239,7 +242,6 @@
           </packages>
         </osSpecific>
       </osSpecifics>
-
       <commandScript>
         <script>scripts/service_check.py</script>
         <scriptType>PYTHON</scriptType>


### PR DESCRIPTION
We omitted metron-data-management in our first iteration of the MPack. This corrects that.

Tested on simulated distributed cluster in Docker.