### PR TITLE
METRON-554: Require proper error handling when invalid input is fed to Threat triage rules

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/StellarPredicateProcessor.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/StellarPredicateProcessor.java
@@ -21,10 +21,7 @@ package org.apache.metron.common.stellar;
 
 import org.apache.metron.common.dsl.Context;
 import org.apache.metron.common.dsl.FunctionResolver;
-import org.apache.metron.common.dsl.StellarFunction;
 import org.apache.metron.common.dsl.VariableResolver;
-
-import java.util.function.Function;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
@@ -51,6 +48,11 @@ public class StellarPredicateProcessor extends BaseStellarProcessor<Boolean> {
     if(rule == null || isEmpty(rule.trim())) {
       return true;
     }
-    return super.parse(rule, variableResolver, functionResolver, context);
+    try {
+      return super.parse(rule, variableResolver, functionResolver, context);
+    } catch (ClassCastException e) {
+      // predicate must return boolean
+      throw new IllegalArgumentException(String.format("The rule '%s' does not return a boolean value.", rule));
+    }
   }
 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/StellarPredicateProcessor.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/StellarPredicateProcessor.java
@@ -52,7 +52,7 @@ public class StellarPredicateProcessor extends BaseStellarProcessor<Boolean> {
       return super.parse(rule, variableResolver, functionResolver, context);
     } catch (ClassCastException e) {
       // predicate must return boolean
-      throw new IllegalArgumentException(String.format("The rule '%s' does not return a boolean value.", rule));
+      throw new IllegalArgumentException(String.format("The rule '%s' does not return a boolean value.", rule), e);
     }
   }
 }

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/StellarTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/stellar/StellarTest.java
@@ -21,21 +21,17 @@ package org.apache.metron.common.stellar;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.metron.common.dsl.*;
 import org.apache.metron.common.utils.SerDeUtils;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.reflections.Reflections;
 import org.reflections.util.ConfigurationBuilder;
 
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
 
 import static org.apache.metron.common.dsl.FunctionResolverSingleton.effectiveClassPathUrls;
 
@@ -659,6 +655,19 @@ public class StellarTest {
     Assert.assertFalse(runPredicate("not(IN_SUBNET(ip_src_addr, '192.168.0.0/24'))", v-> variableMap.get(v)));
     Assert.assertFalse(runPredicate("IN_SUBNET(ip_dst_addr, '192.168.0.0/24')", v-> variableMap.get(v)));
     Assert.assertTrue(runPredicate("not(IN_SUBNET(ip_dst_addr, '192.168.0.0/24'))", v-> variableMap.get(v)));
+  }
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void non_boolean_predicate_throws_exception() {
+    final Map<String, String> variableMap = new HashMap<String, String>() {{
+      put("protocol", "http");
+    }};
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("The rule 'TO_UPPER(protocol)' does not return a boolean value.");
+    runPredicate("TO_UPPER(protocol)", v -> variableMap.get(v));
   }
 
 }


### PR DESCRIPTION
This completes https://issues.apache.org/jira/browse/METRON-554

Non-boolean-returning functions used as predicates in the triage rules will cause generic exceptions like the following:
```
java.lang.ClassCastException: Cannot cast java.lang.String to java.lang.Boolean
	at java.lang.Class.cast(Class.java:3369) ~[?:1.8.0_60]
	at org.apache.metron.common.stellar.BaseStellarProcessor.parse(BaseStellarProcessor.java:58) ~[stormjar.jar:?]
	at org.apache.metron.common.stellar.StellarPredicateProcessor.parse(StellarPredicateProcessor.java:53) ~[stormjar.jar:?]
	at org.apache.metron.threatintel.triage.ThreatTriageProcessor.apply(ThreatTriageProcessor.java:58) ~[stormjar.jar:?]
```

This fix makes it clear where the problem is.

**Testing**

Edit the bro enrichment config in $METRON_HOME/config/zookeeper/enrichments/bro.json

Add a predicate to the riskLevelRules that does not return a boolean value, e.g. `"TO_UPPER(protocol)" : 0.92"` as shown in the example below.

```
{
  "index": "bro",
  "batchSize": 5,
  "enrichment" : {
    "fieldMap": {
      "geo": ["ip_dst_addr", "ip_src_addr"],
      "host": ["host"]
    }
  },
  "threatIntel": {
    "fieldMap": {
      "hbaseThreatIntel": ["ip_src_addr", "ip_dst_addr"]
    },
    "fieldToTypeMap": {
      "ip_src_addr" : ["malicious_ip"],
      "ip_dst_addr" : ["malicious_ip"]
    },
    "triageConfig" : {
	"riskLevelRules" : {
	    "exists(ip_dst_addr)" : 0.10,
	    "TO_UPPER(protocol) == 'HTTP'" : 0.91,
	    "TO_UPPER(protocol)" : 0.92,
	    "exists(ip_dst_port)" : 0.20,
	    "exists(ip_src_port)" : 0.30000000000
	},
	"aggregator" : "MAX",
	"aggregationConfig":
	{
	    "NEGATIVE_VALUES_TRUMP_CONF" : "false"
	}
    }
  }
}
```

