### PR TITLE
METRON-521: Stellar function documentation needs grammar/clarity fixes

### DIFF
--- a/metron-platform/metron-common/README.md
+++ b/metron-platform/metron-common/README.md
@@ -146,10 +146,10 @@ The following functions are supported:
     * address - The string to test
   * Returns: True if the string is a valid email address and false if otherwise.
 * `IS_EMPTY`
-  * Description: Returns true if string or collection is empty and false if otherwise.
+  * Description: Returns true if string or collection is empty or null and false if otherwise.
   * Input:
     * input - Object of string or collection type (for example, list)
-  * Returns: True if the string or collection is empty and false otherwise.
+  * Returns: True if the string or collection is empty or null and false if otherwise.
 * `IS_INTEGER`
   * Description: Determines whether or not an object is an integer.
   * Input:
@@ -348,7 +348,7 @@ The following functions are supported:
     * input - Object of string or numeric type
   * Returns: Double version of the first argument
 * `TO_EPOCH_TIMESTAMP`
-  * Description: Returns the epoch timestamp of the dateTime in the specifiedthe format. If the format does not have a timestamp and you wish to assume a given timestamp, you may specify the timezone optionally.
+  * Description: Returns the epoch timestamp of the dateTime in the specified the format. If the format does not have a timestamp and you wish to assume a given timestamp, you may specify the timezone optionally.
   * Input:
     * dateTime - DateTime in String format
     * format - DateTime format as a String

--- a/metron-platform/metron-common/README.md
+++ b/metron-platform/metron-common/README.md
@@ -348,7 +348,7 @@ The following functions are supported:
     * input - Object of string or numeric type
   * Returns: Double version of the first argument
 * `TO_EPOCH_TIMESTAMP`
-  * Description: Returns the epoch timestamp of the dateTime in the specified the format. If the format does not have a timestamp and you wish to assume a given timestamp, you may specify the timezone optionally.
+  * Description: Returns the epoch timestamp of the dateTime in the specified format. If the format does not have a timestamp and you wish to assume a given timestamp, you may specify the timezone optionally.
   * Input:
     * dateTime - DateTime in String format
     * format - DateTime format as a String

--- a/metron-platform/metron-common/README.md
+++ b/metron-platform/metron-common/README.md
@@ -71,26 +71,26 @@ The following functions are supported:
     * dateTime - The datetime as a long representing the milliseconds since unix epoch
   * Returns: The day number within the year.
 * `DOMAIN_REMOVE_SUBDOMAINS`
-  * Description: Remove subdomains from a domain.
+  * Description: Removes the subdomains from a domain.
   * Input:
-    * domain - fully qualified domain name
-  * Returns: The domain without the subdomains.  e.g. DOMAIN_REMOVE_SUBDOMAINS('mail.yahoo.com') yields 'yahoo.com'
+    * domain - Fully qualified domain name
+  * Returns: The domain without the subdomains.  (for example, DOMAIN_REMOVE_SUBDOMAINS('mail.yahoo.com') yields 'yahoo.com')
 * `DOMAIN_REMOVE_TLD`
-  * Description: Remove top level domain suffix from a domain.
+  * Description: Removes the top level domain (TLD) suffix from a domain.
   * Input:
-    * domain - fully qualified domain name
-  * Returns: The domain without the TLD.  e.g. DOMAIN_REMOVE_TLD('mail.yahoo.co.uk') yields 'mail.yahoo'
+    * domain - Fully qualified domain name
+  * Returns: The domain without the TLD.  (for example, DOMAIN_REMOVE_TLD('mail.yahoo.co.uk') yields 'mail.yahoo')
 * `DOMAIN_TO_TLD`
-  * Description: Extract the top level domain from a domain
+  * Description: Extracts the top level domain from a domain
   * Input:
-    * domain - fully qualified domain name
-  * Returns: The TLD of the domain.  e.g. DOMAIN_TO_TLD('mail.yahoo.co.uk') yields 'co.uk'
+    * domain - Fully qualified domain name
+  * Returns: The TLD of the domain.  (for example, DOMAIN_TO_TLD('mail.yahoo.co.uk') yields 'co.uk')
 * `ENDS_WITH`
-  * Description: Determines whether a string ends with a prefix
+  * Description: Determines whether a string ends with a specified suffix
   * Input:
     * string - The string to test
     * suffix - The proposed suffix
-  * Returns: True if the string ends with the specified suffix and false otherwise.
+  * Returns: True if the string ends with the specified suffix and false if otherwise
 * `ENRICHMENT_EXISTS`
   * Description: Interrogates the HBase table holding the simple hbase enrichment data and returns whether the enrichment type and indicator are in the table.
   * Input:
@@ -111,7 +111,7 @@ The following functions are supported:
   * Description: Returns the i'th element of the list 
   * Input:
     * input - List
-    * i - the index (0-based)
+    * i - The index (0-based)
   * Returns: First element of the list
 * `GET_FIRST`
   * Description: Returns the first element of the list
@@ -124,87 +124,101 @@ The following functions are supported:
     * input - List
   * Returns: Last element of the list
 * `IN_SUBNET`
-  * Description: Returns if an IP is within a subnet range.
+  * Description: Returns true if an IP is within a subnet range.
   * Input:
-    * ip - the IP address in String form
-    * cidr+ - one or more IP ranges specified in CIDR notation (e.g. 192.168.0.0/24)
-  * Returns: True if the IP address is within at least one of the network ranges and false otherwise
+    * ip - The IP address in string form
+    * cidr+ - One or more IP ranges specified in CIDR notation (for example 192.168.0.0/24)
+  * Returns: True if the IP address is within at least one of the network ranges and false if otherwise
 * `IS_DATE`
-  * Description: Determines if a string passed is a date of a given format.
+  * Description: Determines if the date contained in the string conforms to the specified format.
   * Input:
-    * date - The date in string form.
-    * format - The format of the date.
-  * Returns: True if the date is of the specified format and false otherwise.
+    * date - The date in string form
+    * format - The format of the date
+  * Returns: True if the date is in the specified format and false if otherwise.
 * `IS_DOMAIN`
