### PR TITLE
METRON-535: Global Validations type still refers to MQL rather than Stellar

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/validation/FieldValidations.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/validation/FieldValidations.java
@@ -29,7 +29,7 @@ import org.apache.metron.common.field.validation.primitive.RegexValidation;
 import org.apache.metron.common.utils.ReflectionUtils;
 
 public enum FieldValidations {
-  MQL(new QueryValidation())
+  STELLAR(new QueryValidation())
   ,IP(new IPValidation())
   ,DOMAIN(new DomainValidation())
   ,EMAIL(new EmailValidation())

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/validation/QueryValidationTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/field/validation/QueryValidationTest.java
@@ -35,7 +35,7 @@ public class QueryValidationTest extends BaseValidationTest{
    {
     "fieldValidations" : [
           {
-           "validation" : "MQL"
+           "validation" : "STELLAR"
           ,"config" : {
                 "condition" : "exists(field1)"
                       }
@@ -50,7 +50,7 @@ public class QueryValidationTest extends BaseValidationTest{
    {
     "fieldValidations" : [
           {
-           "validation" : "MQL"
+           "validation" : "STELLAR"
           ,"config" : {
                       }
           }
@@ -64,7 +64,7 @@ public class QueryValidationTest extends BaseValidationTest{
    {
     "fieldValidations" : [
           {
-           "validation" : "MQL"
+           "validation" : "STELLAR"
           ,"config" : {
               "condition" : "exi and "
                       }
@@ -78,7 +78,7 @@ public class QueryValidationTest extends BaseValidationTest{
    {
     "fieldValidations" : [
           {
-           "validation" : "MQL"
+           "validation" : "STELLAR"
           ,"config" : {
                 "condition" : "MAP_EXISTS(dc, dc2tz)"
                 ,"dc2tz" : {


### PR DESCRIPTION
The global validation processor that allows you to specify global validations via Stellar is still named "MQL" rather than "STELLAR". The documentation states otherwise. This is inconsistent and should have its name changed.