### PR TITLE
METRON-510: Update elasticsearch bro templates for *_body_len

### DIFF
--- a/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/bro_index.template
+++ b/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/bro_index.template
@@ -127,7 +127,7 @@
           "index": "not_analyzed"
         },
         "request_body_len": {
-          "type": "integer"
+          "type": "long"
         },
         "uri": {
           "type": "string",
@@ -153,7 +153,7 @@
           "index": "not_analyzed"
         },
         "response_body_len": {
-          "type": "integer"
+          "type": "long"
         },
         "user_agent": {
           "type": "string"


### PR DESCRIPTION
## Problem

[METRON-510](https://issues.apache.org/jira/browse/METRON-510)

The bro *_body_len fields in [HTTP::Info](https://www.bro.org/sphinx/scripts/base/protocols/http/main.bro.html#type-HTTP::Info) can exceed the range of an int, and so writing to ElasticSearch fails with the following exception:

```
MapperParsingException[failed to parse [response_body_len]]; nested: JsonParseException[Numeric value (9876543210) out of range of int
```
## Solution

I updated the bro_index elasticsearch template to use a datatype of `long` for {request,response}_body_len, as opposed to an `integer`.  