-  * Description: Tests if a string is a valid domain.  Domain names are evaluated according to the standards RFC1034 section 3, and RFC1123 section 2.1.
+  * Description: Tests if a string refers to a valid domain name.  Domain names are evaluated according to the standards RFC1034 section 3, and RFC1123 section 2.1.
   * Input:
-    * address - The String to test
-  * Returns: True if the string is a valid domain and false otherwise.
+    * address - The string to test
+  * Returns: True if the string refers to a valid domain name and false if otherwise
 * `IS_EMAIL`
   * Description: Tests if a string is a valid email address
   * Input:
-    * address - The String to test
-  * Returns: True if the string is a valid email address and false otherwise.
+    * address - The string to test
+  * Returns: True if the string is a valid email address and false if otherwise.
 * `IS_EMPTY`
-  * Description: Returns true if string or collection is empty and false otherwise
+  * Description: Returns true if string or collection is empty and false if otherwise.
   * Input:
-    * input - Object of string or collection type (e.g. list)
-  * Returns: Boolean
+    * input - Object of string or collection type (for example, list)
+  * Returns: True if the string or collection is empty and false otherwise.
 * `IS_INTEGER`
-  * Description: Determine if an object is an integer or not.
+  * Description: Determines whether or not an object is an integer.
   * Input:
-    * x - An object which we wish to test is an integer
-  * Returns: True if the object can be converted to an integer and false otherwise.
+    * x - The object to test
+  * Returns: True if the object can be converted to an integer and false if otherwise.
 * `IS_IP`
   * Description: Determine if an string is an IP or not.
   * Input:
     * ip - An object which we wish to test is an ip
-    * type (optional) - one of IPV4 or IPV6.  The default is IPV4.
+    * type (optional) - Object of string or collection type (e.g. list) one of IPV4 or IPV6 or both.  The default is IPV4.
   * Returns: True if the string is an IP and false otherwise.
 * `IS_URL`
   * Description: Tests if a string is a valid URL
   * Input:
-    * url - The String to test
-  * Returns: True if the string is a valid URL and false otherwise.
+    * url - The string to test
+  * Returns: True if the string is a valid URL and false if otherwise.
 * `JOIN`
-  * Description: Joins the components of the list with the specified delimiter.
+  * Description: Joins the components in the list of strings with the specified delimiter.
   * Input:
-    * list - List of Strings
+    * list - List of strings
     * delim - String delimiter
   * Returns: String
+* `LENGTH`
+  * Description: Returns the length of a string or size of a collection. Returns 0 for empty or null Strings
+  * Input:
+    * input - Object of string or collection type (e.g. list)
+  * Returns: Integer
 * `MAAS_GET_ENDPOINT`
-  * Description: Inspects zookeeper and returns a map containing the name, version and url for the model referred to by the input params
+  * Description: Inspects ZooKeeper and returns a map containing the name, version and url for the model referred to by the input parameters.
   * Input:
-    * model_name - the name of the model
-    * model_version - the optional version of the model.  If it is not specified, the most current version is used.
-  * Returns: A map containing the name, version, url for the REST endpoint (fields named name, version and url).  Note that the output of this function is suitable for input into the first argument of MAAS_MODEL_APPLY.
+    * model_name - The name of the model
+    * model_version - The optional version of the model.  If the model version is not specified, the most current version is used.
+  * Returns: A map containing the name, version, and url for the REST endpoint (fields named name, version and url).  Note that the output of this function is suitable for input into the first argument of MAAS_MODEL_APPLY.
 * `MAAS_MODEL_APPLY`
-  * Description: Returns the output of a model deployed via model which is deployed at endpoint. NOTE: Results are cached at the client for 10 minutes.
+  * Description: Returns the output of a model deployed via Model as a Service. NOTE: Results are cached locally for 10 minutes.
   * Input:
-    * endpoint - a map containing name, version, url for the REST endpoint
-    * function - the optional endpoint path, default is 'apply'
-    * model_args - dictionary of arguments for the model (these become request params).
+    * endpoint - A map containing the name, version, and url for the REST endpoint
+    * function - The optional endpoint path; default is 'apply'
+    * model_args - A Dictionary of arguments for the model (these become request params)
   * Returns: The output of the model deployed as a REST endpoint in Map form.  Assumes REST endpoint returns a JSON Map.
 * `MAP_EXISTS`
   * Description: Checks for existence of a key in a map.
   * Input:
     * key - The key to check for existence
     * map - The map to check for existence of the key
-  * Returns: True if the key is found in the map and false otherwise.
+  * Returns: True if the key is found in the map and false if otherwise.
 * `MAP_GET`
   * Description: Gets the value associated with a key from a map
   * Input:
     * key - The key
     * map - The map
     * default - Optionally the default value to return if the key is not in the map.
-  * Returns: The object associated with key in the map.  If there is no value associated, then default if specified and null if a default is not specified.
+  * Returns: The object associated with the key in the map.  If no value is associated with the key and default is specified, then default is returned. If no value is associated with the key or default, then null is returned.
 * `MONTH`
   * Description: The number representing the month.  The first month, January, has a value of 0.
   * Input:
     * dateTime - The datetime as a long representing the milliseconds since unix epoch
   * Returns: The current month (0-based).
+* `PROFILE_GET`
+  * Description: Retrieves a series of values from a stored profile.
+  * Input:
+    * profile - The name of the profile.
+    * entity - The name of the entity.
+    * durationAgo - How long ago should values be retrieved from?
+    * units - The units of 'durationAgo'.
+    * groups - Optional - The groups used to sort the profile.
+  * Returns: The profile measurements.
 * `PROTOCOL_TO_NAME`
-  * Description: Convert the IANA protocol number to the protocol name
+  * Description: Converts the IANA protocol number to the protocol name
   * Input:
     * IANA Number
   * Returns: The protocol name associated with the IANA number.
