### PR TITLE
METRON-513: Ambari MP Metainfo should not advertise version

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/metainfo.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/metainfo.xml
@@ -30,7 +30,7 @@
           <displayName>Metron Parsers</displayName>
           <category>MASTER</category>
           <cardinality>1</cardinality>
-          <versionAdvertised>true</versionAdvertised>
+          <versionAdvertised>false</versionAdvertised>
           <reassignAllowed>false</reassignAllowed>
           <clientsToUpdateConfigs></clientsToUpdateConfigs>
           <dependencies>
@@ -77,7 +77,7 @@
           <displayName>Metron Enrichment</displayName>
           <category>MASTER</category>
           <cardinality>1</cardinality>
-          <versionAdvertised>true</versionAdvertised>
+          <versionAdvertised>false</versionAdvertised>
           <dependencies>
             <dependency>
               <name>HDFS/HDFS_CLIENT</name>
@@ -136,7 +136,7 @@
           <displayName>Metron Indexing</displayName>
           <category>MASTER</category>
           <cardinality>1</cardinality>
-          <versionAdvertised>true</versionAdvertised>
+          <versionAdvertised>false</versionAdvertised>
           <reassignAllowed>false</reassignAllowed>
           <clientsToUpdateConfigs></clientsToUpdateConfigs>
           <dependencies>


### PR DESCRIPTION
Set versionAdvertised to false in metainfo.xml for the MPack.

Prior to this change, the cluster would report the Metron host as "OUT_OF_SYNC".

Tested on Docker cluster following procedure here: [Metron MPack](https://www.evernote.com/l/AhLFVR-9CsFIYYnOnF43BlxSsT4F856qwaY)

No longer reports "OUT_OF_SYNC"
> curl -H "X-Requested-By: ambari" -X GET -u admin:admin 
http://localhost:8080/api/v1/clusters/docker-metron/stack_versions/1
> {
>  "ClusterStackVersions" : {
>     "cluster_name" : "docker-metron",
>     "id" : 1,
>     "repository_version" : 1,
>     "stack" : "HDP",
>     "state" : "CURRENT",
>     "version" : "2.4",
>     "host_states" : {
>       "CURRENT" : [
>         "amb1.service.consul",
>         "amb2.service.consul",
>         "amb3.service.consul",
>         "amb4.service.consul"
>       ],
>       "INIT" : [ ],
>       "INSTALLED" : [ ],
>       "INSTALLING" : [ ],
>       "INSTALL_FAILED" : [ ],
>       "NOT_REQUIRED" : [ ],
>       "OUT_OF_SYNC" : [ ]
>     }