### PR TITLE
METRON-489: RemoveSubdomains Stellar Function behaves incorrectly for some domains

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
@@ -78,13 +78,16 @@ public class NetworkFunctions {
 
     @Override
     public Object apply(List<Object> objects) {
+      if(objects.isEmpty()) {
+        return null;
+      }
       Object dnObj = objects.get(0);
       InternetDomainName idn = toDomainName(dnObj);
       if(idn != null) {
         String dn = dnObj.toString();
         String tld = idn.publicSuffix().toString();
-        String suffix = Iterables.getFirst(Splitter.on(tld).split(dn), null);
-        if(suffix != null)
+        String suffix = dn.substring(0, dn.length() - tld.length());
+        if(suffix != null )
         {
           String hostnameWithoutTLD = suffix.substring(0, suffix.length() - 1);
           String hostnameWithoutSubsAndTLD = Iterables.getLast(Splitter.on(".").split(hostnameWithoutTLD), null);

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
@@ -18,6 +18,7 @@
 
 package org.apache.metron.common.dsl.functions;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.google.common.net.InternetDomainName;
@@ -85,7 +86,7 @@ public class NetworkFunctions {
       InternetDomainName idn = toDomainName(dnObj);
       if(idn != null) {
         String dn = dnObj.toString();
-        String tld = idn.publicSuffix().toString();
+        String tld = Joiner.on(".").join(idn.publicSuffix().parts());
         String suffix = dn.substring(0, dn.length() - tld.length());
         String hostnameWithoutTLD = suffix.substring(0, suffix.length() - 1);
         String hostnameWithoutSubsAndTLD = Iterables.getLast(Splitter.on(".").split(hostnameWithoutTLD), null);

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
@@ -87,18 +87,13 @@ public class NetworkFunctions {
         String dn = dnObj.toString();
         String tld = idn.publicSuffix().toString();
         String suffix = dn.substring(0, dn.length() - tld.length());
-        if(suffix != null )
-        {
-          String hostnameWithoutTLD = suffix.substring(0, suffix.length() - 1);
-          String hostnameWithoutSubsAndTLD = Iterables.getLast(Splitter.on(".").split(hostnameWithoutTLD), null);
-          if(hostnameWithoutSubsAndTLD == null) {
-            return null;
-          }
-          return hostnameWithoutSubsAndTLD + "." + tld;
-        }
-        else {
+        String hostnameWithoutTLD = suffix.substring(0, suffix.length() - 1);
+        String hostnameWithoutSubsAndTLD = Iterables.getLast(Splitter.on(".").split(hostnameWithoutTLD), null);
+        if(hostnameWithoutSubsAndTLD == null) {
           return null;
         }
+        return hostnameWithoutSubsAndTLD + "." + tld;
+
       }
       return null;
     }

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/network/RemoveSubdomainsTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/network/RemoveSubdomainsTest.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.common.stellar.network;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.metron.common.dsl.functions.NetworkFunctions;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RemoveSubdomainsTest {
+
+  @Test
+  public void testEdgeCasesTldSquared() {
+    NetworkFunctions.RemoveSubdomains removeSubdomains = new NetworkFunctions.RemoveSubdomains();
+    Assert.assertEquals("com.com", removeSubdomains.apply(ImmutableList.of("com.com")));
+    Assert.assertEquals("net.net", removeSubdomains.apply(ImmutableList.of("net.net")));
+    Assert.assertEquals("uk.co.uk", removeSubdomains.apply(ImmutableList.of("co.uk.co.uk")));
+    Assert.assertEquals("com.com", removeSubdomains.apply(ImmutableList.of("www.subdomain.com.com")));
+  }
+
+  @Test
+  public void testHappyPath() {
+    NetworkFunctions.RemoveSubdomains removeSubdomains = new NetworkFunctions.RemoveSubdomains();
+    Assert.assertEquals("example.com", removeSubdomains.apply(ImmutableList.of("my.example.com")));
+    Assert.assertEquals("example.co.uk", removeSubdomains.apply(ImmutableList.of("my.example.co.uk")));
+  }
+}


### PR DESCRIPTION
com.com throws an exception
www.subdomain.com.com returns subdomain.com
Unsure if other standard weirdness with TLDs get handled like this (e.g. net.net, co.uk.co.uk)