@@ -213,117 +227,117 @@ The following functions are supported:
   * Input:
     * string - The string to test
     * pattern - The proposed regex pattern
-  * Returns: True if the regex pattern matches the string and false otherwise.
+  * Returns: True if the regex pattern matches the string and false if otherwise.
 * `SPLIT`
   * Description: Splits the string by the delimiter.
   * Input:
     * input - String to split
     * delim - String delimiter
-  * Returns: List of Strings
+  * Returns: List of strings
 * `STARTS_WITH`
   * Description: Determines whether a string starts with a prefix
   * Input:
     * string - The string to test
     * prefix - The proposed prefix
-  * Returns: True if the string starts with the specified prefix and false otherwise.
+  * Returns: True if the string starts with the specified prefix and false if otherwise
 * `STATS_ADD`
-  * Description: Add one or more input values to those that are used to calculate the summary statistics.
+  * Description: Adds one or more input values to those that are used to calculate the summary statistics.
   * Input:
     * stats - The Stellar statistics object.  If null, then a new one is initialized.
-    * value+ - one or more numbers to add 
-  * Returns: A StatisticsProvider object
+    * value+ - One or more numbers to add
+  * Returns: A Stellar statistics object
 * `STATS_COUNT`
   * Description: Calculates the count of the values accumulated (or in the window if a window is used).
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
   * Returns: The count of the values in the window or NaN if the statistics object is null.
 * `STATS_GEOMETRIC_MEAN`
-  * Description: Calculates the geometric mean of the values accumulated (or in the window if a window is used). See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
+  * Description: Calculates the geometric mean of the accumulated values (or in the window if a window is used). See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
   * Returns: The geometric mean of the values in the window or NaN if the statistics object is null.
 * `STATS_INIT`
-  * Description: Initialize a Statistics object
+  * Description: Initializes a statistics object
   * Input:
-    * window_size - The number of input data values to maintain in a rolling window in memory.  If equal to 0, then no rolling window is maintained. Using no rolling window is less memory intensive, but cannot calculate certain statistics like percentiles and kurtosis.
-  * Returns: A StatisticsProvider object
+    * window_size - The number of input data values to maintain in a rolling window in memory.  If window_size is equal to 0, then no rolling window is maintained. Using no rolling window is less memory intensive, but cannot calculate certain statistics like percentiles and kurtosis.
+  * Returns: A Stellar statistics object
 * `STATS_KURTOSIS`
-  * Description: Calculates the kurtosis of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
+  * Description: Calculates the kurtosis of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
   * Returns: The kurtosis of the values in the window or NaN if the statistics object is null.
 * `STATS_MAX`
-  * Description: Calculates the max of the values accumulated (or in the window if a window is used).
+  * Description: Calculates the maximum of the accumulated values (or in the window if a window is used).
   * Input:
-    * stats - The Stellar statistics object.
-  * Returns: The max of the values in the window or NaN if the statistics object is null.
+    * stats - The Stellar statistics object
+  * Returns: The maximum of the accumulated values in the window or NaN if the statistics object is null.
 * `STATS_MEAN`
-  * Description: Calculates the mean of the values accumulated (or in the window if a window is used).
+  * Description: Calculates the mean of the accumulated values (or in the window if a window is used).
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
   * Returns: The mean of the values in the window or NaN if the statistics object is null.
 * `STATS_MERGE`
-  * Description: Merge statistic providers
+  * Description: Merges statistics objects.
   * Input:
-    * statisticsProviders - A list of statistics providers
-  * Returns: A StatisticsProvider object
+    * statistics - A list of statistics objects
+  * Returns: A Stellar statistics object
 * `STATS_MIN`
-  * Description: Calculates the min of the values accumulated (or in the window if a window is used).
+  * Description: Calculates the minimum of the accumulated values (or in the window if a window is used).
   * Input:
-    * stats - The Stellar statistics object.
-  * Returns: The min of the values in the window or NaN if the statistics object is null.
+    * stats - The Stellar statistics object
+  * Returns: The minimum of the accumulated values in the window or NaN if the statistics object is null.
 * `STATS_PERCENTILE`
-  * Description: Computes the p'th percentile of the values accumulated (or in the window if a window is used).
+  * Description: Computes the p'th percentile of the accumulated values (or in the window if a window is used).
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
     * p - a double where 0 <= p < 1 representing the percentile
   * Returns: The p'th percentile of the data or NaN if the statistics object is null
 * `STATS_POPULATION_VARIANCE`
-  * Description: Calculates the population variance of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
+  * Description: Calculates the population variance of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
   * Returns: The population variance of the values in the window or NaN if the statistics object is null.
 * `STATS_QUADRATIC_MEAN`
-  * Description: Calculates the quadratic mean of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
+  * Description: Calculates the quadratic mean of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
   * Returns: The quadratic mean of the values in the window or NaN if the statistics object is null.
 * `STATS_SD`
-  * Description: Calculates the standard deviation of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
+  * Description: Calculates the standard deviation of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
   * Returns: The standard deviation of the values in the window or NaN if the statistics object is null.
 * `STATS_SKEWNESS`
-  * Description: Calculates the skewness of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
+  * Description: Calculates the skewness of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
   * Returns: The skewness of the values in the window or NaN if the statistics object is null.
 * `STATS_SUM`
-  * Description: Calculates the sum of the values accumulated (or in the window if a window is used).
+  * Description: Calculates the sum of the accumulated values (or in the window if a window is used).
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
   * Returns: The sum of the values in the window or NaN if the statistics object is null.
 * `STATS_SUM_LOGS`
-  * Description: Calculates the sum of the (natural) log of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
+  * Description: Calculates the sum of the (natural) log of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
   * Returns: The sum of the (natural) log of the values in the window or NaN if the statistics object is null.
 * `STATS_SUM_SQUARES`
-  * Description: Calculates the sum of the squares of the values accumulated (or in the window if a window is used).
+  * Description: Calculates the sum of the squares of the accumulated values (or in the window if a window is used).
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
   * Returns: The sum of the squares of the values in the window or NaN if the statistics object is null.
 * `STATS_VARIANCE`
