### PR TITLE
METRON-410: mysql_server's MySQL install causes mutually assured dest…

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/configuration/metron-env.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/configuration/metron-env.xml
@@ -48,25 +48,29 @@
         <value>metron</value>
         <property-type>GROUP</property-type>
         <description>The group for Metron</description>
+        <display-name>Metron Group Name</display-name>
     </property>
     <property>
         <name>metron_topic_retention</name>
         <description>Kafka Retention in GB</description>
         <value>10</value>
+        <display-name>Topic Retention</display-name>
     </property>
     <property>
         <name>parsers</name>
         <value>bro,snort,yaf</value>
         <description>Metron parsers to deploy</description>
-        <display-name>Metron parsers</display-name>
+        <display-name>Metron Parsers</display-name>
     </property>
     <property>
         <name>metron_enrichment_db_user</name>
         <value>metron</value>
         <description>Database username to use to connect to the database.</description>
+        <display-name>Enrichment Database User</display-name>
     </property>
     <property>
         <name>metron_enrichment_db_port</name>
+        <display-name>Metron Enrichment Database Port</display-name>
         <value>3306</value>
         <description>Database port to use to connect to the database.</description>
     </property>
@@ -83,31 +87,75 @@
         <on-ambari-upgrade add="true"/>
     </property>
     <property>
+        <name>mysql_admin_password</name>
+        <value></value>
+        <property-type>PASSWORD</property-type>
+        <display-name>MySQL root user password</display-name>
+        <description>Password to use to add Metron user to MySQL</description>
+        <value-attributes>
+            <type>password</type>
+            <overridable>false</overridable>
+        </value-attributes>
+        <on-ambari-upgrade add="true"/>
+    </property>
+    <property>
         <name>metron_indexing_topology</name>
         <value>indexing</value>
         <description>The Storm topology name for Indexing</description>
+        <display-name>Indexing Topology Name</display-name>
     </property>
     <property>
         <name>es_cluster_name</name>
         <value>metron</value>
         <description>Name of Elasticsearch Cluster</description>
+        <display-name>Elasticsearch Cluster Name</display-name>
     </property>
     <property>
         <name>geoip_url</name>
         <value>http://geolite.maxmind.com/download/geoip/database/GeoLiteCity_CSV/GeoLiteCity-latest.tar.xz</value>
         <description>Location of the GeoIP data to load.</description>
+        <display-name>GEOIP Load Datafile URL</display-name>
     </property>
     <property require-input="true">
         <name>es_url</name>
         <value></value>
         <description>Comma delimited list of Elasticsearch URLs. (eshost1:9300,eshost2:9300)</description>
+        <display-name>Elasticsearch URL</display-name>
     </property>
-    <property>
+    <property require-input = "true">
         <name>storm_rest_addr</name>
+        <display-name>Storm Rest Server Address</display-name>
+        <description>URL of Storm UI (storm.ui.hostname:8744)</description>
         <!--<value-attributes>-->
             <!--<editable-only-at-install>true</editable-only-at-install>-->
             <!--<overridable>false</overridable>-->
         <!--</value-attributes>-->
+        <value></value>
+    </property>
+    <property>
+        <name>install_mysql</name>
+        <description>Install New MySQL Instance for Enrichments</description>
+        <display-name>Install MySQL</display-name>
+        <value>Yes</value>
+        <value-attributes>
+            <overridable>false</overridable>
+            <type>value-list</type>
+            <entries>
+                <entry>
+                    <value>Yes</value>
+                    <label>Yes</label>
+                </entry>
+                <entry>
+                    <value>No</value>
+                    <label>No</label>
+                </entry>
+            </entries>
+            <selection-cardinality>1</selection-cardinality>
+        </value-attributes>
+    </property>
+    <property>
+        <name>mysql_host</name>
+        <display-name>MySQL Host Address</display-name>
         <value></value>
     </property>
     <property>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/metainfo.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/metainfo.xml
@@ -216,6 +216,15 @@
           </packages>
         </osSpecific>
         <osSpecific>
