### PR TITLE
METRON-443 Exception seen while running stellar or fixed query on pcap data

### DIFF
--- a/metron-platform/metron-pcap/src/main/java/org/apache/metron/pcap/PcapPacketComparator.java
+++ b/metron-platform/metron-pcap/src/main/java/org/apache/metron/pcap/PcapPacketComparator.java
@@ -25,15 +25,13 @@ import org.krakenapps.pcap.packet.PcapPacket;
 
 public class PcapPacketComparator implements Comparator<PcapPacket> {
 
-	/** The Constant LOG. */
-	private static final Logger LOG = Logger.getLogger(PcapMerger.class);
-	
-	public int compare(PcapPacket p1, PcapPacket p2) {
+  /** The Constant LOG. */
+  private static final Logger LOG = Logger.getLogger(PcapMerger.class);
 
-		Long p1time = new Long(p1.getPacketHeader().getTsSec()) * 1000000L + new Long(p1.getPacketHeader().getTsUsec());
-		Long p2time = new Long(p2.getPacketHeader().getTsSec()) * 1000000L + new Long(p2.getPacketHeader().getTsUsec());
-		Long delta = p1time - p2time;
-		LOG.debug("p1time: " + p1time.toString() + " p2time: " + p2time.toString() + " delta: " + delta.toString());
-		return delta.intValue();
-	}
+  public int compare(PcapPacket p1, PcapPacket p2) {
+    long p1time = p1.getPacketHeader().getTsSec() * 1000000L + p1.getPacketHeader().getTsUsec();
+    long p2time = p2.getPacketHeader().getTsSec() * 1000000L + p2.getPacketHeader().getTsUsec();
+    LOG.debug("p1time: " + p1time + " p2time: " + p2time);
+    return Long.compare(p1time, p2time);
+  }
 }

--- a/metron-platform/metron-pcap/src/test/java/org/apache/metron/pcap/PcapPackerComparatorTest.java
+++ b/metron-platform/metron-pcap/src/test/java/org/apache/metron/pcap/PcapPackerComparatorTest.java
@@ -1,0 +1,95 @@
+package org.apache.metron.pcap;
+
+import org.junit.Test;
+import org.krakenapps.pcap.packet.PacketHeader;
+import org.krakenapps.pcap.packet.PacketPayload;
+import org.krakenapps.pcap.packet.PcapPacket;
+
+import java.text.ParseException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PcapPackerComparatorTest {
+  private static final String BASE_DATE = "July 26, 2016 8:21:13 AM UTC";
+  private static final String DATE_FORMAT = "MMMM dd, yyyy h:mm:ss a z";
+
+  private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT);
+  private static final ZonedDateTime JULY_26 = ZonedDateTime.parse(BASE_DATE, FORMATTER);
+
+  private static final long JULY_26_SECONDS = JULY_26.toInstant().getEpochSecond();
+  private static final long JULY_26_PLUS_ONE_SECOND_SECONDS = JULY_26.plusSeconds(1L).toInstant().getEpochSecond();
+  private static final long JULY_26_PLUS_TWENTY_YEARS_SECONDS = JULY_26.plusYears(20L).toInstant().getEpochSecond();
+
+  private static final PacketPayload EMPTY_PAYLOAD = new PacketPayload(new byte[0]);
+
+  private static final PcapPacketComparator comp = new PcapPacketComparator();
+
+  @Test
+  public void testEqual() throws ParseException {
+    PacketHeader ph = new PacketHeader((int) JULY_26_SECONDS, 0, 0, 0);
+    PcapPacket packet = new PcapPacket(ph, EMPTY_PAYLOAD);
+
+    PacketHeader ph2 = new PacketHeader((int) JULY_26_SECONDS, 0, 0, 0);
+    PcapPacket packet2 = new PcapPacket(ph2, EMPTY_PAYLOAD);
+
+    assertEquals("Timestamps should be equal", comp.compare(packet, packet2), 0);
+    assertEquals("Timestamps should be equal", comp.compare(packet2, packet), 0);
+  }
+
+  @Test
+  public void testDifferingSeconds() throws ParseException {
+    PacketHeader ph = new PacketHeader((int) JULY_26_SECONDS, 0, 0, 0);
+    PcapPacket earlier = new PcapPacket(ph, EMPTY_PAYLOAD);
+
+    PacketHeader ph2 = new PacketHeader((int) JULY_26_PLUS_ONE_SECOND_SECONDS, 0, 0, 0);
+    PcapPacket later = new PcapPacket(ph2, EMPTY_PAYLOAD);
+
+    PcapPacketComparator comp = new PcapPacketComparator();
+    assertTrue("Earlier should be less than later", comp.compare(earlier, later) < 0);
+    assertTrue("Later should be greater than earlier", comp.compare(later, earlier) > 0);
+  }
+
+  @Test
+  public void testDifferingMicroseconds() throws ParseException {
+    PacketHeader ph = new PacketHeader((int) JULY_26_SECONDS, 0, 0, 0);
+    PcapPacket earlier = new PcapPacket(ph, EMPTY_PAYLOAD);
+
+    PacketHeader ph2 = new PacketHeader((int) JULY_26_SECONDS, 1, 0, 0);
+    PcapPacket later = new PcapPacket(ph2, EMPTY_PAYLOAD);
+
+    PcapPacketComparator comp = new PcapPacketComparator();
+    assertTrue("Earlier should be less than later", comp.compare(earlier, later) < 0);
+    assertTrue("Later should be greater than earlier", comp.compare(later, earlier) > 0);
+  }
+
+  @Test
+  public void testBothSmallDifferences() throws ParseException {
+    PacketHeader ph = new PacketHeader((int) JULY_26_SECONDS, 0, 0, 0);
+    PcapPacket earlier = new PcapPacket(ph, EMPTY_PAYLOAD);
+
+    PacketHeader ph2 = new PacketHeader((int) JULY_26_PLUS_ONE_SECOND_SECONDS, 1, 0, 0);
+    PcapPacket later = new PcapPacket(ph2, EMPTY_PAYLOAD);
+
+    PcapPacketComparator comp = new PcapPacketComparator();
+    assertTrue("Earlier should be less than later", comp.compare(earlier, later) < 0);
+    assertTrue("Later should be greater than earlier", comp.compare(later, earlier) > 0);
+  }
+
+  @Test
+  public void testLargeDifference() throws ParseException {
+    PacketHeader ph = new PacketHeader((int) JULY_26_SECONDS, 0, 0, 0);
+    PcapPacket earlier = new PcapPacket(ph, EMPTY_PAYLOAD);
+
+    PacketHeader ph2 = new PacketHeader((int) JULY_26_PLUS_TWENTY_YEARS_SECONDS, 999999, 0, 0);
+    PcapPacket later = new PcapPacket(ph2, EMPTY_PAYLOAD);
+
+    PcapPacketComparator comp = new PcapPacketComparator();
+    System.out.println(ph);
+    System.out.println(ph2);
+    assertTrue("Earlier should be less than later", comp.compare(earlier, later) < 0);
+    assertTrue("Later should be greater than earlier", comp.compare(later, earlier) > 0);
+  }
+}

