### PR TITLE
METRON-463: Pull RPMs from Remote (configurable) repos

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/configuration/metron-env.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/configuration/metron-env.xml
@@ -126,10 +126,32 @@
         <name>storm_rest_addr</name>
         <display-name>Storm Rest Server Address</display-name>
         <description>URL of Storm UI (storm.ui.hostname:8744)</description>
-        <!--<value-attributes>-->
-            <!--<editable-only-at-install>true</editable-only-at-install>-->
-            <!--<overridable>false</overridable>-->
-        <!--</value-attributes>-->
+        <value></value>
+    </property>
+    <property>
+        <name>repo_type</name>
+        <display-name>Repository Type</display-name>
+        <description>Type of Repository: Local or Remote</description>
+        <value>local</value>
+        <value-attributes>
+            <overridable>false</overridable>
+            <type>value-list</type>
+            <entries>
+                <entry>
+                    <value>local</value>
+                    <label>Local</label>
+                </entry>
+                <entry>
+                    <value>remote</value>
+                    <label>Remote</label>
+                </entry>
+            </entries>
+            <selection-cardinality>1</selection-cardinality>
+        </value-attributes>
+    </property>
+    <property>
+        <name>repo_url</name>
+        <display-name>Repository URL</display-name>
         <value></value>
     </property>
     <property>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/enrichment_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/enrichment_commands.py
@@ -49,27 +49,33 @@ class EnrichmentCommands:
              mode=0775)
 
     def setup_repo(self):
+
         def local_repo():
             Logger.info("Setting up local repo")
             Execute("yum -y install createrepo")
             Execute("createrepo /localrepo")
             Execute("chmod -R o-w+r /localrepo")
-            Execute("echo \"[METRON-0.2.1BETA]\n"
-                    "name=Metron 0.2.1BETA packages\n"
-                    "baseurl=file:///localrepo\n"
-                    "gpgcheck=0\n"
-                    "enabled=1\" > /etc/yum.repos.d/local.repo")
 
         def remote_repo():
-            print('Using remote repo')
+            Logger.info('Using remote repo')
 
         yum_repo_types = {
             'local': local_repo,
             'remote': remote_repo
         }
+
         repo_type = self.__params.yum_repo_type
+
         if repo_type in yum_repo_types:
             yum_repo_types[repo_type]()
+            Logger.info("Writing out repo file")
+            repo_template = ("echo \"[METRON-0.2.1BETA]\n"
+                            "name=Metron 0.2.1BETA packages\n"
+                            "baseurl={0}\n"
+                            "gpgcheck=0\n"
+                            "enabled=1\n\""
+                         "   > /etc/yum.repos.d/metron.repo")
+            Execute(repo_template.format(self.__params.repo_url))
         else:
             raise ValueError("Unsupported repo type '{0}'".format(repo_type))
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/params/params_linux.py
@@ -57,7 +57,13 @@ global_json_template = config['configurations']['metron-env']['global-json']
 global_properties_template = config['configurations']['metron-env']['elasticsearch-properties']
 es_cluster_name = config['configurations']['metron-env']['es_cluster_name']
 es_url = config['configurations']['metron-env']['es_url']
-yum_repo_type = 'local'
+
+#install repo
+yum_repo_type = config['configurations']['metron-env']['repo_type']
+if yum_repo_type == 'local':
+    repo_url = 'file:///localrepo'
+else:
+    repo_url = config['configurations']['metron-env']['repo_url']
 
 # hadoop params
 stack_root = Script.get_stack_root()

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/service_advisor.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/service_advisor.py
@@ -36,6 +36,19 @@ except Exception as e:
 
 class METRON021BETAServiceAdvisor(service_advisor.ServiceAdvisor):
 
+    def getServiceConfigurationRecommendations(self, configurations, clusterData, services, hosts):
+
+        #Suggest Storm Rest URL
+        stormUIServerHost = self.getComponentHostNames(services, "STORM", "STORM_UI_SERVER")[0]
+        stormUIServerPort = services["configurations"]["storm-site"]["properties"]["ui.port"]
+        stormUIServerURL = stormUIServerHost + ":" + stormUIServerPort
+        putMetronEnvProperty = self.putProperty(configurations, "metron-env", services)
+        putMetronEnvProperty("storm_rest_addr",stormUIServerURL)
+
+        #Suggest mysql server hostname
+        mySQLServerHost = self.getComponentHostNames(services, "METRON", "METRON_ENRICHMENT_MYSQL_SERVER")[0]
+        putMetronEnvProperty = self.putProperty(configurations, "metron-env", services)
+        putMetronEnvProperty("mysql_host",mySQLServerHost)
     def getServiceComponentLayoutValidations(self, services, hosts):
 
         componentsListList = [service["components"] for service in services["services"]]

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/themes/metron_theme.json
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/themes/metron_theme.json
@@ -40,6 +40,34 @@
                 }
               ]
             }
+          },
+          {
+            "name": "metron_repo",
+            "display-name" : "Repository",
+            "layout": {
+              "tab-columns" : "1",
+              "tab-rows" : "1",
+              "sections" : [
+                {
+                  "name" : "section-repo",
+                  "row-index": "0",
+                  "column-index" : "0",
+                  "row-span": "1",
+                  "column-span": "1",
+                  "section-columns": "1",
+                  "section-rows": "1",
+                  "subsections": [
+                    {
+                    "name": "subsection-repo",
+                    "row-index": "0",
+                    "column-index": "0",
+                    "row-span": "1",
+                    "column-span": "1"
+                    }
+                  ]
+                }
+              ]
+            }
           }
         ]
       }
@@ -88,6 +116,32 @@
         {
           "config": "metron-env/es_cluster_name",
           "subsection-name": "subsection-general-indexing"
+        },
+        {
+          "config": "metron-env/repo_type",
+          "subsection-name": "subsection-repo"
+        },
+        {
+          "config": "metron-env/repo_url",
+          "subsection-name": "subsection-repo",
+          "depends-on": [
+            {
+              "configs":[
+                "metron-env/repo_type"
+              ],
+              "if": "${metron-env/repo_type} === remote",
+              "then": {
+                "property_value_attributes": {
+                  "visible": true
+                }
+              },
+              "else": {
+                "property_value_attributes": {
+                  "visible": false
+                }
+              }
+            }
+          ]
         }
       ]
     },
@@ -124,6 +178,18 @@
       },
       {
         "config": "metron-env/es_cluster_name",
+        "widget": {
+          "type": "text-field"
+        }
+      },
+      {
+        "config": "metron-env/repo_type",
+        "widget": {
+          "type": "toggle"
+        }
+      },
+      {
+        "config": "metron-env/repo_url",
         "widget": {
           "type": "text-field"
         }


### PR DESCRIPTION
Tested on Docker cluster following procedure here: [Metron MPack](https://www.evernote.com/l/AhLFVR-9CsFIYYnOnF43BlxSsT4F856qwaY)

Test case 1: Default install (local repo file:///localrepo)
Test case 2: Different repo URL (file:///testrepo)

Ambari will use createrepo to create the repo in local mode (prior behavior), does not run createrepo in remote mode. 