+          <osFamily>redhat6,redhat7</osFamily>
+          <packages>
+            <package>
+              <name>expect</name>
+              <skipUpgrade>true</skipUpgrade>
+            </package>
+          </packages>
+        </osSpecific>
+        <osSpecific>
           <osFamily>redhat7</osFamily>
           <packages>
             <package>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/metainfo.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/metainfo.xml
@@ -67,9 +67,6 @@
             <script>scripts/parser_master.py</script>
             <scriptType>PYTHON</scriptType>
           </commandScript>
-          <configuration-dependencies>
-            <config-type>metron-parsers</config-type>
-          </configuration-dependencies>
         </component>
 
         <component>
@@ -95,7 +92,7 @@
             </dependency>
             <dependency>
               <name>KAFKA/KAFKA_BROKER</name>
-              <scope>cluster</scope>
+              <scope>host</scope>
               <auto-deploy>
                 <enabled>true</enabled>
               </auto-deploy>
@@ -184,11 +181,15 @@
                 </commandScript>
               </customCommand>
           </customCommands>
-          <configuration-dependencies>
-            <config-type>metron-indexing</config-type>
-          </configuration-dependencies>
         </component>
       </components>
+
+      <themes>
+        <theme>
+          <fileName>metron_theme.json</fileName>
+          <default>true</default>
+        </theme>
+      </themes>
 
       <osSpecifics>
         <osSpecific>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/files/addMysqlUser.sh
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/files/addMysqlUser.sh
@@ -24,21 +24,14 @@ mysqldservice=$1
 mysqldbuser=$2
 mysqldbpasswd=$3
 mysqldbhost=$4
+mysqlqdminpassword=$5
 myhostname=$(hostname -f)
 
-service $mysqldservice start
-echo "Adding user $mysqldbuser@$mysqldbhost and $mysqldbuser@localhost"
-mysql -u root -e "CREATE USER '$mysqldbuser'@'$mysqldbhost' IDENTIFIED BY '$mysqldbpasswd';"
-mysql -u root -e "CREATE USER '$mysqldbuser'@'localhost' IDENTIFIED BY '$mysqldbpasswd';"
+echo "Adding user ${mysqldbuser}@${mysqldbhost} and ${mysqldbuser}@localhost"
+mysql -u root --password=${mysqlqdminpassword} -e "CREATE USER '${mysqldbuser}'@'${mysqldbhost}' IDENTIFIED BY '${mysqldbpasswd}';"
+mysql -u root --password=${mysqlqdminpassword} -e "CREATE USER '${mysqldbuser}'@'localhost' IDENTIFIED BY '${mysqldbpasswd}';"
 
-mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO '$mysqldbuser'@'$mysqldbhost';"
-mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO '$mysqldbuser'@'localhost';"
-mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO '$mysqldbuser'@'%' IDENTIFIED BY '$mysqldbpasswd';"
-
-if [ '$(mysql -u root -e "select user from mysql.user where user='$mysqldbuser' and host='$myhostname'" | grep "$mysqldbuser")' != '0' ]; then
-  echo "Adding user $mysqldbuser@$myhostname";
-  mysql -u root -e "CREATE USER '$mysqldbuser'@'$myhostname' IDENTIFIED BY '$mysqldbpasswd';";
-  mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO '$mysqldbuser'@'$myhostname';";
-fi
-mysql -u root -e "flush privileges;"
-service ${mysqldservice} stop
+mysql -u root --password=${mysqlqdminpassword} -e "GRANT ALL PRIVILEGES ON *.* TO '${mysqldbuser}'@'${mysqldbhost}';"
+mysql -u root --password=${mysqlqdminpassword} -e "GRANT ALL PRIVILEGES ON *.* TO '${mysqldbuser}'@'localhost';"
+mysql -u root --password=${mysqlqdminpassword} -e "GRANT ALL PRIVILEGES ON *.* TO '${mysqldbuser}'@'%' IDENTIFIED BY '${mysqldbpasswd}';"
+mysql -u root --password=${mysqlqdminpassword} -e "flush privileges;"

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/files/createMysqlGeoIp.sh
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/files/createMysqlGeoIp.sh
@@ -19,10 +19,12 @@
 # under the License.
 #
 #