--- a/metron-platform/metron-pcap/src/test/java/org/apache/metron/pcap/PcapPackerComparatorTest.java
+++ b/metron-platform/metron-pcap/src/test/java/org/apache/metron/pcap/PcapPackerComparatorTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.metron.pcap;
 
 import org.junit.Test;

--- a/metron-platform/metron-pcap/src/test/java/org/apache/metron/pcap/PcapPackerComparatorTest.java
+++ b/metron-platform/metron-pcap/src/test/java/org/apache/metron/pcap/PcapPackerComparatorTest.java
@@ -105,8 +105,6 @@ public class PcapPackerComparatorTest {
     PcapPacket later = new PcapPacket(ph2, EMPTY_PAYLOAD);
 
     PcapPacketComparator comp = new PcapPacketComparator();
-    System.out.println(ph);
-    System.out.println(ph2);
     assertTrue("Earlier should be less than later", comp.compare(earlier, later) < 0);
     assertTrue("Later should be greater than earlier", comp.compare(later, earlier) > 0);
   }


### PR DESCRIPTION
I believe this resolves this ticket, but was unable to prove it directly with the provided information.  However, this does solve a specific, input dependent, bug that would result in the described error.

The original implementation of the comparator was generating microseconds since epoch as Longs from the provided packets (seconds \* 1000000 + microseconds). While Long is sufficient for holding these values, a narrowing conversion occurs during the intValue() call on the difference.  The problem is that narrowing conversions do not necessarily maintain sign. This can then result in incorrect comparisons and the error seen.  See http://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.3

> A narrowing conversion of a signed integer to an integral type T simply discards all but the n lowest order bits, where n is the number of bits used to represent type T. In addition to a possible loss of information about the magnitude of the numeric value, this may cause the sign of the resulting value to differ from the sign of the input value.

The code has been updated and cleaned up a bit to avoid this narrowing conversion and avoid some unnecessary boxing while I was already in the code. Given that it has plain longs, rather than calculate a difference, it just calls `Long.compare()` on the generated microseconds since epoch.  Debug message is modified accordingly to not use the difference anymore, because it's no longer calculated or used.

Unit tests are added, and the original function fails `testLargeDifference()`, while the new one succeeds. This function adds twenty years to the original date, and does a comparison.  `compare(earlier, later)` should return negative, but due to the narrowing conversion actually return positive as demonstrated here:

> p1time:1469521273000000 p2time: 2100673273999999 delta: -631152000999999
> -631152000999999 - After longValue()
> 2033081793 - After intValue()

I haven't run this up in a dev environment, given the relatively small size of the change and the ability to directly unit test and prove the error. If anyone wants me to run it up and do more involved testing, I'm happy to do that too.
