### PR TITLE
METRON-512 up default junit to 4.12

### DIFF
--- a/metron-analytics/pom.xml
+++ b/metron-analytics/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>${global_junit_version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/metron-platform/metron-data-management/pom.xml
+++ b/metron-platform/metron-data-management/pom.xml
@@ -242,7 +242,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${global_junit_version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/metron-platform/metron-test-utilities/pom.xml
+++ b/metron-platform/metron-test-utilities/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>${global_junit_version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/metron-platform/pom.xml
+++ b/metron-platform/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>${global_junit_version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <global_elasticsearch_version>2.3.3</global_elasticsearch_version>
         <global_json_simple_version>1.1.1</global_json_simple_version>
         <global_metrics_version>3.0.2</global_metrics_version>
-        <global_junit_version>4.4</global_junit_version>
+        <global_junit_version>4.12</global_junit_version>
         <global_guava_version>17.0</global_guava_version>
         <global_hbase_guava_version>12.0</global_hbase_guava_version>
         <global_json_schema_validator_version>2.2.5</global_json_schema_validator_version>


### PR DESCRIPTION
"Global default JUnit version is 4.4. It would be nice to update this to 4.12 and expose newer JUnit featues. Existing pom files should be updated - some are pointing to the version in an ad-hoc fashion rather than using the global version."


full build and tests passing