+from ../scripts/params import params
 
 mysqldservice=$1
 geoipscript=$2
 geoipurl=$3
+mysqlqdminpassword=$4
 
 # Download and extract the actual GeoIP files
 mkdir -p /tmp/geoip
@@ -35,8 +37,7 @@ tar xf GeoLiteCity-latest.tar.xz
 cp /tmp/geoip/*/*.csv /var/lib/mysql-files/
 popd
 
-# Load MySQL with the GeoIP data and start service
-service ${mysqldservice} start
-mysql -u root < ${geoipscript}
-mysql -u root -e "show databases;"
-service ${mysqldservice} stop
+# Load MySQL with the GeoIP data
+mysql -u root --password=${mysqlqdminpassword} < ${geoipscript}
+mysql -u root --password=${mysqlqdminpassword} -e "show databases;"
+

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/files/createMysqlGeoIp.sh
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/files/createMysqlGeoIp.sh
@@ -21,10 +21,9 @@
 #
 from ../scripts/params import params
 
-mysqldservice=$1
-geoipscript=$2
-geoipurl=$3
-mysqlqdminpassword=$4
+geoipscript=$1
+geoipurl=$2
+mysqlqdminpassword=$3
 
 # Download and extract the actual GeoIP files
 mkdir -p /tmp/geoip
@@ -38,6 +37,17 @@ cp /tmp/geoip/*/*.csv /var/lib/mysql-files/
 popd
 
 # Load MySQL with the GeoIP data
-mysql -u root --password=${mysqlqdminpassword} < ${geoipscript}
-mysql -u root --password=${mysqlqdminpassword} -e "show databases;"
-
+expect <<EOF
+log_user 0
+# start mysql process using password prompt
+spawn mysql -u root -p
+expect "password:"
+send "${mysqlqdminpassword}\r"
+# echo all output until the end
+log_user 1
+expect "mysql>"
+send "source ${geoipscript}\r"
+expect "mysql>"
+send "show databases;\r"
+send "\q"
+EOF

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/files/removeMysqlUser.sh
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/files/removeMysqlUser.sh
@@ -23,11 +23,10 @@
 mysqldservice=$1
 mysqldbuser=$2
 userhost=$3
+mysqlqdminpassword=$4
 myhostname=$(hostname -f)
 sudo_prefix="/var/lib/ambari-agent/ambari-sudo.sh -H -E"
 
-${sudo_prefix} service ${mysqldservice} start
 echo "Removing user $mysqldbuser@$userhost"
-/var/lib/ambari-agent/ambari-sudo.sh su mysql -s /bin/bash - -c "mysql -u root -e \"DROP USER '$mysqldbuser'@'$userhost';\""
-/var/lib/ambari-agent/ambari-sudo.sh su mysql -s /bin/bash - -c "mysql -u root -e \"flush privileges;\""
-${sudo_prefix} service ${mysqldservice} stop
+/var/lib/ambari-agent/ambari-sudo.sh su mysql -s /bin/bash - -c "mysql -u root --password=${mysqlqdminpassword} -e \"DROP USER '${mysqldbuser}'@'${userhost}';\""
+/var/lib/ambari-agent/ambari-sudo.sh su mysql -s /bin/bash - -c "mysql -u root --oassword=${mysqlqdminpassword} -e \"flush privileges;\""

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/files/removeMysqlUser.sh
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/files/removeMysqlUser.sh
@@ -20,13 +20,24 @@
 #
 #
 
-mysqldservice=$1
-mysqldbuser=$2
-userhost=$3
-mysqlqdminpassword=$4
+mysqldbuser=$1
+userhost=$2
+mysqlqdminpassword=$3
 myhostname=$(hostname -f)
 sudo_prefix="/var/lib/ambari-agent/ambari-sudo.sh -H -E"
 
 echo "Removing user $mysqldbuser@$userhost"
