### PR TITLE
METRON-505: Add environment variable and system property functions to the Stellar language

### DIFF
--- a/metron-platform/metron-common/README.md
+++ b/metron-platform/metron-common/README.md
@@ -318,6 +318,16 @@ The following functions are supported:
   * Input:
     * stats - The Stellar statistics object.
   * Returns: The variance of the values in the window or NaN if the statistics object is null.
+  `SYSTEM_ENV_GET`
+  * Description: Returns the value associated with an environment variable
+  * Input:
+    * env_var - Environment variable name to get the value for
+  * Returns: String
+  `SYSTEM_PROPERTY_GET`
+  * Description: Returns the value associated with a Java system property
+  * Input:
+    * key - Property to get the value for
+  * Returns: String
 * `TO_DOUBLE`
   * Description: Transforms the first argument to a double precision number
   * Input:

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/SystemFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/SystemFunctions.java
@@ -22,6 +22,7 @@ import org.apache.metron.common.dsl.Stellar;
 import org.apache.metron.common.system.Environment;
 
 import java.util.List;
+import java.util.function.Function;
 
 public class SystemFunctions {
 
@@ -46,11 +47,26 @@ public class SystemFunctions {
 
     @Override
     public Object apply(List<Object> args) {
-      if (args.size() == 0) {
-        return null;
-      } else {
-        return env.get((String) args.get(0));
-      }
+      return extractTypeChecked(args, 0, String.class, x -> env.get((String) x.get(0)));
+    }
+  }
+
+  /**
+   * Extract type-checked value from an argument list using the specified type check and extraction function
+   *
+   * @param args Arguments to check
+   * @param i Index of argument to extract
+   * @param clazz Object type to verify
+   * @param extractFunc Function applied to extract the value from args
+   * @return value from args if passes type checks, null otherwise
+   */
+  public static Object extractTypeChecked(List<Object> args, int i, Class clazz, Function<List<Object>, Object> extractFunc) {
+    if (args.size() < i + 1) {
+      return null;
+    } else if (clazz.isInstance(args.get(i))) {
+      return extractFunc.apply(args);
+    } else {
+      return null;
     }
   }
 
@@ -65,11 +81,7 @@ public class SystemFunctions {
   public static class PropertyGet extends BaseStellarFunction {
     @Override
     public Object apply(List<Object> args) {
-      if (args.size() == 0) {
-        return null;
-      } else {
-        return System.getProperty((String) args.get(0));
-      }
+      return extractTypeChecked(args, 0, String.class, x -> System.getProperty((String) args.get(0)));
     }
   }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/SystemFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/SystemFunctions.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.common.dsl.functions;
+
+import org.apache.metron.common.dsl.BaseStellarFunction;
+import org.apache.metron.common.dsl.Stellar;
+import org.apache.metron.common.system.Environment;
+
+import java.util.List;
+
+public class SystemFunctions {
+
+  @Stellar(namespace = "SYSTEM",
+          name = "ENV_GET",
+          description = "Returns the value associated with an environment variable",
+          params = {
+                  "env_var - Environment variable name to get the value for"
+          },
+          returns = "String"
+  )
+  public static class EnvGet extends BaseStellarFunction {
+    private Environment env;
+
+    public EnvGet() {
+      this(new Environment());
+    }
+
+    public EnvGet(Environment env) {
+      this.env = env;
+    }
+
+    @Override
+    public Object apply(List<Object> args) {
+      if (args.size() == 0) {
+        return null;
+      } else {
+        return env.get((String) args.get(0));
+      }
+    }
+  }
+
+  @Stellar(namespace = "SYSTEM",
+          name = "PROPERTY_GET",
+          description = "Returns the value associated with a Java system property",
+          params = {
+                  "key - Property to get the value for"
+          },
+          returns = "String"
+  )
+  public static class PropertyGet extends BaseStellarFunction {
+    @Override
+    public Object apply(List<Object> args) {
+      if (args.size() == 0) {
+        return null;
+      } else {
+        return System.getProperty((String) args.get(0));
+      }
+    }
+  }
+}

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/system/Environment.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/system/Environment.java
@@ -15,28 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.metron.common.dsl;
-
-import java.util.List;
+package org.apache.metron.common.system;
 
 /**
- * Functions that do not require initialization can extend this class rather than directly implement StellarFunction
+ * Useful so we can test mock dependency injection with environment variables
  */
-public abstract class BaseStellarFunction implements StellarFunction {
-  public abstract Object apply(List<Object> args);
-
-  @Override
-  public Object apply(List<Object> args, Context context) throws ParseException {
-    return apply(args);
-  }
-
-  @Override
-  public void initialize(Context context) {
-
-  }
-
-  @Override
-  public boolean isInitialized() {
-    return true;
+public class Environment {
+  public String get(String variable) {
+    return System.getenv().get(variable);
   }
 }

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/dsl/functions/SystemFunctionsTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/dsl/functions/SystemFunctionsTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.common.dsl.functions;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.metron.common.system.Environment;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SystemFunctionsTest {
+
+  @Test
+  public void smoke_test_non_mocked_env() {
+    SystemFunctions.EnvGet envGet = new SystemFunctions.EnvGet();
+    String envVal = (String) envGet.apply(ImmutableList.of("ENV_GET_VAR"));
+    assertThat("Value should not exist", envVal, equalTo(null));
+  }
+
+  @Test
+  public void env_get_returns_value() {
+    Environment env = mock(Environment.class);
+    when(env.get("ENV_GET_VAR")).thenReturn("ENV_GET_VALUE");
+    SystemFunctions.EnvGet envGet = new SystemFunctions.EnvGet(env);
+    String envVal = (String) envGet.apply(ImmutableList.of("ENV_GET_VAR"));
+    assertThat("Value should match", envVal, equalTo("ENV_GET_VALUE"));
+  }
+
+  @Test
+  public void property_get_returns_value() {
+    System.getProperties().put("ENV_GET_VAR", "ENV_GET_VALUE");
+    SystemFunctions.PropertyGet propertyGet = new SystemFunctions.PropertyGet();
+    String propertyVal = (String) propertyGet.apply(ImmutableList.of("ENV_GET_VAR"));
+    assertThat("Value should match", propertyVal, equalTo("ENV_GET_VALUE"));
+  }
+
+  @Test
+  public void property_get_nonexistent_returns_null() {
+    SystemFunctions.PropertyGet propertyGet = new SystemFunctions.PropertyGet();
+    String propertyVal = (String) propertyGet.apply(ImmutableList.of("PROPERTY_MISSING"));
+    assertThat("Value should not exist", propertyVal, equalTo(null));
+  }
+
+}

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/dsl/functions/SystemFunctionsTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/dsl/functions/SystemFunctionsTest.java
@@ -21,6 +21,8 @@ import com.google.common.collect.ImmutableList;
 import org.apache.metron.common.system.Environment;
 import org.junit.Test;
 
+import java.util.ArrayList;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -45,6 +47,13 @@ public class SystemFunctionsTest {
   }
 
   @Test
+  public void env_get_returns_null_if_key_is_not_string() {
+    SystemFunctions.EnvGet envGet = new SystemFunctions.EnvGet();
+    String envVal = (String) envGet.apply(ImmutableList.of(new ArrayList()));
+    assertThat("Value should be null", envVal, equalTo(null));
+  }
+
+  @Test
   public void property_get_returns_value() {
     System.getProperties().put("ENV_GET_VAR", "ENV_GET_VALUE");
     SystemFunctions.PropertyGet propertyGet = new SystemFunctions.PropertyGet();
@@ -57,6 +66,13 @@ public class SystemFunctionsTest {
     SystemFunctions.PropertyGet propertyGet = new SystemFunctions.PropertyGet();
     String propertyVal = (String) propertyGet.apply(ImmutableList.of("PROPERTY_MISSING"));
     assertThat("Value should not exist", propertyVal, equalTo(null));
+  }
+
+  @Test
+  public void property_get_returns_null_if_key_is_not_string() {
+    SystemFunctions.PropertyGet propertyGet = new SystemFunctions.PropertyGet();
+    String propertyVal = (String) propertyGet.apply(ImmutableList.of(new ArrayList()));
+    assertThat("Value should be null", propertyVal, equalTo(null));
   }
 
 }


### PR DESCRIPTION
Tested in quick-dev from the Stellar REPL.

Build the platform, as normal. The new functions will get picked up automatically on the classpath via the annotations.

**Examples:**
```
SYSTEM_ENV_GET for exposing environment variables

[root@node1 bin]# export MIKE_VAR="blah blah blah"
[root@node1 bin]# echo $MIKE_VAR
blah blah blah

[Stellar]>>> mikevar := SYSTEM_ENV_GET('MIKE_VAR')
[Stellar]>>> mikevar
blah blah blah

SYSTEM_PROPERTY_GET for exposing system properties

[Stellar]>>> prop := SYSTEM_PROPERTY_GET( 'os.name' )
[Stellar]>>> prop
Linux
[Stellar]>>> prop := SYSTEM_PROPERTY_GET( 'user.name' )
[Stellar]>>> prop
root
```

EDIT: Also please note that I have added these functions to the metron-common project as this functionality seems like it would be useful not just in the REPL, but also within Storm topologies.