### PR TITLE
METRON-440 - handle empty strings in DOMAIN_REMOVE_SUBDOMAINS

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
@@ -21,6 +21,7 @@ package org.apache.metron.common.dsl.functions;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
+import org.apache.commons.lang3.StringUtils;
 import com.google.common.net.InternetDomainName;
 import org.apache.commons.net.util.SubnetUtils;
 import org.apache.metron.common.dsl.BaseStellarFunction;
@@ -223,7 +224,9 @@ public class NetworkFunctions {
   private static InternetDomainName toDomainName(Object dnObj) {
     if(dnObj != null) {
       String dn = dnObj.toString();
-      return InternetDomainName.from(dn);
+      if(!StringUtils.isEmpty(dn)) {
+        return InternetDomainName.from(dn);
+      }
     }
     return null;
   }

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/network/RemoveSubdomainsTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/network/RemoveSubdomainsTest.java
@@ -39,4 +39,10 @@ public class RemoveSubdomainsTest {
     Assert.assertEquals("example.com", removeSubdomains.apply(ImmutableList.of("my.example.com")));
     Assert.assertEquals("example.co.uk", removeSubdomains.apply(ImmutableList.of("my.example.co.uk")));
   }
+
+  @Test
+  public void testEmptyString() {
+    NetworkFunctions.RemoveSubdomains removeSubdomains = new NetworkFunctions.RemoveSubdomains();
+    Assert.assertEquals(null, removeSubdomains.apply(ImmutableList.of("")));
+  }
 }


### PR DESCRIPTION
DOMAIN_REMOVE_SUBDOMAINS would throw an exception if passed an empty string.  Changed to handle same as being passed null ( return null )
