### PR TITLE
METRON-515: Stellar IS_EMPTY() function does not work as expected

### DIFF
--- a/metron-platform/metron-common/README.md
+++ b/metron-platform/metron-common/README.md
@@ -146,9 +146,9 @@ The following functions are supported:
     * address - The String to test
   * Returns: True if the string is a valid email address and false otherwise.
 * `IS_EMPTY`
-  * Description: Returns true if string or collection is empty and false otherwise
+  * Description: Returns true if value is null or if string or collection is empty
   * Input:
-    * input - Object of string or collection type (e.g. list)
+    * input - Object
   * Returns: Boolean
 * `IS_INTEGER`
   * Description: Determine if an object is an integer or not.

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DataStructureFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DataStructureFunctions.java
@@ -158,7 +158,7 @@ public class DataStructureFunctions {
         return val == null || val.isEmpty() ? true : false;
       }
       else {
-        return true;
+        return o == null;
       }
     }
   }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DataStructureFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DataStructureFunctions.java
@@ -138,8 +138,8 @@ public class DataStructureFunctions {
   }
 
   @Stellar(name="IS_EMPTY"
-          , description="Returns true if string or collection is empty and false otherwise"
-          , params = { "input - Object of string or collection type (e.g. list)"}
+          , description="Returns true if value is null or if string or collection is empty"
+          , params = { "input - Object"}
           , returns = "Boolean"
           )
   public static class IsEmpty extends BaseStellarFunction {

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/dsl/functions/DataStructureFunctionsTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/dsl/functions/DataStructureFunctionsTest.java
@@ -36,6 +36,10 @@ public class DataStructureFunctionsTest {
       boolean empty = (boolean) isEmpty.apply(ImmutableList.of(ImmutableList.of("hello", "world")));
       Assert.assertThat("should be false", empty, CoreMatchers.equalTo(false));
     }
+    {
+      boolean empty = (boolean) isEmpty.apply(ImmutableList.of(1));
+      Assert.assertThat("should be false", empty, CoreMatchers.equalTo(false));
+    }
   }
 
   @Test
@@ -51,10 +55,6 @@ public class DataStructureFunctionsTest {
     }
     {
       boolean empty = (boolean) isEmpty.apply(ImmutableList.of(""));
-      Assert.assertThat("should be true", empty, CoreMatchers.equalTo(true));
-    }
-    {
-      boolean empty = (boolean) isEmpty.apply(ImmutableList.of(new Object()));
       Assert.assertThat("should be true", empty, CoreMatchers.equalTo(true));
     }
   }


### PR DESCRIPTION
The "IS_EMPTY" Stellar function is always returning true if the field value is not a String type.  This PR changes the function to only return true when a value is missing, an empty string, or has a null value.  

I also modified the unit test to include a test for an Integer type and removed the test that asserts true when the value is a newly created object.  In my opinion that is not a valid test case.  