### PR TITLE
METRON-249: Field Transformation functions fail to handle invalid user inputs

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
@@ -224,7 +224,12 @@ public class NetworkFunctions {
     if(dnObj != null) {
       if(dnObj instanceof String) {
         String dn = dnObj.toString();
-        return InternetDomainName.from(dn);
+        try {
+          return InternetDomainName.from(dn);
+        }
+        catch(IllegalArgumentException iae) {
+          return null;
+        }
       }
       else {
         throw new IllegalArgumentException(dnObj + " is not a string and therefore also not a domain.");

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/NetworkFunctions.java
@@ -222,8 +222,13 @@ public class NetworkFunctions {
 
   private static InternetDomainName toDomainName(Object dnObj) {
     if(dnObj != null) {
-      String dn = dnObj.toString();
-      return InternetDomainName.from(dn);
+      if(dnObj instanceof String) {
+        String dn = dnObj.toString();
+        return InternetDomainName.from(dn);
+      }
+      else {
+        throw new IllegalArgumentException(dnObj + " is not a string and therefore also not a domain.");
+      }
     }
     return null;
   }
@@ -232,10 +237,15 @@ public class NetworkFunctions {
     if(urlObj == null) {
       return null;
     }
-    try {
-      return new URL(urlObj.toString());
-    } catch (MalformedURLException e) {
-      return null;
+    if(urlObj instanceof String) {
+      try {
+        return new URL(urlObj.toString());
+      } catch (MalformedURLException e) {
+        return null;
+      }
+    }
+    else {
+      throw new IllegalArgumentException(urlObj + " is not a string and therefore also not a URL.");
     }
   }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/transformation/StellarTransformation.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/transformation/StellarTransformation.java
@@ -38,14 +38,22 @@ public class StellarTransformation implements FieldTransformation {
                                 )
   {
     Map<String, Object> ret = new HashMap<>();
-    VariableResolver resolver = new MapVariableResolver(ret, input,fieldMappingConfig, sensorConfig);
+    VariableResolver resolver = new MapVariableResolver(ret, input, sensorConfig);
     StellarProcessor processor = new StellarProcessor();
     for(String oField : outputField) {
       Object transformObj = fieldMappingConfig.get(oField);
       if(transformObj != null) {
-        Object o = processor.parse(transformObj.toString(), resolver, StellarFunctions.FUNCTION_RESOLVER(), context);
-        if (o != null) {
-          ret.put(oField, o);
+        try {
+          Object o = processor.parse(transformObj.toString(), resolver, StellarFunctions.FUNCTION_RESOLVER(), context);
+          if (o != null) {
+            ret.put(oField, o);
+          }
+        }
+        catch(Exception ex) {
+          throw new IllegalStateException( "Unable to process transformation: " + transformObj.toString()
+                                         + " for " + oField + " because " + ex.getMessage()
+                                         , ex
+                                         );
         }
       }
     }

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/transformation/StellarTransformationTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/transformation/StellarTransformationTest.java
@@ -34,6 +34,40 @@ public class StellarTransformationTest {
   /**
    {
     "fieldTransformations" : [
+     {
+       "transformation" : "STELLAR"
+      ,"output" : [ "full_hostname", "domain_without_subdomains" ]
+      ,"config" : {
+         "full_hostname" : "URL_TO_HOST(123)"
+        ,"domain_without_subdomains" : "DOMAIN_REMOVE_SUBDOMAINS(full_hostname)"
+                  }
+     }
+                      ]
+   }
+   */
+  @Multiline
+  public static String badConfig;
+
+  @Test(expected=IllegalStateException.class)
+  public void testStellarBadConfig() throws Exception {
+
+    SensorParserConfig c = SensorParserConfig.fromBytes(Bytes.toBytes(badConfig));
+    FieldTransformer handler = Iterables.getFirst(c.getFieldTransformations(), null);
+    JSONObject input = new JSONObject();
+    try {
+      handler.transformAndUpdate(input, new HashMap<>(), Context.EMPTY_CONTEXT());
+    }
+    catch(IllegalStateException ex) {
+      Assert.assertTrue(ex.getMessage().contains("URL_TO_HOST"));
+      Assert.assertTrue(ex.getMessage().contains("123"));
+      throw ex;
+    }
+
+  }
+
+  /**
+   {
+    "fieldTransformations" : [
           {
            "transformation" : "STELLAR"
           ,"output" : "utc_timestamp"
@@ -63,6 +97,7 @@ public class StellarTransformationTest {
    */
   @Multiline
   public static String stellarConfigEspecial;
+
 
   @Test
   public void testStellarSpecialCharacters() throws Exception {

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/transformation/StellarTransformationTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/transformation/StellarTransformationTest.java
@@ -48,6 +48,38 @@ public class StellarTransformationTest {
   @Multiline
   public static String badConfig;
 
+
+  /** { "fieldTransformations" : [
+        { "transformation" : "STELLAR"
+        ,"output" : [ "full_hostname", "domain_without_subdomains" ]
+        ,"config" : {
+          "full_hostname" : "URL_TO_HOST('http://1234567890123456789012345678901234567890123456789012345678901234567890/index.html')"
+          ,"domain_without_subdomains" : "DOMAIN_REMOVE_SUBDOMAINS(full_hostname)"
+                    }
+        }
+                                ]
+      }
+   */
+  @Multiline
+  public static String configNumericDomain;
+
+  @Test
+  public void testStellarNumericDomain() throws Exception {
+    /*
+    Despite the domain being weird, URL_TO_HOST should allow it to pass through.
+    However, because it does NOT form a proper domain (no TLD), DOMAIN_REMOVE_SUBDOMAINS returns
+    null indicating that the input is semantically incorrect.
+     */
+    SensorParserConfig c = SensorParserConfig.fromBytes(Bytes.toBytes(configNumericDomain));
+    FieldTransformer handler = Iterables.getFirst(c.getFieldTransformations(), null);
+    JSONObject input = new JSONObject();
+    handler.transformAndUpdate(input, new HashMap<>(), Context.EMPTY_CONTEXT());
+    Assert.assertTrue(input.containsKey("full_hostname"));
+    Assert.assertEquals("1234567890123456789012345678901234567890123456789012345678901234567890", input.get("full_hostname"));
+    Assert.assertFalse(input.containsKey("domain_without_subdomains"));
+
+  }
+
   @Test(expected=IllegalStateException.class)
   public void testStellarBadConfig() throws Exception {
 


### PR DESCRIPTION
The field transformation functions fail to handle invalid user input in a way that is apparent to the user what went on.  As discussed in the dev-list discussion, a better error message with the actual stellar statement at fault should be displayed rather than an opaque, general purpose antlr exception.