### PR TITLE
METRON-148 compress logs with logrotate

### DIFF
--- a/metron-deployment/roles/ambari_common/templates/metron-hadoop-logrotate.yml
+++ b/metron-deployment/roles/ambari_common/templates/metron-hadoop-logrotate.yml
@@ -22,6 +22,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 /var/log/hadoop/hdfs/*.out {
@@ -30,6 +31,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 /var/log/hadoop/hdfs/*.audit {
@@ -38,6 +40,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 #Hadoop Yarn Logs
@@ -47,6 +50,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 #Hadoop Mapreduce Logs
@@ -56,6 +60,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 #Storm Logs
@@ -65,6 +70,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 /var/log/storm/*.out {
@@ -73,6 +79,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 #Kafka Logs
@@ -82,6 +89,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 /var/log/kafka/*.err {
@@ -90,6 +98,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 #HBase Logs
@@ -99,6 +108,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 /var/log/hbase/*.out {
@@ -107,6 +117,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 /var/log/hbase/*.audit {
@@ -115,6 +126,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 #Zookeeper Logs
@@ -124,6 +136,7 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 
 /var/log/zookeeper/*.out {
@@ -132,4 +145,5 @@
   missingok
   notifempty
   copytruncate
+  compress
 }

--- a/metron-deployment/roles/elasticsearch/templates/metron-elasticsearch-logrotate.yml
+++ b/metron-deployment/roles/elasticsearch/templates/metron-elasticsearch-logrotate.yml
@@ -22,5 +22,6 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 

--- a/metron-deployment/roles/metron_pcapservice/templates/metron-pcapservice-logrotate.yml
+++ b/metron-deployment/roles/metron_pcapservice/templates/metron-pcapservice-logrotate.yml
@@ -22,5 +22,6 @@
   missingok
   notifempty
   copytruncate
+  compress
 }
 


### PR DESCRIPTION
Add compress configuration for logrotate.d/ configurations

Tested using the logrotate -f /etc/logrotate.d/metron-\* commands
