### PR TITLE
METRON-517: Update elasticsearch bro templates for uri

### DIFF
--- a/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/bro_index.template
+++ b/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/bro_index.template
@@ -132,7 +132,7 @@
         "uri": {
           "type": "string",
           "index": "not_analyzed",
-          "ignore_above": 10922
+          "ignore_above": 8191
         },
         "uid": {
           "type": "string",

--- a/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/bro_index.template
+++ b/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/bro_index.template
@@ -131,7 +131,8 @@
         },
         "uri": {
           "type": "string",
-          "index": "not_analyzed"
+          "index": "not_analyzed",
+          "ignore_above": 10922
         },
         "uid": {
           "type": "string",


### PR DESCRIPTION
## Problem

[METRON-517](https://issues.apache.org/jira/browse/METRON-517)

The bro uri field in [HTTP::Info](https://www.bro.org/sphinx/scripts/base/protocols/http/main.bro.html#type-HTTP::Info) can grow to a size which fails to insert the message into Elasticsearch.  The related error message is:
`IllegalArgumentException[Document contains at least one immense term in field=\"uri\" (whose UTF8 encoding is longer than the max length 32766), all of which were skipped...`

## Short-term Solution

Set the elasticsearch template to [ignore the URI field](https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html) if it is greater than 10922 (32776 / 3) bytes, as [RFC 3986](https://tools.ietf.org/html/rfc3986) allows UTF-8 characters to be used in URIs.  32766 is a size limitation built into Lucene ([MAX_TERM_LENGTH](https://lucene.apache.org/core/6_2_1/core/constant-values.html#org.apache.lucene.index.IndexWriter.MAX_TERM_LENGTH)), and each UTF-8 character can be at most 4 bytes, but are predominantly [3 bytes](https://en.wikipedia.org/wiki/CJK_characters).

## Long-term Solution

Currently being tracked via [METRON-542](https://issues.apache.org/jira/browse/METRON-542)

## Testing

Inserted this into my bare metal cluster via `curl --data "@/root/incubator-metron/metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/bro_index.template" -XPUT server5:9200/_template/bro_index`

Did some kibana queries and cluster monitoring on my bare metal cluster.