### PR TITLE
METRON-499 Check for Metron Jar Fails During Quick-Dev Deployment

### DIFF
--- a/metron-deployment/roles/metron_common/tasks/main.yml
+++ b/metron-deployment/roles/metron_common/tasks/main.yml
@@ -20,6 +20,7 @@
   when: (ansible_distribution != "CentOS" or ansible_distribution_major_version != "6")
 
 - name: Check for Metron jar path
+  become: false
   local_action: stat path={{ metron_jar_path }}
   register: metron_jars
 


### PR DESCRIPTION
[METRON-499](https://issues.apache.org/jira/browse/METRON-499)

When deploying with Quick-Dev, it fails when checking to see if the Metron jars have been built.  When checking the local file system, it attempts to obtain elevated privileges and fails.

```
 @ ~/Development/incubator-metron/metron-deployment/vagrant/quick-dev-platform
$ vagrant provision
 Running with ansible-tags: ["hdp-deploy", "metron"]
 Running with ansible-skip-tags: ["solr", "yaf"]
==> node1: Running provisioner: ansible...
    node1: Running ansible-playbook...

....

TASK [metron_common : Check for Metron jar path] *******************************
fatal: [node1 -> localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
```

When checking the local file system for the jar, Ansible attempts to obtain elevated privileges, since most of the tasks defined in the playbooks run with elevated privileges.  Elevated privilege is not needed in this case.  

Tested by running on Quick-Dev.