-/var/lib/ambari-agent/ambari-sudo.sh su mysql -s /bin/bash - -c "mysql -u root --password=${mysqlqdminpassword} -e \"DROP USER '${mysqldbuser}'@'${userhost}';\""
-/var/lib/ambari-agent/ambari-sudo.sh su mysql -s /bin/bash - -c "mysql -u root --oassword=${mysqlqdminpassword} -e \"flush privileges;\""
+expect <<EOF
+log_user 0
+# start mysql process using password prompt
+spawn mysql -u root -p
+expect "password:"
+send "${mysqlqdminpassword}\r"
+# echo all output until the end
+log_user 1
+expect "mysql>"
+send "DROP USER '${mysqldbuser}'@'${userhost}';\r"
+expect "mysql>"
+send "flush privileges;;\r"
+send "\q"
+EOF

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/enrichment_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/enrichment_master.py
@@ -30,7 +30,6 @@ class Enrichment(Script):
         env.set_params(params)
         commands = EnrichmentCommands(params)
         commands.setup_repo()
-        Logger.info('Install RPM packages')
         self.install_packages(env)
         self.configure(env)
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/indexing_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/indexing_master.py
@@ -34,7 +34,6 @@ class Indexing(Script):
         env.set_params(params)
         commands = IndexingCommands(params)
         commands.setup_repo()
-        Logger.info('Install RPM packages')
         self.install_packages(env)
 
     def configure(self, env, upgrade_type=None, config_dir=None):

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/mysql_server.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/mysql_server.py
@@ -23,7 +23,8 @@ from resource_management.libraries.script.script import Script
 import mysql_users
 from mysql_service import mysql_service
 from mysql_utils import mysql_configure
-
+from resource_management.core.resources.packaging import Package
+from ambari_commons.os_family_impl import OsFamilyFuncImpl, OsFamilyImpl
 
 class MysqlServer(Script):
     def install(self, env):
@@ -33,7 +34,8 @@ class MysqlServer(Script):
     def clean(self, env):
         from params import params
         env.set_params(params)
-        mysql_users.mysql_deluser()
+        if params.install_mysql == 'Yes':
+            mysql_users.mysql_deluser()
 
     def configure(self, env, upgrade_type=None, config_dir=None):
         from params import params

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/mysql_users.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/mysql_users.py
@@ -32,7 +32,7 @@ def mysql_adduser():
          content=StaticFile('addMysqlUser.sh')
          )
 
-    add_user_cmd = format("bash -x {mysql_adduser_path} {daemon_name} {metron_user} {enrichment_metron_user_passwd!p} {mysql_host} {mysql_admin_password}")
+    add_user_cmd = format("bash -x {mysql_adduser_path} {metron_user} {enrichment_metron_user_passwd!p} {mysql_host} {mysql_admin_password!p}")
     Execute(add_user_cmd,
             tries=3,
             try_sleep=5,
@@ -50,7 +50,7 @@ def mysql_deluser():
          content=StaticFile('removeMysqlUser.sh')
          )
 
-    del_user_cmd = format("bash -x {mysql_deluser_path} {daemon_name} {metron_user} {mysql_host} {mysql_admin_password!p}")
+    del_user_cmd = format("bash -x {mysql_deluser_path} {metron_user} {mysql_host} {mysql_admin_password!p}")
     Execute(del_user_cmd,
             tries=3,
             try_sleep=5,

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/mysql_users.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/mysql_users.py
@@ -32,7 +32,7 @@ def mysql_adduser():
          content=StaticFile('addMysqlUser.sh')
          )
 
-    add_user_cmd = format("bash -x {mysql_adduser_path} {daemon_name} {metron_user} {enrichment_metron_user_passwd!p} {enrichment_host}")
+    add_user_cmd = format("bash -x {mysql_adduser_path} {daemon_name} {metron_user} {enrichment_metron_user_passwd!p} {mysql_host} {mysql_admin_password}")
     Execute(add_user_cmd,
             tries=3,
             try_sleep=5,
@@ -50,7 +50,7 @@ def mysql_deluser():
          content=StaticFile('removeMysqlUser.sh')
          )
 
-    del_user_cmd = format("bash -x {mysql_deluser_path} {daemon_name} {metron_user} {enrichment_host}")
+    del_user_cmd = format("bash -x {mysql_deluser_path} {daemon_name} {metron_user} {mysql_host} {mysql_admin_password!p}")
     Execute(del_user_cmd,
             tries=3,
             try_sleep=5,

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/mysql_utils.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/mysql_utils.py
@@ -44,7 +44,7 @@ def mysql_configure():
          content=StaticFile('createMysqlGeoIp.sh')
          )
 