Load the new configuration in zookeeper doing the following:
```
$METRON_HOME/bin/zk_load_configs.sh -z node1:2181 -m PUSH -i $METRON_HOME/config/zookeeper/
```

The configuration should push out to the enrichment topology. You will need to wait a bit for new bro messages to percolate through the system. Verify the new, more specific error message in the storm worker logs, an example of which is shown below.

example path for enrichment - /var/log/storm/workers-artifacts/enrichment-7-1478449668/6700/worker.log

Revised Storm worker error message:

```
2016-11-06 16:47:56.325 o.a.m.e.b.JoinBolt [ERROR] [Metron] Unable to join messages: {"adapter.threatinteladapter.end.ts":"1478450876296","adapter.threatinteladapter.begin.ts":"1478450876296","source.type":"bro"}
java.lang.IllegalArgumentException: The rule 'TO_UPPER(protocol)' does not return a boolean value.
        at org.apache.metron.common.stellar.StellarPredicateProcessor.parse(StellarPredicateProcessor.java:55) ~[stormjar.jar:?]
        at org.apache.metron.threatintel.triage.ThreatTriageProcessor.apply(ThreatTriageProcessor.java:58) ~[stormjar.jar:?]
        at org.apache.metron.enrichment.bolt.ThreatIntelJoinBolt.joinMessages(ThreatIntelJoinBolt.java:133) ~[stormjar.jar:?]
        at org.apache.metron.enrichment.bolt.ThreatIntelJoinBolt.joinMessages(ThreatIntelJoinBolt.java:38) ~[stormjar.jar:?]
        at org.apache.metron.enrichment.bolt.JoinBolt.execute(JoinBolt.java:113) [stormjar.jar:?]
        at org.apache.storm.daemon.executor$fn__6571$tuple_action_fn__6573.invoke(executor.clj:734) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.daemon.executor$mk_task_receiver$fn__6492.invoke(executor.clj:466) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.disruptor$clojure_handler$reify__6005.onEvent(disruptor.clj:40) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.utils.DisruptorQueue.consumeBatchToCursor(DisruptorQueue.java:451) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.utils.DisruptorQueue.consumeBatchWhenAvailable(DisruptorQueue.java:430) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.disruptor$consume_batch_when_available.invoke(disruptor.clj:73) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.daemon.executor$fn__6571$fn__6584$fn__6637.invoke(executor.clj:853) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.util$async_loop$fn__554.invoke(util.clj:484) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at clojure.lang.AFn.run(AFn.java:22) [clojure-1.7.0.jar:?]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_77]
2016-11-06 16:47:56.326 o.a.s.d.executor [ERROR]
java.lang.IllegalArgumentException: The rule 'TO_UPPER(protocol)' does not return a boolean value.
        at org.apache.metron.common.stellar.StellarPredicateProcessor.parse(StellarPredicateProcessor.java:55) ~[stormjar.jar:?]
        at org.apache.metron.threatintel.triage.ThreatTriageProcessor.apply(ThreatTriageProcessor.java:58) ~[stormjar.jar:?]
        at org.apache.metron.enrichment.bolt.ThreatIntelJoinBolt.joinMessages(ThreatIntelJoinBolt.java:133) ~[stormjar.jar:?]
        at org.apache.metron.enrichment.bolt.ThreatIntelJoinBolt.joinMessages(ThreatIntelJoinBolt.java:38) ~[stormjar.jar:?]
        at org.apache.metron.enrichment.bolt.JoinBolt.execute(JoinBolt.java:113) [stormjar.jar:?]
        at org.apache.storm.daemon.executor$fn__6571$tuple_action_fn__6573.invoke(executor.clj:734) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.daemon.executor$mk_task_receiver$fn__6492.invoke(executor.clj:466) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.disruptor$clojure_handler$reify__6005.onEvent(disruptor.clj:40) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.utils.DisruptorQueue.consumeBatchToCursor(DisruptorQueue.java:451) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.utils.DisruptorQueue.consumeBatchWhenAvailable(DisruptorQueue.java:430) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.disruptor$consume_batch_when_available.invoke(disruptor.clj:73) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.daemon.executor$fn__6571$fn__6584$fn__6637.invoke(executor.clj:853) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at org.apache.storm.util$async_loop$fn__554.invoke(util.clj:484) [storm-core-1.0.1.2.5.0.0-1245.jar:1.0.1.2.5.0.0-1245]
        at clojure.lang.AFn.run(AFn.java:22) [clojure-1.7.0.jar:?]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_77]
```

I went with an IllegalArgumentException because, while it's a runtime exception, this is more of a configuration error.