### PR TITLE
METRON-425 Stellar transformation fails to handle special characters

### DIFF
--- a/metron-platform/metron-common/README.md
+++ b/metron-platform/metron-common/README.md
@@ -16,6 +16,8 @@ The query language supports the following:
 * The ability to have parenthesis to make order of operations explicit
 * User defined functions
 
+####Note: string values containing arithmetic operations and comparison operators used as literals such as: "foo : <ok>" require escaping such as "foo: \"<ok>\""
+
 The following functions are supported:
 
 * `BLOOM_ADD`

--- a/metron-platform/metron-common/README.md
+++ b/metron-platform/metron-common/README.md
@@ -18,7 +18,8 @@ The query language supports the following:
 
 ##Stellar Language Keywords
 The following keywords need to be single quote escaped in order to be used in Stellar expressions:
-|               |               |             |
+
+|              |              |           |
 |   :---:       |     :---:     |   :---:     | 
 | not| else | exists | 
 | if | then | and |

--- a/metron-platform/metron-common/README.md
+++ b/metron-platform/metron-common/README.md
@@ -16,7 +16,18 @@ The query language supports the following:
 * The ability to have parenthesis to make order of operations explicit
 * User defined functions
 
-####Note: string values containing arithmetic operations and comparison operators used as literals such as: "foo : <ok>" require escaping such as "foo: \"<ok>\""
+##Stellar Language Keywords
+The following keywords need to be single quote escaped in order to be used in Stellar expressions:
+|               |               |             |
+|   :---:       |     :---:     |   :---:     | 
+| not| else | exists | 
+| if | then | and |
+| or | == | != | < |
+| <= | \> | \>= |
+| ? | \+ | \- |
+| , | \* | / |
+
+such as: "foo" : "\<ok\>" requires escaping such as "foo": "\'\<ok\>\'"
 
 The following functions are supported:
 

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/transformation/StellarTransformationTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/transformation/StellarTransformationTest.java
@@ -54,7 +54,7 @@ public class StellarTransformationTest {
    "transformation" : "STELLAR"
    ,"output" : ["newStellarField","utc_timestamp"]
    ,"config" : {
-   "newStellarField" : "\"<<??>>\"",
+   "newStellarField" : "'<<??>>'",
    "utc_timestamp" : "TO_EPOCH_TIMESTAMP(timestamp, 'yyyy-MM-dd HH:mm:ss', 'UTC')"
    }
    }

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/transformation/StellarTransformationTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/transformation/StellarTransformationTest.java
@@ -46,6 +46,39 @@ public class StellarTransformationTest {
    */
   @Multiline
   public static String stellarConfig;
+
+  /**
+   {
+   "fieldTransformations" : [
+   {
+   "transformation" : "STELLAR"
+   ,"output" : ["newStellarField","utc_timestamp"]
+   ,"config" : {
+   "newStellarField" : "\"<<??>>\"",
+   "utc_timestamp" : "TO_EPOCH_TIMESTAMP(timestamp, 'yyyy-MM-dd HH:mm:ss', 'UTC')"
+   }
+   }
+   ]
+   }
+   */
+  @Multiline
+  public static String stellarConfigEspecial;
+
+  @Test
+  public void testStellarSpecialCharacters() throws Exception {
+
+    SensorParserConfig c = SensorParserConfig.fromBytes(Bytes.toBytes(stellarConfigEspecial));
+    FieldTransformer handler = Iterables.getFirst(c.getFieldTransformations(), null);
+    JSONObject input = new JSONObject(new HashMap<String, Object>() {{
+      put("timestamp", "2016-01-05 17:02:30");
+    }});
+    handler.transformAndUpdate(input, new HashMap<>(), Context.EMPTY_CONTEXT());
+    long expected = 1452013350000L;
+    Assert.assertEquals(expected, input.get("utc_timestamp"));
+    Assert.assertTrue(input.containsKey("timestamp"));
+    Assert.assertTrue(input.containsKey("newStellarField"));
+  }
+
   /**
    * Test the happy path.  This ensures that a simple transformation, converting a timestamp in a yyyy-MM-dd HH:mm:ss
    * format can be converted to the expected UTC MS since Epoch.


### PR DESCRIPTION
The issue is that per our grammar the arithmetic and comparison operators need to be escaped to be used as literals.

I have added a unit test to the system for this case ( for field transformations ).
I have also taken a stab at updating the readme.md.  I do not thing the readme is correct though.  It may need to be written out more better by someone who writes good.