-    geoip_setup_cmd = format("bash -x {mysql_create_geoip_path} {daemon_name} {geoip_ddl} {geoip_url} {mysql_admin_password}")
+    geoip_setup_cmd = format("bash -x {mysql_create_geoip_path} {geoip_ddl} {geoip_url} {mysql_admin_password!p}")
 
     Execute(geoip_setup_cmd,
             tries=3,

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/params/params_linux.py
@@ -132,9 +132,6 @@ mysql_adduser_path = tmp_dir + "/addMysqlUser.sh"
 mysql_deluser_path = tmp_dir + "/removeMysqlUser.sh"
 mysql_create_geoip_path = tmp_dir + "/createMysqlGeoIp.sh"
 
-#enrichment_hosts = default("/clusterHostInfo/enrichment_host", [])
-#enrichment_host = enrichment_hosts[0] if len(enrichment_hosts) > 0 else None
-
 enrichment_metron_user = config['configurations']['metron-env']['metron_enrichment_db_user']
 enrichment_metron_user_passwd = config['configurations']['metron-env']['metron_enrichment_db_password']
 enrichment_metron_user_passwd = unicode(enrichment_metron_user_passwd) if not is_empty(

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/params/params_linux.py
@@ -119,16 +119,21 @@ else:
     mysql_configname = '/etc/my.cnf'
 
 daemon_name = status_params.daemon_name
+
+install_mysql = config['configurations']['metron-env']['install_mysql']
+mysql_admin_password = config['configurations']['metron-env']['mysql_admin_password']
+
 # There will always be exactly one mysql_host
 mysql_host = config['clusterHostInfo']['metron_enrichment_mysql_server_hosts'][0]
+
 mysql_port = config['configurations']['metron-env']['metron_enrichment_db_port']
 
 mysql_adduser_path = tmp_dir + "/addMysqlUser.sh"
 mysql_deluser_path = tmp_dir + "/removeMysqlUser.sh"
 mysql_create_geoip_path = tmp_dir + "/createMysqlGeoIp.sh"
 
-enrichment_hosts = default("/clusterHostInfo/enrichment_host", [])
-enrichment_host = enrichment_hosts[0] if len(enrichment_hosts) > 0 else None
+#enrichment_hosts = default("/clusterHostInfo/enrichment_host", [])
+#enrichment_host = enrichment_hosts[0] if len(enrichment_hosts) > 0 else None
 
 enrichment_metron_user = config['configurations']['metron-env']['metron_enrichment_db_user']
 enrichment_metron_user_passwd = config['configurations']['metron-env']['metron_enrichment_db_password']

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/parser_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/parser_master.py
@@ -36,7 +36,6 @@ class ParserMaster(Script):
         env.set_params(params)
         commands = ParserCommands(params)
         commands.setup_repo()
-        Logger.info('Install RPM packages')
         self.install_packages(env)
 
     def configure(self, env, upgrade_type=None, config_dir=None):

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/service_advisor.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/service_advisor.py
@@ -85,6 +85,18 @@ class METRON021BETAServiceAdvisor(service_advisor.ServiceAdvisor):
 
     def getServiceConfigurationRecommendations(self, configurations, clusterData, services, hosts):
 
+        #Suggest Storm Rest URL
+        stormUIServerHost = self.getComponentHostNames(services, "STORM", "STORM_UI_SERVER")[0]
+        stormUIServerPort = services["configurations"]["storm-site"]["properties"]["ui.port"]
+        stormUIServerURL = stormUIServerHost + ":" + stormUIServerPort
+        putMetronEnvProperty = self.putProperty(configurations, "metron-env", services)
+        putMetronEnvProperty("storm_rest_addr",stormUIServerURL)
+
+        #Suggest mysql server hostname
+        mySQLServerHost = self.getComponentHostNames(services, "METRON", "METRON_ENRICHMENT_MYSQL_SERVER")[0]
+        putMetronEnvProperty = self.putProperty(configurations, "metron-env", services)
+        putMetronEnvProperty("mysql_host",mySQLServerHost)
+
         if "storm-site" in services["configurations"]:
 
             storm_site = services["configurations"]["storm-site"]["properties"]

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/themes/metron_theme.json
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/themes/metron_theme.json
@@ -1,0 +1,133 @@
+{
+  "configuration": {
+    "layouts": [
+      {
+        "name": "default",
+        "tabs": [
+          {
+            "name": "metron_general",
+            "display-name": "Settings",
+            "layout": {
+              "tab-columns": "1",
+              "tab-rows": "1",
+              "sections": [
+                {
+                  "name": "section-general",
+                  "row-index": "0",
+                  "column-index": "0",
+                  "row-span": "1",
+                  "column-span": "1",
+                  "section-columns": "2",
+                  "section-rows": "1",
+                  "subsections": [
+                    {
+                      "name": "subsection-general-database",
+                      "display-name" : "Database Settings",
+                      "row-index": "0",
+                      "column-index": "0",
+                      "row-span": "1",
+                      "column-span": "1"
+                    },
+                    {
+                      "name": "subsection-general-indexing",
+                      "display-name": "Index Settings",
+                      "row-index": "0",
+                      "column-index": "1",
+                      "row-span": "1",
+                      "column-span": "1"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "placement": {
+      "configuration-layout": "default",
+      "configs": [
+        {
+          "config": "metron-env/install_mysql",
+          "subsection-name": "subsection-general-database"
+        },
+        {
+          "config": "metron-env/mysql_admin_password",
+          "subsection-name": "subsection-general-database",
+          "depends-on": [
+            {
+              "configs":[
+                "metron-env/install_mysql"
+              ],
+              "if": "${metron-env/install_mysql} === No",
+              "then": {
+                "property_value_attributes": {
+                  "visible": true
+                }
+              },
+              "else": {
+                "property_value_attributes": {
+                  "visible": false
+                }
+              }
+            }
+          ]
+        },
+        {
+          "config": "metron-env/metron_enrichment_db_password",
+          "subsection-name": "subsection-general-database"
+        },
+        {
+          "config": "metron-env/metron_enrichment_db_port",
+          "subsection-name": "subsection-general-database"
+        },
+        {
+          "config": "metron-env/es_url",
+          "subsection-name": "subsection-general-indexing"
+        },
+        {
+          "config": "metron-env/es_cluster_name",
+          "subsection-name": "subsection-general-indexing"
+        }
+      ]
+    },
+    "widgets": [
+      {
+        "config": "metron-env/install_mysql",
+        "widget": {
+          "type": "toggle"
+        }
+      },
+      {
+        "config": "metron-env/mysql_admin_password",
+        "widget": {
+          "type": "password"
+        }
+      },
+      {
+        "config": "metron-env/metron_enrichment_db_password",
+        "widget": {
+          "type": "password"
+        }
+      },
+      {
+        "config": "metron-env/metron_enrichment_db_port",
+        "widget": {
+          "type": "text-field"
+        }
+      },
+      {
+        "config": "metron-env/es_url",
+        "widget": {
+          "type": "text-field"
+        }
+      },
+      {
+        "config": "metron-env/es_cluster_name",
+        "widget": {
+          "type": "text-field"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
…ruction when installed on the same machine as the Ambari Hive MySQL

Allowed the user to indicate their using an existing MySQL instance:

a) Refactored the required database and index settings to a separate property sheet using enhanced configs.
b) Made the MySQL start/stop logic from the add user, remove user and geo ip database load conditional.
c) Auto-populated the Storm UI URL and MySQL Host Address from the Add Service Wizard Master Install Selection page.
d) Cleaned up some lingering metainfo.xml items since I was in the file anyway to add the theme.

Tested on Docker cluster following procedure here: [Metron MPack](https://www.evernote.com/l/AhLFVR-9CsFIYYnOnF43BlxSsT4F856qwaY)

Test case 1: Default install (Ambari installed MySQL)l
Test case 2: Pre-existing MySQL install.
