### PR TITLE
METRON-502 Make the ParserIntegrationTest more clear on errors

### DIFF
--- a/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/integration/ElasticsearchIndexingIntegrationTest.java
+++ b/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/integration/ElasticsearchIndexingIntegrationTest.java
@@ -17,14 +17,13 @@
  */
 package org.apache.metron.elasticsearch.integration;
 
+import org.apache.metron.common.Constants;
 import org.apache.metron.common.interfaces.FieldNameConverter;
 import org.apache.metron.elasticsearch.writer.ElasticsearchFieldNameConverter;
 import org.apache.metron.indexing.integration.IndexingIntegrationTest;
-import org.apache.metron.integration.ComponentRunner;
-import org.apache.metron.integration.InMemoryComponent;
-import org.apache.metron.integration.Processor;
-import org.apache.metron.integration.ReadinessState;
+import org.apache.metron.integration.*;
 import org.apache.metron.elasticsearch.integration.components.ElasticSearchComponent;
+import org.apache.metron.integration.components.KafkaWithZKComponent;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,8 +57,10 @@ public class ElasticsearchIndexingIntegrationTest extends IndexingIntegrationTes
   public Processor<List<Map<String, Object>>> getProcessor(final List<byte[]> inputMessages) {
     return new Processor<List<Map<String, Object>>>() {
       List<Map<String, Object>> docs = null;
+      List<byte[]> errors = null;
       public ReadinessState process(ComponentRunner runner) {
         ElasticSearchComponent elasticSearchComponent = runner.getComponent("search", ElasticSearchComponent.class);
+        KafkaWithZKComponent kafkaWithZKComponent = runner.getComponent("kafka", KafkaWithZKComponent.class);
         if (elasticSearchComponent.hasIndex(index)) {
           List<Map<String, Object>> docsFromDisk;
           try {
@@ -70,6 +71,10 @@ public class ElasticsearchIndexingIntegrationTest extends IndexingIntegrationTes
             throw new IllegalStateException("Unable to retrieve indexed documents.", e);
           }
           if (docs.size() < inputMessages.size() || docs.size() != docsFromDisk.size()) {
+            errors = kafkaWithZKComponent.readMessages(Constants.INDEXING_ERROR_TOPIC);
+            if(errors.size() > 0){
+              return ReadinessState.READY;
+            }
             return ReadinessState.NOT_READY;
           } else {
             return ReadinessState.READY;
@@ -79,8 +84,9 @@ public class ElasticsearchIndexingIntegrationTest extends IndexingIntegrationTes
         }
       }
 
-      public List<Map<String, Object>> getResult() {
-        return docs;
+      public ProcessorResult<List<Map<String, Object>>> getResult()  {
+        ProcessorResult.Builder<List<Map<String,Object>>> builder = new ProcessorResult.Builder();
+        return builder.withResult(docs).withProcessErrors(errors).build();
       }
     };
   }

--- a/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
+++ b/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
@@ -27,10 +27,7 @@ import org.apache.metron.common.interfaces.FieldNameConverter;
 import org.apache.metron.common.spout.kafka.SpoutConfig;
 import org.apache.metron.common.utils.JSONUtils;
 import org.apache.metron.enrichment.integration.components.ConfigUploadComponent;
-import org.apache.metron.integration.BaseIntegrationTest;
-import org.apache.metron.integration.ComponentRunner;
-import org.apache.metron.integration.InMemoryComponent;
-import org.apache.metron.integration.Processor;
+import org.apache.metron.integration.*;
 import org.apache.metron.integration.components.FluxTopologyComponent;
 import org.apache.metron.integration.components.KafkaWithZKComponent;
 import org.apache.metron.integration.utils.TestUtils;
@@ -175,7 +172,11 @@ public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
     }
   }
 
