### PR TITLE
METRON-500: fix assembly id

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/assemblies/metron-mpack.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/assemblies/metron-mpack.xml
@@ -18,7 +18,7 @@
         xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
-    <id></id>
+    <id>archive</id>
     <formats>
         <format>tar.gz</format>
     </formats>


### PR DESCRIPTION
The build on current master fails because <id></id> is empty.

In previous versions of maven (before 2.2 final), leaving off the assembly id and leaving the classifier unconfigured resulted in the assembly being used as the project's main artifact. With the 2.2 release, this configuration results in a validation error.