### PR TITLE
METRON-441: Aggregator function "MIN" does not work for threat triage

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/aggregator/Aggregators.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/aggregator/Aggregators.java
@@ -27,7 +27,7 @@ import java.util.function.Predicate;
 
 public enum Aggregators implements Aggregator {
    MAX( (numbers, config) -> accumulate(0d, (x,y) -> Math.max(x.doubleValue(),y.doubleValue()), numbers, config))
-  ,MIN( (numbers, config) -> accumulate(0d, (x,y) -> Math.min(x.doubleValue(),y.doubleValue()), numbers, config))
+  ,MIN( (numbers, config) -> accumulate(Double.MAX_VALUE, (x,y) -> Math.min(x.doubleValue(),y.doubleValue()), numbers, config))
   ,SUM( (numbers, config) -> accumulate(0d, (x,y) -> x.doubleValue() + y.doubleValue(), numbers, config))
   ,MEAN( (numbers, config) -> scale(SUM.aggregate(numbers, config), numbers, n -> true))
   ,POSITIVE_MEAN( (numbers, config) -> positiveMean(numbers, config))

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/AggregatorsTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/AggregatorsTest.java
@@ -42,6 +42,11 @@ public class AggregatorsTest {
   }
 
   @Test
+  public void testMinAllPositive() {
+    Assert.assertEquals(1, Aggregators.MIN.aggregate(ImmutableList.of(1, 5, 7), ImmutableMap.of(Aggregators.NEGATIVE_VALUES_TRUMP_CONF, "false")), 1e-7);
+  }
+
+  @Test
   public void testMean() {
     Assert.assertEquals(Double.NEGATIVE_INFINITY, Aggregators.MEAN.aggregate(ImmutableList.of(1, 5, -1, 7, 0), new HashMap<>()), 1e-7);
     Assert.assertEquals(12.0/5.0, Aggregators.MEAN.aggregate(ImmutableList.of(1, 5, -1, 7, 0), ImmutableMap.of(Aggregators.NEGATIVE_VALUES_TRUMP_CONF, "false")), 1e-7);


### PR DESCRIPTION
If you are aggregating a series of strictly positive numbers, `MIN` does not function properly (returns `0` instead of the real minimum).