### PR TITLE
METRON-482 Add logging to GrokParser to indicate supplied TimeZone

### DIFF
--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/GrokParser.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/GrokParser.java
@@ -70,8 +70,10 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
     String timeZoneParam = (String) parserConfig.get("timeZone");
     if (timeZoneParam != null) {
       dateFormat.setTimeZone(TimeZone.getTimeZone(timeZoneParam));
+      LOG.debug("Grok Parser using provided TimeZone: {}", timeZoneParam);
     } else {
       dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+      LOG.debug("Grok Parser using default TimeZone (UTC)");
     }
   }
 
@@ -201,9 +203,8 @@ public class GrokParser implements MessageParser<JSONObject>, Serializable {
 
   protected long toEpoch(String datetime) throws ParseException {
 
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Grok parser converting timestamp to epoch: " + datetime);
-    }
+    LOG.debug("Grok parser converting timestamp to epoch: {}", datetime);
+    LOG.debug("Grok parser's DateFormat has TimeZone: {}", dateFormat.getTimeZone());
 
     Date date = dateFormat.parse(datetime);
     if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
Added a few logging statements: both during configure() and during the actual conversion.