### PR TITLE
METRON-439: Stellar : IS_EMPTY(host) throws exception

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DataStructureFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DataStructureFunctions.java
@@ -146,8 +146,8 @@ public class DataStructureFunctions {
 
     @Override
     public Object apply(List<Object> list) {
-      if(list.size() == 0) {
-        throw new IllegalStateException("IS_EMPTY expects one string arg");
+      if(null == list || list.size() == 0) {
+        return true;
       }
       Object o = list.get(0);
       if(o instanceof Collection) {
@@ -158,7 +158,7 @@ public class DataStructureFunctions {
         return val == null || val.isEmpty() ? true : false;
       }
       else {
-        throw new IllegalStateException("IS_EMPTY expects a collection or string");
+        return true;
       }
     }
   }

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/dsl/functions/DataStructureFunctionsTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/dsl/functions/DataStructureFunctionsTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.common.dsl.functions;
+
+import com.google.common.collect.ImmutableList;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DataStructureFunctionsTest {
+
+  @Test
+  public void is_empty_handles_happy_path() {
+    DataStructureFunctions.IsEmpty isEmpty = new DataStructureFunctions.IsEmpty();
+    {
+      boolean empty = (boolean) isEmpty.apply(ImmutableList.of("hello"));
+      Assert.assertThat("should be false", empty, CoreMatchers.equalTo(false));
+    }
+    {
+      boolean empty = (boolean) isEmpty.apply(ImmutableList.of(ImmutableList.of("hello", "world")));
+      Assert.assertThat("should be false", empty, CoreMatchers.equalTo(false));
+    }
+  }
+
+  @Test
+  public void is_empty_handles_empty_values() {
+    DataStructureFunctions.IsEmpty isEmpty = new DataStructureFunctions.IsEmpty();
+    {
+      boolean empty = (boolean) isEmpty.apply(ImmutableList.of());
+      Assert.assertThat("should be true", empty, CoreMatchers.equalTo(true));
+    }
+    {
+      boolean empty = (boolean) isEmpty.apply(null);
+      Assert.assertThat("should be true", empty, CoreMatchers.equalTo(true));
+    }
+    {
+      boolean empty = (boolean) isEmpty.apply(ImmutableList.of(""));
+      Assert.assertThat("should be true", empty, CoreMatchers.equalTo(true));
+    }
+    {
+      boolean empty = (boolean) isEmpty.apply(ImmutableList.of(new Object()));
+      Assert.assertThat("should be true", empty, CoreMatchers.equalTo(true));
+    }
+  }
+
+}


### PR DESCRIPTION
Fix Stellar IS_EMPTY validation to handle empty and null

Addresses https://issues.apache.org/jira/browse/METRON-439

Things have changed a bit since the original Jira was filed. Most notably, this error appears while dumping config from Zookeeper after it has already been loaded. The current functionality/validation would not have allowed the load to succeed in the first place. Even so, empty and null checks could be handled more gracefully. This PR changes IS_EMPTY to return true on null or empty string rather than throw an exception.

Added new unit tests and validated on quick-dev with multiple bro messages - normal host, empty host string, and null/non-existent host string.