### PR TITLE
METRON-465: Automatically set storm-site topology.classpath

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/service_advisor.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/service_advisor.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env ambari-python-wrap
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+import fnmatch
+import imp
+import socket
+import sys
+import traceback
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+STACKS_DIR = os.path.join(SCRIPT_DIR, '../../../../../stacks/')
+PARENT_FILE = os.path.join(STACKS_DIR, 'service_advisor.py')
+
+try:
+    with open(PARENT_FILE, 'rb') as fp:
+        service_advisor = imp.load_module('service_advisor', fp, PARENT_FILE, ('.py', 'rb', imp.PY_SOURCE))
+except Exception as e:
+    traceback.print_exc()
+    print "Failed to load parent"
+
+class METRON021BETAServiceAdvisor(service_advisor.ServiceAdvisor):
+
+
+    def getServiceConfigurationsValidationItems(self, configurations, recommendedDefaults, services, hosts):
+
+        # validate recommended properties in storm-site
+        siteName = "storm-site"
+        method = self.validateSTORMSiteConfigurations
+        items = self.validateConfigurationsForSite(configurations, recommendedDefaults, services, hosts, siteName, method)
+
+        return items
+
+    def getServiceConfigurationRecommendations(self, configurations, clusterData, services, hosts):
+
+        if "storm-site" in services["configurations"]:
+
+            storm_site = services["configurations"]["storm-site"]["properties"]
+            putStormSiteProperty = self.putProperty(configurations, "storm-site", services)
+
+            for property, desired_value in self.getSTORMSiteDesiredValues().iteritems():
+                if property not in storm_site:
+                    putStormSiteProperty(property, desired_value)
+                elif  property == "topology.classpath" and storm_site[property] != desired_value:
+                    topololgyClasspath = storm_site[property]
+                    #check that desired values exist in topology.classpath. append them if they do not
+                    for path in desired_value.split(':'):
+                        if path not in topololgyClasspath:
+                            topololgyClasspath += ":" + path
+                    putStormSiteProperty(property,topololgyClasspath)
+
+    def validateSTORMSiteConfigurations(self, properties, recommendedDefaults, configurations, services, hosts):
+
+        storm_site = properties
+        validationItems = []
+
+        for property, desired_value in self.getSTORMSiteDesiredValues().iteritems():
+            if property not in storm_site :
+                message = "Metron requires this property to be set to the recommended value of " + desired_value
+                item = self.getErrorItem(message) if property == "topology.classpath" else self.getWarnItem(message)
+                validationItems.append({"config-name": property, "item": item})
+            elif  storm_site[property] != desired_value:
+                topologyClasspath = storm_site[property]
+                for path in desired_value.split(':'):
+                    if path not in topologyClasspath:
+                        message = "Metron requires this property to contain " + desired_value
+                        item = self.getErrorItem(message)
+                        validationItems.append({"config-name": property, "item": item})
+
+        return self.toConfigurationValidationProblems(validationItems, "storm-site")
+
+    def getSTORMSiteDesiredValues(self):
+
+        storm_site_desired_values = {
+            "topology.classpath" : "/etc/hbase/conf:/etc/hadoop/conf"
+        }
+
+        return storm_site_desired_values
+


### PR DESCRIPTION
1) Set storm-site topology.classpath to /etc/hbase/conf:/etc/hadoop/conf as recommendation
2) Display error when storm-site topology.classpath doesn't not contain /etc/hbase/conf or /etc/hadoop/conf

Tested on Docker cluster following procedure here: [Metron MPack](https://www.evernote.com/l/AhLFVR-9CsFIYYnOnF43BlxSsT4F856qwaY) for following cases.

1) Adds topology.classpath to storm-site configuration and sets it to /etc/hbase/conf:/etc/hadoop/conf when it does not exist.
2) Appends /etc/hbase/conf:/etc/hadoop/conf when topology.classpath does not contain both paths
3) Append appropriate path when only one is missing. 
