### PR TITLE
METRON-561 the system property should override the sys env shell if set

### DIFF
--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/ShellFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/ShellFunctions.java
@@ -209,14 +209,16 @@ public class ShellFunctions {
   public static class Edit implements StellarFunction {
 
     private String getEditor() {
-      String editor = System.getenv().get("EDITOR");
-      if(editor == null) {
+      // if we have editor in the system properties, it should
+      // override the env so we check that first
+      String editor = System.getProperty("EDITOR");
+      if(org.apache.commons.lang3.StringUtils.isEmpty(editor)) {
+        editor = System.getenv().get("EDITOR");
+      }
+      if(org.apache.commons.lang3.StringUtils.isEmpty(editor)) {
         editor = System.getenv("VISUAL");
       }
-      if(editor == null) {
-        editor = System.getProperty("EDITOR");
-      }
-      if(editor == null) {
+      if(org.apache.commons.lang3.StringUtils.isEmpty(editor)) {
         editor = "/bin/vi";
       }
       return editor;


### PR DESCRIPTION


When running mvn integration-test , after having set EDITOR=vim in my .zshrc I see the following:

Running org.apache.metron.management.ShellFunctionsTest

Vim: Warning: Output is not to a terminal
Vim: Warning: Input is not from a terminal

And the tests never complete.

The tests should run to completion and not count on system variables being configured the "right" way

---

If the System.Property for EDITOR is set, then let that override the sys env