-  public List<Map<String, Object>> cleanDocs(List<Map<String, Object>> docs) {
+  public List<Map<String, Object>> cleanDocs(ProcessorResult<List<Map<String, Object>>> result) {
+    List<Map<String,Object>> docs = result.getResult();
+    if(result.failed()){
+      result.printBadResults();
+    }
     List<Map<String, Object>> ret = new ArrayList<>();
     for (Map<String, Object> doc : docs) {
       Map<String, Object> msg = new HashMap<>();

--- a/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/ComponentRunner.java
+++ b/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/ComponentRunner.java
@@ -122,7 +122,7 @@ public class ComponentRunner {
     }
 
 
-    public <T> T process(Processor<T> successState) {
+    public <T> ProcessorResult<T> process(Processor<T> successState) {
         int retryCount = 0;
         long start = System.currentTimeMillis();
         while(true) {

--- a/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/Processor.java
+++ b/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/Processor.java
@@ -19,5 +19,5 @@ package org.apache.metron.integration;
 
 public interface Processor<T> {
     ReadinessState process(ComponentRunner runner);
-    T getResult();
+    ProcessorResult<T> getResult();
 }

--- a/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/ProcessorResult.java
+++ b/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/ProcessorResult.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.integration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProcessorResult<T> {
+    public static class Builder<T>{
+        T result;
+        List<byte[]> processErrors;
+        List<byte[]> processInvalids;
+
+        public Builder(){}
+
+        public Builder withResult(T result){
+            this.result = result;
+            return this;
+        }
+
+        public Builder withProcessErrors(List<byte[]> processErrors){
+            this.processErrors = processErrors;
+            return this;
+        }
+
+        public Builder withProcessInvalids(List<byte[]> processInvalids){
+            this.processInvalids = processInvalids;
+            return this;
+        }
+
+        public ProcessorResult<T> build(){
+            return new ProcessorResult<T>(result,processErrors,processInvalids);
+        }
+
+    }
+
+    T result;
+    List<byte[]> processErrors;
+    List<byte[]> processInvalids;
+    @SuppressWarnings("unchecked")
+    public ProcessorResult(T result,List<byte[]> processErrors, List<byte[]> processInvalids){
+        this.result = result;
+        this.processErrors = processErrors == null ? new ArrayList() : processErrors;
+        this.processInvalids = processInvalids == null ? new ArrayList() : processInvalids;
+    }
+
+    public T getResult(){
+        return result;
+    }
+
+    public List<byte[]> getProcessErrors(){
+        return processErrors;
+    }
+
+    public List<byte[]> getProcessInvalids(){
+        return processInvalids;
+    }
+
+    public boolean failed(){
+        return processErrors.size() > 0 || processInvalids.size() > 0;
+    }
+
+    public void printBadResults(){
+        System.out.println(String.format("%d Errors", processErrors.size()));
+        for (byte[] outputMessage : processErrors) {
+            System.out.println(new String(outputMessage));
+        }
+        System.out.println();
+        System.out.println(String.format("%d Invalid Messages", processInvalids.size()));
+        for (byte[] outputMessage : processInvalids) {
+            System.out.println(new String(outputMessage));
+        }
+        System.out.println();
+    }
+}

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/integration/WriterBoltIntegrationTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/integration/WriterBoltIntegrationTest.java
@@ -119,7 +119,7 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
     try {
       runner.start();
       kafkaComponent.writeMessages(sensorType, inputMessages);
-      Map<String, List<JSONObject>> outputMessages =
+      ProcessorResult<Map<String, List<JSONObject>>> result =
               runner.process(new Processor<Map<String, List<JSONObject>>>() {
                 Map<String, List<JSONObject>> messages = null;
 
@@ -139,10 +139,12 @@ public class WriterBoltIntegrationTest extends BaseIntegrationTest {
                   return ReadinessState.NOT_READY;
                 }
 
-                public Map<String, List<JSONObject>> getResult() {
-                  return messages;
+                public ProcessorResult<Map<String, List<JSONObject>>> getResult() {
+                  ProcessorResult.Builder<Map<String,List<JSONObject>>> builder = new ProcessorResult.Builder();
+                  return builder.withResult(messages).build();
                 }
               });
+      Map<String,List<JSONObject>> outputMessages = result.getResult();
       Assert.assertEquals(3, outputMessages.size());
       Assert.assertEquals(1, outputMessages.get(Constants.ENRICHMENT_TOPIC).size());
       Assert.assertEquals("valid", outputMessages.get(Constants.ENRICHMENT_TOPIC).get(0).get("action"));

--- a/metron-platform/metron-pcap-backend/src/test/java/org/apache/metron/pcap/integration/PcapTopologyIntegrationTest.java
+++ b/metron-platform/metron-pcap-backend/src/test/java/org/apache/metron/pcap/integration/PcapTopologyIntegrationTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.metron.common.Constants;
 import org.apache.metron.integration.ComponentRunner;
 import org.apache.metron.integration.Processor;
+import org.apache.metron.integration.ProcessorResult;
 import org.apache.metron.integration.ReadinessState;
 import org.apache.metron.integration.components.FluxTopologyComponent;
 import org.apache.metron.integration.components.KafkaWithZKComponent;
@@ -264,7 +265,7 @@ public class PcapTopologyIntegrationTest {
         }
 
         @Override
-        public Void getResult() {
+        public ProcessorResult<Void> getResult() {
           return null;
         }
       });

--- a/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrIndexingIntegrationTest.java
+++ b/metron-platform/metron-solr/src/test/java/org/apache/metron/solr/integration/SolrIndexingIntegrationTest.java
@@ -18,14 +18,12 @@
 package org.apache.metron.solr.integration;
 
 import com.google.common.base.Function;
+import org.apache.metron.common.Constants;
 import org.apache.metron.common.configuration.Configurations;
 import org.apache.metron.common.interfaces.FieldNameConverter;
 import org.apache.metron.enrichment.integration.utils.SampleUtil;
 import org.apache.metron.indexing.integration.IndexingIntegrationTest;
-import org.apache.metron.integration.ComponentRunner;
-import org.apache.metron.integration.InMemoryComponent;
-import org.apache.metron.integration.Processor;
-import org.apache.metron.integration.ReadinessState;
+import org.apache.metron.integration.*;
 import org.apache.metron.integration.components.KafkaWithZKComponent;
 import org.apache.metron.solr.integration.components.SolrComponent;
 import org.apache.metron.common.configuration.ConfigurationsUtils;
@@ -75,8 +73,10 @@ public class SolrIndexingIntegrationTest extends IndexingIntegrationTest {
   public Processor<List<Map<String, Object>>> getProcessor(final List<byte[]> inputMessages) {
     return new Processor<List<Map<String, Object>>>() {
       List<Map<String, Object>> docs = null;
+      List<byte[]> errors = null;
       public ReadinessState process(ComponentRunner runner) {
         SolrComponent solrComponent = runner.getComponent("search", SolrComponent.class);
+        KafkaWithZKComponent kafkaWithZKComponent = runner.getComponent("kafka", KafkaWithZKComponent.class);
         if (solrComponent.hasCollection(collection)) {
           List<Map<String, Object>> docsFromDisk;
           try {
@@ -87,6 +87,10 @@ public class SolrIndexingIntegrationTest extends IndexingIntegrationTest {
             throw new IllegalStateException("Unable to retrieve indexed documents.", e);
           }
           if (docs.size() < inputMessages.size() || docs.size() != docsFromDisk.size()) {
+            errors = kafkaWithZKComponent.readMessages(Constants.INDEXING_ERROR_TOPIC);
+            if(errors.size() > 0){
+              return ReadinessState.READY;
+            }
             return ReadinessState.NOT_READY;
           } else {
             return ReadinessState.READY;
@@ -96,8 +100,9 @@ public class SolrIndexingIntegrationTest extends IndexingIntegrationTest {
         }
       }
 
-      public List<Map<String, Object>> getResult() {
-        return docs;
+      public ProcessorResult<List<Map<String, Object>>> getResult() {
+        ProcessorResult.Builder<List<Map<String,Object>>> builder = new ProcessorResult.Builder();
+        return builder.withResult(docs).withProcessErrors(errors).build();
       }
     };
   }


### PR DESCRIPTION
This is an attempt to enhance the Integration Test framework to support exposing processor errors and invalid messages.

There are two goals here:

1. Expose errors that are in present but not exposed because the kafka queues or other error sources are not check or exposed through the Processor run
2. Allow the integration tests to fail quicker as opposed to timing out ( if for example there are invalid messages or errors in the kafka queue such that the message in never == message out the test will keep re-trying until timeout ).

A new type ProcessorResult<T> has been added to the system as the return from running a Processor.  This type encapsulates the results, errors and invalids from any given run.

All integration tests with master run.

As always any feedback is appreciated.  Specifically in two areas:

- Is there a better way, or a way more consistent with the system than introducing the ProcessorResult type?
- The integration project does not have any tests, should it ( unit tests?)
- What is the best way to test this?  Should each individual test have a 'failure mode' test as well?

 