-  * Description: Calculates the variance of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
+  * Description: Calculates the variance of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics 
   * Input:
-    * stats - The Stellar statistics object.
+    * stats - The Stellar statistics object
   * Returns: The variance of the values in the window or NaN if the statistics object is null.
-  `SYSTEM_ENV_GET`
+* `SYSTEM_ENV_GET`
   * Description: Returns the value associated with an environment variable
   * Input:
     * env_var - Environment variable name to get the value for
   * Returns: String
-  `SYSTEM_PROPERTY_GET`
+* `SYSTEM_PROPERTY_GET`
   * Description: Returns the value associated with a Java system property
   * Input:
     * key - Property to get the value for
@@ -332,24 +346,24 @@ The following functions are supported:
   * Description: Transforms the first argument to a double precision number
   * Input:
     * input - Object of string or numeric type
-  * Returns: Double
+  * Returns: Double version of the first argument
 * `TO_EPOCH_TIMESTAMP`
-  * Description: Returns the epoch timestamp of the dateTime given the format. If the format does not have a timestamp and you wish to assume a given timestamp, you may specify the timezone optionally.
+  * Description: Returns the epoch timestamp of the dateTime in the specifiedthe format. If the format does not have a timestamp and you wish to assume a given timestamp, you may specify the timezone optionally.
   * Input:
     * dateTime - DateTime in String format
     * format - DateTime format as a String
     * timezone - Optional timezone in String format
-  * Returns: Boolean
+  * Returns: Epoch timestamp
 * `TO_INTEGER`
   * Description: Transforms the first argument to an integer
   * Input:
     * input - Object of string or numeric type
-  * Returns: Integer
+  * Returns: Integer version of the first argument
 * `TO_LOWER`
   * Description: Transforms the first argument to a lowercase string
   * Input:
     * input - String
-  * Returns: String
+  * Returns: Lowercase string
 * `TO_STRING`
   * Description: Transforms the first argument to a string
   * Input:
@@ -359,17 +373,12 @@ The following functions are supported:
   * Description: Transforms the first argument to an uppercase string
   * Input:
     * input - String
-  * Returns: String
+  * Returns: Uppercase string
 * `TRIM`
   * Description: Trims whitespace from both sides of a string.
   * Input:
     * input - String
   * Returns: String
-* `LENGTH`
-  * Description: Returns the length of a string or the size of a collection.
-  * Input:
-    * input - Object of string or collection type (e.g. list)"
-  * Returns: Integer
 * `URL_TO_HOST`
   * Description: Extract the hostname from a URL.
   * Input:
@@ -383,8 +392,8 @@ The following functions are supported:
 * `URL_TO_PORT`
   * Description: Extract the port from a URL.  If the port is not explicitly stated in the URL, then an implicit port is inferred based on the protocol.
   * Input:
