### PR TITLE
METRON-520: /apps/metron/enrichment directory does not get created for Metron cluster deployed via Ambari

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/configuration/metron-env.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/configuration/metron-env.xml
@@ -164,7 +164,7 @@ bolt.hdfs.file.system.url={{ default_fs }}
 bolt.hdfs.wip.file.path=/paloalto/wip
 bolt.hdfs.finished.file.path=/paloalto/rotated
 bolt.hdfs.compression.codec.class=org.apache.hadoop.io.compress.SnappyCodec
-index.hdfs.output=/apps/metron/enrichment
+index.hdfs.output={{ metron_apps_enrichment_dir }}
         </value>
         <value-attributes>
             <type>content</type>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/configuration/metron-env.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/configuration/metron-env.xml
@@ -164,7 +164,7 @@ bolt.hdfs.file.system.url={{ default_fs }}
 bolt.hdfs.wip.file.path=/paloalto/wip
 bolt.hdfs.finished.file.path=/paloalto/rotated
 bolt.hdfs.compression.codec.class=org.apache.hadoop.io.compress.SnappyCodec
-index.hdfs.output=/tmp/metron/enriched
+index.hdfs.output=/apps/metron/enrichment
         </value>
         <value-attributes>
             <type>content</type>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/metainfo.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/metainfo.xml
@@ -212,6 +212,9 @@
             <package>
               <name>metron-elasticsearch</name>
             </package>
+            <package>
+              <name>metron-pcap</name>
+            </package>
           </packages>
         </osSpecific>
         <osSpecific>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/enrichment_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/enrichment_commands.py
@@ -20,6 +20,7 @@ import time
 
 from resource_management.core.logger import Logger
 from resource_management.core.resources.system import Execute, File
+from resource_management.libraries.resources.hdfs_resource import HdfsResource
 
 import metron_service
 
@@ -96,6 +97,15 @@ class EnrichmentCommands:
                                         replication_factor,
                                         retention_bytes))
         Logger.info("Done creating Kafka topics")
+
+    def init_hdfs_dir(self):
+        self.__params.HdfsResource(self.__params.metron_apps_enrichment_dir,
+                                   type="directory",
+                                   action="create_on_execute",
+                                   owner=self.__params.metron_user,
+                                   group=self.__params.user_group,
+                                   mode=0775,
+                                   )
 
     def start_enrichment_topology(self):
         Logger.info("Starting Metron enrichment topology: {0}".format(self.__enrichment_topology))

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/enrichment_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/enrichment_master.py
@@ -52,6 +52,7 @@ class Enrichment(Script):
         if not commands.is_configured():
             commands.init_kafka_topics()
             commands.create_hbase_tables()
+            commands.init_hdfs_dir()
             commands.set_configured()
 
         commands.start_enrichment_topology()

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/params/params_linux.py
@@ -39,6 +39,7 @@ config = Script.get_config()
 tmp_dir = Script.get_tmp_dir()
 
 hostname = config['hostname']
+user_group = config['configurations']['cluster-env']['user_group']
 metron_home = status_params.metron_home
 parsers = status_params.parsers
 metron_ddl_dir = metron_home + '/ddl'
@@ -96,6 +97,7 @@ if has_kafka_host:
     kafka_brokers += ':' + kafka_broker_port
 
 metron_apps_dir = config['configurations']['metron-env']['metron_apps_hdfs_dir']
+metron_apps_enrichment_dir = metron_apps_dir + '/enrichment'
 metron_topic_retention = config['configurations']['metron-env']['metron_topic_retention']
 
 local_grok_patterns_dir = format("{metron_home}/patterns")

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/params/status_params.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/params/status_params.py
@@ -51,7 +51,7 @@ metron_indexing_topology = config['configurations']['metron-env']['metron_indexi
 indexing_configured_flag_file = metron_zookeeper_config_path + '/../metron_indexing_configured'
 
 # Enrichment
-enrichment_configured_flag_file = metron_zookeeper_config_path + '/../metron_enrichment_is_configured'
+enrichment_configured_flag_file = metron_zookeeper_config_path + '/../metron_enrichment_configured'
 
 # Storm
 storm_rest_addr = config['configurations']['metron-env']['storm_rest_addr']

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/parser_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.2.1BETA/package/scripts/parser_commands.py
@@ -58,8 +58,8 @@ class ParserCommands:
     def init_parsers(self):
         Logger.info(
             "Copying grok patterns from local directory '{0}' to HDFS '{1}'".format(self.__params.local_grok_patterns_dir,
-                                                                                    self.__params.metron_apps_dir))
-        self.__params.HdfsResource(self.__params.metron_apps_dir,
+                                                                                    self.__params.hdfs_grok_patterns_dir))
+        self.__params.HdfsResource(self.__params.hdfs_grok_patterns_dir,
                                    type="directory",
                                    action="create_on_execute",
                                    owner=self.__params.metron_user,


### PR DESCRIPTION
In addition to the main goal, there's a couple minor changes I made while I was in the neighborhood for simple changes that didn't seem to make sense to bother with separate PRs. If anyone wants them to be split out, I'm happy to break the commit up appropriately.

This PR covers 3 things:

1. The original directory fix.  It did exist before, but was configured to be /tmp/metron/enriched.  This moves it to be consistent with quick-dev and adjusts the folder's permissions appropriately so that it can actually be written to by Storm (owned by the Hadoop group with 755 perms, same as quick dev).  Complimentary to this the /apps/metron/patterns folder is properly created and used.  It was defined in configs before, but /apps/metron was passed instead of the /apps/metron/patterns.

2. Pcap RPM never got installed.  It's a simple three line change to make sure the scripts get deployed.

3. Made the is_configured files consistent (enrichment had slightly different file pattern).  One line config change.

To test, I used the docker-ambari procedure outline at: https://www.evernote.com/shard/s530/sh/c5551fbd-0ac1-4861-89ce-9c5e37065c52/b13e05f39eaac1a6

After spinning up the instance and installing the service, the directories are appropriately created (/apps/metron/enrichments and /apps/metron/patterns).  The Metron home directory on the nodes contains the pcap scripts and yum reports the pcap rpm as installed.  Finally, the configured files are all just metron_<indexing|enrichment|parsers>_configured