### PR TITLE
METRON-558 use posix for gnu tar with maven assembly plugin

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/pom.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/pom.xml
@@ -101,7 +101,7 @@
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
-                    <tarLongFileMode>gnu</tarLongFileMode>
+                    <tarLongFileMode>posix</tarLongFileMode>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
                         <descriptor>src/main/assemblies/metron-mpack.xml</descriptor>


### PR DESCRIPTION
This allows it to handle large group id's and resolves the following error

[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 09:36 min
[INFO] Finished at: 2016-11-09T10:13:17-05:00
[INFO] Final Memory: 177M/1916M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.6:single (build-tarball) on project metron_mpack: Execution build-tarball of goal org.apache.maven.plugins:maven-assembly-plugin:2.6:single failed: group id '397160923' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.


The typical answer is to configure the plugin to use posix for tarLongFileMode.  