-    * url - URL in String form
-  * Returns: The port used in the URL as an Integer.  e.g. URL_TO_PORT('http://www.yahoo.com/foo') would yield 80
+    * url - URL in string form
+  * Returns: The port used in the URL as an integer (for example, URL_TO_PORT('http://www.yahoo.com/foo') would yield 80)
 * `URL_TO_PROTOCOL`
   * Description: Extract the protocol from a URL.
   * Input:

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/ConversionFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/ConversionFunctions.java
@@ -40,7 +40,7 @@ public class ConversionFunctions {
   @Stellar(name="TO_INTEGER"
           , description="Transforms the first argument to an integer"
           , params = { "input - Object of string or numeric type"}
-          , returns = "Integer"
+          , returns = "Integer version of the first argument"
           )
   public static class TO_INTEGER extends Cast<Integer> {
 
@@ -52,7 +52,7 @@ public class ConversionFunctions {
   @Stellar(name="TO_DOUBLE"
           , description="Transforms the first argument to a double precision number"
           , params = { "input - Object of string or numeric type"}
-          , returns = "Double"
+          , returns = "Double version of the first argument"
           )
   public static class TO_DOUBLE extends Cast<Double> {
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DataStructureFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DataStructureFunctions.java
@@ -138,9 +138,9 @@ public class DataStructureFunctions {
   }
 
   @Stellar(name="IS_EMPTY"
-          , description="Returns true if string or collection is empty and false if otherwise."
+          , description="Returns true if string or collection is empty or null and false if otherwise."
           , params = { "input - Object of string or collection type (for example, list)"}
-          , returns = "True if the string or collection is empty and false otherwise."
+          , returns = "True if the string or collection is empty or null and false if otherwise."
           )
   public static class IsEmpty extends BaseStellarFunction {
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DataStructureFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DataStructureFunctions.java
@@ -138,9 +138,9 @@ public class DataStructureFunctions {
   }
 
   @Stellar(name="IS_EMPTY"
-          , description="Returns true if string or collection is empty and false otherwise"
-          , params = { "input - Object of string or collection type (e.g. list)"}
-          , returns = "Boolean"
+          , description="Returns true if string or collection is empty and false if otherwise."
+          , params = { "input - Object of string or collection type (for example, list)"}
+          , returns = "True if the string or collection is empty and false otherwise."
           )
   public static class IsEmpty extends BaseStellarFunction {
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DateFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DateFunctions.java
@@ -114,14 +114,14 @@ public class DateFunctions {
    * Stellar Function: TO_EPOCH_TIMESTAMP
    */
   @Stellar( name="TO_EPOCH_TIMESTAMP"
-          , description="Returns the epoch timestamp of the dateTime given the format. " +
+          , description="Returns the epoch timestamp of the dateTime in the specifiedthe format. " +
                         "If the format does not have a timestamp and you wish to assume a " +
                         "given timestamp, you may specify the timezone optionally."
           , params = { "dateTime - DateTime in String format"
                      , "format - DateTime format as a String"
                      , "timezone - Optional timezone in String format"
                      }
-          , returns = "Boolean")
+          , returns = "Epoch timestamp")
   public static class ToTimestamp extends BaseStellarFunction {
     @Override
     public Object apply(List<Object> objects) {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DateFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DateFunctions.java
@@ -114,7 +114,7 @@ public class DateFunctions {
    * Stellar Function: TO_EPOCH_TIMESTAMP
    */
   @Stellar( name="TO_EPOCH_TIMESTAMP"
-          , description="Returns the epoch timestamp of the dateTime in the specified the format. " +
+          , description="Returns the epoch timestamp of the dateTime in the specified format. " +
                         "If the format does not have a timestamp and you wish to assume a " +
                         "given timestamp, you may specify the timezone optionally."
           , params = { "dateTime - DateTime in String format"

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DateFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/DateFunctions.java
@@ -114,7 +114,7 @@ public class DateFunctions {
    * Stellar Function: TO_EPOCH_TIMESTAMP
    */
   @Stellar( name="TO_EPOCH_TIMESTAMP"
-          , description="Returns the epoch timestamp of the dateTime in the specifiedthe format. " +
+          , description="Returns the epoch timestamp of the dateTime in the specified the format. " +
                         "If the format does not have a timestamp and you wish to assume a " +
                         "given timestamp, you may specify the timezone optionally."
           , params = { "dateTime - DateTime in String format"

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/MaaSFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/MaaSFunctions.java
@@ -84,10 +84,10 @@ public class MaaSFunctions {
 
   @Stellar(name="MODEL_APPLY"
           , namespace="MAAS"
-          , description = "Returns the output of a model deployed via model which is deployed at endpoint. NOTE: Results are cached at the client for 10 minutes."
-          , params = { "endpoint - a map containing name, version, url for the REST endpoint"
-                     , "function - the optional endpoint path, default is 'apply'"
-                     , "model_args - dictionary of arguments for the model (these become request params)."
+          , description = "Returns the output of a model deployed via Model as a Service. NOTE: Results are cached locally for 10 minutes."
+          , params = { "endpoint - A map containing the name, version, and url for the REST endpoint"
+                     , "function - The optional endpoint path; default is 'apply'"
+                     , "model_args - A Dictionary of arguments for the model (these become request params)"
                      }
           , returns = "The output of the model deployed as a REST endpoint in Map form.  Assumes REST endpoint returns a JSON Map."
           )
@@ -236,12 +236,12 @@ public class MaaSFunctions {
 
   @Stellar(name="GET_ENDPOINT"
           , namespace="MAAS"
-          , description="Inspects zookeeper and returns a map containing the name, version and url for the model referred to by the input params"
+          , description="Inspects ZooKeeper and returns a map containing the name, version and url for the model referred to by the input parameters."
           , params = {
-                      "model_name - the name of the model"
-                     ,"model_version - the optional version of the model.  If it is not specified, the most current version is used."
+                      "model_name - The name of the model"
+                     ,"model_version - The optional version of the model.  If the model version is not specified, the most current version is used."
                      }
-          , returns = "A map containing the name, version, url for the REST endpoint (fields named name, version and url).  " +
+          , returns = "A map containing the name, version, and url for the REST endpoint (fields named name, version and url).  " +
                       "Note that the output of this function is suitable for input into the first argument of MAAS_MODEL_APPLY."
           )
   public static class GetEndpoint implements StellarFunction {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/MapFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/MapFunctions.java
@@ -34,7 +34,7 @@ public class MapFunctions {
                       "key - The key to check for existence"
                      ,"map - The map to check for existence of the key"
                      }
-          , returns = "True if the key is found in the map and false otherwise."
+          , returns = "True if the key is found in the map and false if otherwise."
           )
   public static class MapExists extends BaseStellarFunction {
 
@@ -60,8 +60,7 @@ public class MapFunctions {
                      ,"map - The map"
                      ,"default - Optionally the default value to return if the key is not in the map."
                      }
-          , returns = "The object associated with key in the map.  " +
-                      "If there is no value associated, then default if specified and null if a default is not specified."
+          , returns = "The object associated with the key in the map.  If no value is associated with the key and default is specified, then default is returned. If no value is associated with the key or default, then null is returned."
           )
   public static class MapGet extends BaseStellarFunction {
     @Override

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
@@ -33,12 +33,12 @@ import java.util.function.Function;
 
 public class NetworkFunctions {
   @Stellar(name="IN_SUBNET"
-          ,description = "Returns if an IP is within a subnet range."
+          ,description = "Returns true if an IP is within a subnet range."
           ,params = {
-                     "ip - the IP address in String form"
-                    ,"cidr+ - one or more IP ranges specified in CIDR notation (e.g. 192.168.0.0/24)"
+                     "ip - The IP address in string form"
+                    ,"cidr+ - One or more IP ranges specified in CIDR notation (for example 192.168.0.0/24)"
                     }
-          ,returns = "True if the IP address is within at least one of the network ranges and false otherwise"
+          ,returns = "True if the IP address is within at least one of the network ranges and false if otherwise"
           )
   public static class InSubnet extends BaseStellarFunction {
 
@@ -68,12 +68,12 @@ public class NetworkFunctions {
 
   @Stellar(name="REMOVE_SUBDOMAINS"
           ,namespace = "DOMAIN"
-          ,description = "Remove subdomains from a domain."
+          ,description = "Removes the subdomains from a domain."
           , params = {
-                      "domain - fully qualified domain name"
+                      "domain - Fully qualified domain name"
                      }
           , returns = "The domain without the subdomains.  " +
-                      "e.g. DOMAIN_REMOVE_SUBDOMAINS('mail.yahoo.com') yields 'yahoo.com'"
+                      "(for example, DOMAIN_REMOVE_SUBDOMAINS('mail.yahoo.com') yields 'yahoo.com')"
           )
   public static class RemoveSubdomains extends BaseStellarFunction {
 
@@ -102,12 +102,12 @@ public class NetworkFunctions {
 
   @Stellar(name="REMOVE_TLD"
           ,namespace = "DOMAIN"
-          ,description = "Remove top level domain suffix from a domain."
+          ,description = "Removes the top level domain (TLD) suffix from a domain."
           , params = {
-                      "domain - fully qualified domain name"
+                      "domain - Fully qualified domain name"
                      }
           , returns = "The domain without the TLD.  " +
-                      "e.g. DOMAIN_REMOVE_TLD('mail.yahoo.co.uk') yields 'mail.yahoo'"
+                      "(for example, DOMAIN_REMOVE_TLD('mail.yahoo.co.uk') yields 'mail.yahoo')"
           )
   public static class RemoveTLD extends BaseStellarFunction {
     @Override
@@ -132,12 +132,12 @@ public class NetworkFunctions {
 
   @Stellar(name="TO_TLD"
           ,namespace = "DOMAIN"
-          ,description = "Extract the top level domain from a domain"
+          ,description = "Extracts the top level domain from a domain"
           , params = {
-                      "domain - fully qualified domain name"
+                      "domain - Fully qualified domain name"
                      }
           , returns = "The TLD of the domain.  " +
-                      "e.g. DOMAIN_TO_TLD('mail.yahoo.co.uk') yields 'co.uk'"
+                      "(for example, DOMAIN_TO_TLD('mail.yahoo.co.uk') yields 'co.uk')"
           )
   public static class ExtractTLD extends BaseStellarFunction {
     @Override
@@ -156,9 +156,9 @@ public class NetworkFunctions {
           ,description = "Extract the port from a URL.  " +
                           "If the port is not explicitly stated in the URL, then an implicit port is inferred based on the protocol."
           , params = {
-                      "url - URL in String form"
+                      "url - URL in string form"
                      }
-          , returns = "The port used in the URL as an Integer.  e.g. URL_TO_PORT('http://www.yahoo.com/foo') would yield 80"
+          , returns = "The port used in the URL as an integer (for example, URL_TO_PORT('http://www.yahoo.com/foo') would yield 80)"
           )
   public static class URLToPort extends BaseStellarFunction {
     @Override

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/StellarStatisticsFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/StellarStatisticsFunctions.java
@@ -55,11 +55,11 @@ public class StellarStatisticsFunctions {
 
   @Stellar( namespace="STATS"
           , name="MERGE"
-          , description = "Merge statistic providers"
+          , description = "Merges statistics objects."
           , params = {
-                      "statisticsProviders - A list of statistics providers"
+                      "statistics - A list of statistics objects"
                       }
-          , returns = "A StatisticsProvider object"
+          , returns = "A Stellar statistics object"
           )
   public static class Merge extends BaseStellarFunction {
     @Override
@@ -100,14 +100,14 @@ public class StellarStatisticsFunctions {
    */
   @Stellar( namespace="STATS"
           , name="INIT"
-          , description = "Initialize a Statistics object"
+          , description = "Initializes a statistics object"
           , params = {
                       "window_size - The number of input data values to maintain in a rolling window " +
-                      "in memory.  If equal to 0, then no rolling window is maintained. " +
+                      "in memory.  If window_size is equal to 0, then no rolling window is maintained. " +
                       "Using no rolling window is less memory intensive, but cannot " +
                       "calculate certain statistics like percentiles and kurtosis."
                       }
-          , returns = "A StatisticsProvider object"
+          , returns = "A Stellar statistics object"
           )
   public static class Init extends BaseStellarFunction {
     @Override
@@ -123,12 +123,12 @@ public class StellarStatisticsFunctions {
    */
   @Stellar(namespace="STATS"
           , name="ADD"
-          , description = "Add one or more input values to those that are used to calculate the summary statistics."
+          , description = "Adds one or more input values to those that are used to calculate the summary statistics."
           , params = {
                       "stats - The Stellar statistics object.  If null, then a new one is initialized."
-                     , "value+ - one or more numbers to add "
+                     , "value+ - One or more numbers to add"
                      }
-          , returns = "A StatisticsProvider object"
+          , returns = "A Stellar statistics object"
           )
   public static class Add extends BaseStellarFunction {
     @Override
@@ -157,9 +157,9 @@ public class StellarStatisticsFunctions {
    */
   @Stellar( namespace="STATS"
           , name="MEAN"
-          , description = "Calculates the mean of the values accumulated (or in the window if a window is used)."
+          , description = "Calculates the mean of the accumulated values (or in the window if a window is used)."
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
           , returns = "The mean of the values in the window or NaN if the statistics object is null."
           )
@@ -176,9 +176,9 @@ public class StellarStatisticsFunctions {
    */
   @Stellar( namespace="STATS"
           , name="GEOMETRIC_MEAN"
-          , description = "Calculates the geometric mean of the values accumulated (or in the window if a window is used). See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
+          , description = "Calculates the geometric mean of the accumulated values (or in the window if a window is used). See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
           , returns = "The geometric mean of the values in the window or NaN if the statistics object is null."
           )
@@ -195,9 +195,9 @@ public class StellarStatisticsFunctions {
    */
   @Stellar(namespace="STATS"
           , name="SUM"
-          , description = "Calculates the sum of the values accumulated (or in the window if a window is used)."
+          , description = "Calculates the sum of the accumulated values (or in the window if a window is used)."
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
           , returns = "The sum of the values in the window or NaN if the statistics object is null."
           )
@@ -213,11 +213,11 @@ public class StellarStatisticsFunctions {
    * Calculates the max.
    */
   @Stellar(namespace="STATS", name="MAX"
-          , description = "Calculates the max of the values accumulated (or in the window if a window is used)."
+          , description = "Calculates the maximum of the accumulated values (or in the window if a window is used)."
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
-          , returns = "The max of the values in the window or NaN if the statistics object is null."
+          , returns = "The maximum of the accumulated values in the window or NaN if the statistics object is null."
           )
   public static class Max extends BaseStellarFunction {
     @Override
@@ -231,11 +231,11 @@ public class StellarStatisticsFunctions {
    * Calculates the min.
    */
   @Stellar(namespace="STATS", name="MIN"
-          , description = "Calculates the min of the values accumulated (or in the window if a window is used)."
+          , description = "Calculates the minimum of the accumulated values (or in the window if a window is used)."
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
-          , returns = "The min of the values in the window or NaN if the statistics object is null."
+          , returns = "The minimum of the accumulated values in the window or NaN if the statistics object is null."
           )
   public static class Min extends BaseStellarFunction {
     @Override
@@ -251,7 +251,7 @@ public class StellarStatisticsFunctions {
   @Stellar(namespace="STATS", name="COUNT"
           , description = "Calculates the count of the values accumulated (or in the window if a window is used)."
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
           , returns = "The count of the values in the window or NaN if the statistics object is null.")
   public static class Count extends BaseStellarFunction {
@@ -266,9 +266,9 @@ public class StellarStatisticsFunctions {
    * Calculates the population variance.
    */
   @Stellar(namespace="STATS", name="POPULATION_VARIANCE"
-          , description = "Calculates the population variance of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
+          , description = "Calculates the population variance of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
           , returns = "The population variance of the values in the window or NaN if the statistics object is null.")
   public static class PopulationVariance extends BaseStellarFunction {
@@ -283,9 +283,9 @@ public class StellarStatisticsFunctions {
    * Calculates the variance.
    */
   @Stellar(namespace="STATS", name="VARIANCE"
-          , description = "Calculates the variance of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
+          , description = "Calculates the variance of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
           , returns = "The variance of the values in the window or NaN if the statistics object is null.")
   public static class Variance extends BaseStellarFunction {
@@ -300,9 +300,9 @@ public class StellarStatisticsFunctions {
    * Calculates the quadratic mean.
    */
   @Stellar(namespace="STATS", name="QUADRATIC_MEAN"
-          , description = "Calculates the quadratic mean of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
+          , description = "Calculates the quadratic mean of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
           , returns = "The quadratic mean of the values in the window or NaN if the statistics object is null.")
   public static class QuadraticMean extends BaseStellarFunction {
@@ -317,9 +317,9 @@ public class StellarStatisticsFunctions {
    * Calculates the standard deviation.
    */
   @Stellar(namespace="STATS", name="SD"
-          , description = "Calculates the standard deviation of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
+          , description = "Calculates the standard deviation of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
           , returns = "The standard deviation of the values in the window or NaN if the statistics object is null.")
   public static class StandardDeviation extends BaseStellarFunction {
@@ -334,9 +334,9 @@ public class StellarStatisticsFunctions {
    * Calculates the sum of logs.
    */
   @Stellar(namespace="STATS", name="SUM_LOGS"
-          , description = "Calculates the sum of the (natural) log of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
+          , description = "Calculates the sum of the (natural) log of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
           , returns = "The sum of the (natural) log of the values in the window or NaN if the statistics object is null.")
   public static class SumLogs extends BaseStellarFunction {
@@ -351,9 +351,9 @@ public class StellarStatisticsFunctions {
    * Calculates the sum of squares.
    */
   @Stellar(namespace="STATS", name="SUM_SQUARES"
-          , description = "Calculates the sum of the squares of the values accumulated (or in the window if a window is used)."
+          , description = "Calculates the sum of the squares of the accumulated values (or in the window if a window is used)."
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
           , returns = "The sum of the squares of the values in the window or NaN if the statistics object is null.")
   public static class SumSquares extends BaseStellarFunction {
@@ -368,9 +368,9 @@ public class StellarStatisticsFunctions {
    * Calculates the kurtosis.
    */
   @Stellar(namespace="STATS", name="KURTOSIS"
-          , description = "Calculates the kurtosis of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
+          , description = "Calculates the kurtosis of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
           , returns = "The kurtosis of the values in the window or NaN if the statistics object is null.")
   public static class Kurtosis extends BaseStellarFunction {
@@ -385,9 +385,9 @@ public class StellarStatisticsFunctions {
    * Calculates the skewness.
    */
   @Stellar(namespace="STATS", name="SKEWNESS"
-          , description = "Calculates the skewness of the values accumulated (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
+          , description = "Calculates the skewness of the accumulated values (or in the window if a window is used).  See http://commons.apache.org/proper/commons-math/userguide/stat.html#a1.2_Descriptive_statistics "
           , params = {
-            "stats - The Stellar statistics object."
+            "stats - The Stellar statistics object"
                      }
           , returns = "The skewness of the values in the window or NaN if the statistics object is null.")
   public static class Skewness extends BaseStellarFunction {
@@ -404,9 +404,9 @@ public class StellarStatisticsFunctions {
    * STATS_PERCENTILE(stats, 0.90)
    */
   @Stellar(namespace="STATS", name="PERCENTILE"
-          , description = "Computes the p'th percentile of the values accumulated (or in the window if a window is used)."
+          , description = "Computes the p'th percentile of the accumulated values (or in the window if a window is used)."
           , params = {
-          "stats - The Stellar statistics object."
+          "stats - The Stellar statistics object"
           ,"p - a double where 0 <= p < 1 representing the percentile"
 
                      }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/StringFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/StringFunctions.java
@@ -36,7 +36,7 @@ public class StringFunctions {
              "string - The string to test"
             ,"pattern - The proposed regex pattern"
             }
-          , returns = "True if the regex pattern matches the string and false otherwise.")
+          , returns = "True if the regex pattern matches the string and false if otherwise.")
   public static class RegexpMatch extends BaseStellarFunction {
 
     @Override
@@ -54,12 +54,12 @@ public class StringFunctions {
   }
 
   @Stellar(name="ENDS_WITH"
-          ,description = "Determines whether a string ends with a prefix"
+          ,description = "Determines whether a string ends with a specified suffix"
           , params = {
              "string - The string to test"
             ,"suffix - The proposed suffix"
             }
-          , returns = "True if the string ends with the specified suffix and false otherwise.")
+          , returns = "True if the string ends with the specified suffix and false if otherwise")
   public static class EndsWith extends BaseStellarFunction {
     @Override
     public Object apply(List<Object> list) {
@@ -81,7 +81,7 @@ public class StringFunctions {
              "string - The string to test"
             ,"prefix - The proposed prefix"
             }
-          , returns = "True if the string starts with the specified prefix and false otherwise."
+          , returns = "True if the string starts with the specified prefix and false if otherwise"
           )
   public static class StartsWith extends BaseStellarFunction {
 
@@ -102,7 +102,7 @@ public class StringFunctions {
   @Stellar( name="TO_LOWER"
           , description = "Transforms the first argument to a lowercase string"
           , params = { "input - String" }
-          , returns = "String"
+          , returns = "Lowercase string"
           )
   public static class ToLower extends BaseStellarFunction {
     @Override
@@ -114,7 +114,7 @@ public class StringFunctions {
   @Stellar( name="TO_UPPER"
           , description = "Transforms the first argument to an uppercase string"
           , params = { "input - String" }
-          , returns = "String"
+          , returns = "Uppercase string"
           )
   public static class ToUpper extends BaseStellarFunction {
     @Override
@@ -148,8 +148,8 @@ public class StringFunctions {
   }
 
   @Stellar( name="JOIN"
-          , description="Joins the components of the list with the specified delimiter."
-          , params = { "list - List of Strings", "delim - String delimiter"}
+          , description="Joins the components in the list of strings with the specified delimiter."
+          , params = { "list - List of strings", "delim - String delimiter"}
           , returns = "String"
           )
   public static class JoinFunction extends BaseStellarFunction {
@@ -164,7 +164,7 @@ public class StringFunctions {
   @Stellar(name="SPLIT"
           , description="Splits the string by the delimiter."
           , params = { "input - String to split", "delim - String delimiter"}
-          , returns = "List of Strings"
+          , returns = "List of strings"
           )
   public static class SplitFunction extends BaseStellarFunction {
     @Override
@@ -208,7 +208,7 @@ public class StringFunctions {
 
   @Stellar(name="GET"
           , description="Returns the i'th element of the list "
-          , params = { "input - List", "i - the index (0-based)"}
+          , params = { "input - List", "i - The index (0-based)"}
           , returns = "First element of the list"
           )
   public static class Get extends BaseStellarFunction {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/transformation/IPProtocolTransformation.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/transformation/IPProtocolTransformation.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 @Stellar(name="PROTOCOL_TO_NAME"
-        , description="Convert the IANA protocol number to the protocol name"
+        , description="Converts the IANA protocol number to the protocol name"
         , params = {
                     "IANA Number"
                    }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/validation/network/DomainValidation.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/validation/network/DomainValidation.java
@@ -30,12 +30,12 @@ import java.util.function.Predicate;
 public class DomainValidation extends SimpleValidation {
 
   @Stellar(name="IS_DOMAIN"
-          ,description = "Tests if a string is a valid domain.  Domain names are evaluated according" +
+          ,description = "Tests if a string refers to a valid domain name.  Domain names are evaluated according" +
           " to the standards RFC1034 section 3, and RFC1123 section 2.1."
           ,params = {
-              "address - The String to test"
+              "address - The string to test"
                     }
-          , returns = "True if the string is a valid domain and false otherwise.")
+          , returns = "True if the string refers to a valid domain name and false if otherwise")
   public static class IS_DOMAIN extends Predicate2StellarFunction {
 
     public IS_DOMAIN() {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/validation/network/EmailValidation.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/validation/network/EmailValidation.java
@@ -31,9 +31,9 @@ public class EmailValidation extends SimpleValidation {
   @Stellar(name="IS_EMAIL"
           ,description = "Tests if a string is a valid email address"
           ,params = {
-              "address - The String to test"
+              "address - The string to test"
                     }
-          , returns = "True if the string is a valid email address and false otherwise.")
+          , returns = "True if the string is a valid email address and false if otherwise.")
   public static class IS_EMAIL extends Predicate2StellarFunction {
 
     public IS_EMAIL() {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/validation/network/URLValidation.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/validation/network/URLValidation.java
@@ -30,9 +30,9 @@ public class URLValidation extends SimpleValidation {
   @Stellar(name="IS_URL"
           ,description = "Tests if a string is a valid URL"
           ,params = {
-              "url - The String to test"
+              "url - The string to test"
                     }
-          , returns = "True if the string is a valid URL and false otherwise."
+          , returns = "True if the string is a valid URL and false if otherwise."
           )
   public static class IS_URL extends Predicate2StellarFunction {
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/validation/primitive/DateValidation.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/validation/primitive/DateValidation.java
@@ -33,12 +33,12 @@ import java.util.function.Predicate;
 public class DateValidation implements FieldValidation, Predicate<List<Object>> {
 
   @Stellar(name="IS_DATE"
-          ,description = "Determines if a string passed is a date of a given format."
+          ,description = "Determines if the date contained in the string conforms to the specified format."
           ,params = {
-            "date - The date in string form."
-          , "format - The format of the date."
+            "date - The date in string form"
+          , "format - The format of the date"
                     }
-          ,returns = "True if the date is of the specified format and false otherwise."
+          ,returns = "True if the date is in the specified format and false if otherwise."
           )
   public static class IS_DATE extends Predicate2StellarFunction {
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/validation/primitive/IntegerValidation.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/validation/primitive/IntegerValidation.java
@@ -28,11 +28,11 @@ import java.util.function.Predicate;
 
 public class IntegerValidation extends SimpleValidation{
   @Stellar(name="IS_INTEGER"
-          , description = "Determine if an object is an integer or not."
+          , description = "Determines whether or not an object is an integer."
           , params = {
-              "x - An object which we wish to test is an integer"
+              "x - The object to test"
                      }
-          , returns = "True if the object can be converted to an integer and false otherwise."
+          , returns = "True if the object can be converted to an integer and false if otherwise."
           )
   public static class IS_INTEGER extends Predicate2StellarFunction {
 


### PR DESCRIPTION
There are some unclear, inconsistent and ungrammatical text in the Stellar function descriptions. This should be corrected.
