### PR TITLE
METRON-578: Missing error handling bolts for enrichment and threat intel

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/package/scripts/enrichment_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/package/scripts/enrichment_commands.py
@@ -20,7 +20,6 @@ import time
 
 from resource_management.core.logger import Logger
 from resource_management.core.resources.system import Execute, File
-from resource_management.libraries.resources.hdfs_resource import HdfsResource
 
 import metron_service
 
@@ -30,6 +29,8 @@ class EnrichmentCommands:
     __params = None
     __enrichment_topology = None
     __enrichment_topic = None
+    __enrichment_error_topic = None
+    __threat_intel_error_topic = None
     __configured = False
 
     def __init__(self, params):
@@ -38,6 +39,8 @@ class EnrichmentCommands:
         self.__params = params
         self.__enrichment_topology = params.metron_enrichment_topology
         self.__enrichment_topic = params.metron_enrichment_topic
+        self.__enrichment_error_topic = params.metron_enrichment_error_topic
+        self.__threat_intel_error_topic = params.metron_threat_intel_error_topic
         self.__configured = os.path.isfile(self.__params.enrichment_configured_flag_file)
 
     def is_configured(self):
@@ -71,11 +74,11 @@ class EnrichmentCommands:
             yum_repo_types[repo_type]()
             Logger.info("Writing out repo file")
             repo_template = ("echo \"[METRON-0.3.0]\n"
-                            "name=Metron 0.3.0 packages\n"
-                            "baseurl={0}\n"
-                            "gpgcheck=0\n"
-                            "enabled=1\n\""
-                         "   > /etc/yum.repos.d/metron.repo")
+                             "name=Metron 0.3.0 packages\n"
+                             "baseurl={0}\n"
+                             "gpgcheck=0\n"
+                             "enabled=1\n\""
+                             "   > /etc/yum.repos.d/metron.repo")
             Execute(repo_template.format(self.__params.repo_url))
         else:
             raise ValueError("Unsupported repo type '{0}'".format(repo_type))
@@ -93,15 +96,18 @@ class EnrichmentCommands:
         replication_factor = 1
         retention_gigabytes = int(self.__params.metron_topic_retention)
         retention_bytes = retention_gigabytes * 1024 * 1024 * 1024
-        Logger.info("Creating topics for enrichment")
 
-        Logger.info("Creating topic'{0}'".format(self.__enrichment_topic))
-        Execute(command_template.format(self.__params.kafka_bin_dir,
-                                        self.__params.zookeeper_quorum,
-                                        self.__enrichment_topic,
-                                        num_partitions,
-                                        replication_factor,
-                                        retention_bytes))
+        Logger.info("Creating topics for enrichment")
+        topics = [self.__enrichment_topic, self.__enrichment_error_topic, self.__threat_intel_error_topic]
+        for topic in topics:
+            Logger.info("Creating topic'{0}'".format(topic))
+            Execute(command_template.format(self.__params.kafka_bin_dir,
+                                            self.__params.zookeeper_quorum,
+                                            topic,
+                                            num_partitions,
+                                            replication_factor,
+                                            retention_bytes))
+
         Logger.info("Done creating Kafka topics")
 
     def init_hdfs_dir(self):

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/package/scripts/params/params_linux.py
@@ -179,6 +179,8 @@ threatintel_cf = status_params.threatintel_cf
 
 metron_enrichment_topology = status_params.metron_enrichment_topology
 metron_enrichment_topic = status_params.metron_enrichment_topic
+metron_enrichment_error_topic = status_params.metron_enrichment_error_topic
+metron_threat_intel_error_topic = status_params.metron_threat_intel_error_topic
 
 # ES Templates
 bro_index_path = tmp_dir + "/bro_index.template"

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/package/scripts/params/status_params.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/package/scripts/params/status_params.py
@@ -34,6 +34,8 @@ parsers_configured_flag_file = metron_zookeeper_config_path + '/../metron_parser
 # Enrichment
 metron_enrichment_topology = 'enrichment'
 metron_enrichment_topic = 'enrichments'
+metron_enrichment_error_topic = 'enrichments_error'
+metron_threat_intel_error_topic = 'threatintel_error'
 
 enrichment_table = 'enrichment'
 enrichment_cf = 't'

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/package/templates/enrichment.properties.j2
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/package/templates/enrichment.properties.j2
@@ -20,6 +20,8 @@
 kafka.zk={{zookeeper_quorum}}
 kafka.broker={{kafka_brokers}}
 enrichment.output.topic=indexing
+enrichment.error.topic=enrichments_error
+threat.intel.error.topic=threatintel_error
 
 ##### MySQL #####
 

--- a/metron-deployment/roles/metron_kafka_topics/defaults/main.yml
+++ b/metron-deployment/roles/metron_kafka_topics/defaults/main.yml
@@ -22,6 +22,8 @@ topics_to_create:
   - { topic: "yaf",         num_partitions: 1, replication_factor: 1, retention_gb: 10 }
   - { topic: "snort",       num_partitions: 1, replication_factor: 1, retention_gb: 10 }
   - { topic: "enrichments", num_partitions: 1, replication_factor: 1, retention_gb: 10 }
+  - { topic: "enrichments_error", num_partitions: 1, replication_factor: 1, retention_gb: 10 }
+  - { topic: "threatintel_error", num_partitions: 1, replication_factor: 1, retention_gb: 10 }
   - { topic: "parser_invalid",  num_partitions: 1, replication_factor: 1, retention_gb: 10 }
   - { topic: "parser_error",    num_partitions: 1, replication_factor: 1, retention_gb: 10 }
   - { topic: "indexing", num_partitions: 1, replication_factor: 1, retention_gb: 10 }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/Constants.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/Constants.java
@@ -27,6 +27,8 @@ public class Constants {
   public static final long DEFAULT_CONFIGURED_BOLT_TIMEOUT = 5000;
   public static final String SENSOR_TYPE = "source.type";
   public static final String ENRICHMENT_TOPIC = "enrichments";
+  public static final String ENRICHMENT_ERROR_TOPIC = "enrichments_error";
+  public static final String THREAT_INTEL_ERROR_TOPIC = "threatintel_error";
   public static final String INDEXING_TOPIC = "indexing";
   public static final String INDEXING_ERROR_TOPIC = "indexing_error";
   public static final String DEFAULT_PARSER_ERROR_TOPIC = "parser_error";

--- a/metron-platform/metron-enrichment/src/main/config/enrichment.properties
+++ b/metron-platform/metron-enrichment/src/main/config/enrichment.properties
@@ -20,6 +20,8 @@
 kafka.zk=node1:2181
 kafka.broker=node1:6667
 enrichment.output.topic=indexing
+enrichment.error.topic=enrichments_error
+threat.intel.error.topic=threatintel_error
 
 ##### MySQL #####
 

--- a/metron-platform/metron-enrichment/src/main/flux/enrichment/remote.yaml
+++ b/metron-platform/metron-enrichment/src/main/flux/enrichment/remote.yaml
@@ -107,6 +107,17 @@ components:
                 args:
                     - ref: "stellarEnrichment"
 
+    #enrichment error
+    -   id: "enrichmentErrorKafkaWriter"
+        className: "org.apache.metron.writer.kafka.KafkaWriter"
+        configMethods:
+            -   name: "withTopic"
+                args:
+                    - "${enrichment.error.topic}"
+            -   name: "withZkQuorum"
+                args:
+                    - "${kafka.zk}"
+
 # Threat Intel
     -   id: "stellarThreatIntelAdapter"
         className: "org.apache.metron.enrichment.adapters.stellar.StellarAdapter"
@@ -159,6 +170,16 @@ components:
                 args:
                     - ref: "stellarThreatIntelEnrichment"
 
+    #threatintel error
+    -   id: "threatIntelErrorKafkaWriter"
+        className: "org.apache.metron.writer.kafka.KafkaWriter"
+        configMethods:
+            -   name: "withTopic"
+                args:
+                    - "${threat.intel.error.topic}"
+            -   name: "withZkQuorum"
+                args:
+                    - "${kafka.zk}"
 
 #indexing
     -   id: "kafkaWriter"
@@ -266,6 +287,14 @@ bolts:
                 args: [10000]
             -   name: "withMaxTimeRetain"
                 args: [10]
+    -   id: "enrichmentErrorOutputBolt"
+        className: "org.apache.metron.writer.bolt.BulkMessageWriterBolt"
+        constructorArgs:
+            - "${kafka.zk}"
+        configMethods:
+            -   name: "withMessageWriter"
+                args:
+                    - ref: "enrichmentErrorKafkaWriter"
 
 # Threat Intel Bolts
     -   id: "threatIntelSplitBolt"
@@ -311,6 +340,15 @@ bolts:
                 args: [10000]
             -   name: "withMaxTimeRetain"
                 args: [10]
+    -   id: "threatIntelErrorOutputBolt"
+        className: "org.apache.metron.writer.bolt.BulkMessageWriterBolt"
+        constructorArgs:
+            - "${kafka.zk}"
+        configMethods:
+            -   name: "withMessageWriter"
+                args:
+                    - ref: "threatIntelErrorKafkaWriter"
+
 # Indexing Bolts
     -   id: "outputBolt"
         className: "org.apache.metron.writer.bolt.BulkMessageWriterBolt"
@@ -402,6 +440,39 @@ streams:
             type: FIELDS
             args: ["key"]
 
+    # Error output
+    -   name: "geoEnrichmentBolt -> enrichmentErrorOutputBolt"
+        from: "geoEnrichmentBolt"
+        to: "enrichmentErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
+
+    -   name: "stellarEnrichmentBolt -> enrichmentErrorOutputBolt"
+        from: "stellarEnrichmentBolt"
+        to: "enrichmentErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
+
+    -   name: "hostEnrichmentBolt -> enrichmentErrorOutputBolt"
+        from: "hostEnrichmentBolt"
+        to: "enrichmentErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
+
+    -   name: "simpleHBaseEnrichmentBolt -> enrichmentErrorOutputBolt"
+        from: "simpleHBaseEnrichmentBolt"
+        to: "enrichmentErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
+
 #threat intel
     -   name: "enrichmentJoin -> threatSplit"
         from: "enrichmentJoinBolt"
@@ -458,4 +529,21 @@ streams:
             streamId: "message"
             type: FIELDS
             args: ["key"]
+
+    # Error output
+    -   name: "simpleHBaseThreatIntelBolt -> threatIntelErrorOutputBolt"
+        from: "simpleHBaseThreatIntelBolt"
+        to: "threatIntelErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
+
+    -   name: "stellarThreatIntelBolt -> threatIntelErrorOutputBolt"
+        from: "stellarThreatIntelBolt"
+        to: "threatIntelErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
 

--- a/metron-platform/metron-enrichment/src/main/flux/enrichment/test.yaml
+++ b/metron-platform/metron-enrichment/src/main/flux/enrichment/test.yaml
@@ -88,6 +88,18 @@ components:
             -   name: "add"
                 args:
                     - ref: "stellarEnrichment"
+
+    #enrichment error
+    -   id: "enrichmentErrorKafkaWriter"
+        className: "org.apache.metron.writer.kafka.KafkaWriter"
+        configMethods:
+            -   name: "withTopic"
+                args:
+                    - "${enrichment.error.topic}"
+            -   name: "withZkQuorum"
+                args:
+                    - "${kafka.zk}"
+
 # Threat Intel
     -   id: "stellarThreatIntelAdapter"
         className: "org.apache.metron.enrichment.adapters.stellar.StellarAdapter"
@@ -139,6 +151,17 @@ components:
             -   name: "add"
                 args:
                     - ref: "stellarThreatIntelEnrichment"
+
+    #threatintel error
+    -   id: "threatIntelErrorKafkaWriter"
+        className: "org.apache.metron.writer.kafka.KafkaWriter"
+        configMethods:
+            -   name: "withTopic"
+                args:
+                    - "${threat.intel.error.topic}"
+            -   name: "withZkQuorum"
+                args:
+                    - "${kafka.zk}"
 
 #indexing
     -   id: "kafkaWriter"
@@ -236,6 +259,18 @@ bolts:
                 args: [10000]
             -   name: "withMaxTimeRetain"
                 args: [10]
+    -   id: "ErrorEnrichmentBolt"
+        className: "org.apache.metron.enrichment.bolt.ErrorEnrichmentBolt"
+        constructorArgs:
+            - "${kafka.zk}"
+        configMethods:
+            -   name: "withEnrichment"
+                args:
+                    - ref: "geoEnrichment"
+            -   name: "withMaxCacheSize"
+                args: [10000]
+            -   name: "withMaxTimeRetain"
+                args: [10]
     -   id: "enrichmentJoinBolt"
         className: "org.apache.metron.enrichment.bolt.EnrichmentJoinBolt"
         constructorArgs:
@@ -245,6 +280,14 @@ bolts:
                 args: [10000]
             -   name: "withMaxTimeRetain"
                 args: [10]
+    -   id: "enrichmentErrorOutputBolt"
+        className: "org.apache.metron.writer.bolt.BulkMessageWriterBolt"
+        constructorArgs:
+            - "${kafka.zk}"
+        configMethods:
+            -   name: "withMessageWriter"
+                args:
+                    - ref: "enrichmentErrorKafkaWriter"
 
 # Threat Intel Bolts
     -   id: "threatIntelSplitBolt"
@@ -290,6 +333,15 @@ bolts:
                 args: [10000]
             -   name: "withMaxTimeRetain"
                 args: [10]
+    -   id: "threatIntelErrorOutputBolt"
+        className: "org.apache.metron.writer.bolt.BulkMessageWriterBolt"
+        constructorArgs:
+            - "${kafka.zk}"
+        configMethods:
+            -   name: "withMessageWriter"
+                args:
+                    - ref: "threatIntelErrorKafkaWriter"
+
 # Indexing Bolts
     -   id: "outputBolt"
         className: "org.apache.metron.writer.bolt.BulkMessageWriterBolt"
@@ -341,6 +393,14 @@ streams:
             type: FIELDS
             args: ["key"]
 
+    -   name: "enrichmentSplit -> ErrorEnrichmentBolt"
+        from: "enrichmentSplitBolt"
+        to: "ErrorEnrichmentBolt"
+        grouping:
+            streamId: "hbaseEnrichment"
+            type: FIELDS
+            args: ["key"]
+
     -   name: "splitter -> join"
         from: "enrichmentSplitBolt"
         to: "enrichmentJoinBolt"
@@ -378,6 +438,47 @@ streams:
             streamId: "host"
             type: FIELDS
             args: ["key"]
+
+    # Error output
+    -   name: "geoEnrichmentBolt -> enrichmentErrorOutputBolt"
+        from: "geoEnrichmentBolt"
+        to: "enrichmentErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
+
+    -   name: "stellarEnrichmentBolt -> enrichmentErrorOutputBolt"
+        from: "stellarEnrichmentBolt"
+        to: "enrichmentErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
+
+    -   name: "hostEnrichmentBolt -> enrichmentErrorOutputBolt"
+        from: "hostEnrichmentBolt"
+        to: "enrichmentErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
+
+    -   name: "simpleHBaseEnrichmentBolt -> enrichmentErrorOutputBolt"
+        from: "simpleHBaseEnrichmentBolt"
+        to: "enrichmentErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
+
+    -   name: "ErrorEnrichmentBolt -> enrichmentErrorOutputBolt"
+        from: "ErrorEnrichmentBolt"
+        to: "enrichmentErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
 
 #threat intel
     -   name: "enrichmentJoin -> threatSplit"
@@ -434,3 +535,21 @@ streams:
             streamId: "message"
             type: FIELDS
             args: ["key"]
+
+    # Error output
+    -   name: "simpleHBaseThreatIntelBolt -> threatIntelErrorOutputBolt"
+        from: "simpleHBaseThreatIntelBolt"
+        to: "threatIntelErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
+
+    -   name: "stellarThreatIntelBolt -> threatIntelErrorOutputBolt"
+        from: "stellarThreatIntelBolt"
+        to: "threatIntelErrorOutputBolt"
+        grouping:
+            streamId: "error"
+            type: FIELDS
+            args: ["message"]
+

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/bolt/ErrorEnrichmentBolt.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/bolt/ErrorEnrichmentBolt.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.metron.enrichment.bolt;
+
+import org.json.simple.JSONObject;
+import org.apache.storm.tuple.Tuple;
+
+/**
+ * Exists in order to provide a bolt that tests that when the GenericEnrichmentBolt writes to error, that it actually carries
+ * through the queue
+ */
+public class ErrorEnrichmentBolt extends GenericEnrichmentBolt {
+
+  public static final String TEST_ERROR_MESSAGE = "Test throwing error from ErrorEnrichmentBolt";
+
+  public ErrorEnrichmentBolt(String zookeeperUrl) {
+    super(zookeeperUrl);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void execute(Tuple tuple) {
+    JSONObject rawMessage = new JSONObject();
+    rawMessage.put("rawMessage", "Error Test Raw Message String");
+
+    JSONObject enrichedMessage= new JSONObject();
+    enrichedMessage.put("enrichedMessage", "Error Test Enriched Message String");
+    handleError("key", rawMessage, "subgroup", enrichedMessage, new IllegalStateException(TEST_ERROR_MESSAGE));
+  }
+}


### PR DESCRIPTION
In the flux files, added outputs for the various `GenericEnrichmentBolt` used throughout, to tie their error output streams to Kafka topics.  Specifically, enrichment is tied to enrichments_error and threat intel is tied to threatintel_error.

Quick-dev and the Ambari mpack are updated to ensure the topics are created, so that no errors occur on usage.  Both were run up to ensure that the topics were created and the flux files don't give errors.

To test, an adjustment was made to the `EnrichmentIntegrationTest` to have an enrichment bolt that always throws errors.  This bolt is derived from `GenericEnrichmentBolt` (which has been slightly refactored) to ensure that it uses the same error logic, but ignores the actual logic that leads to errors.  This was done because I couldn't find input that resulted in the error stream code path in actual practice.  Other errors can result, but don't go to the error stream (e.g. JSON decoding errors).

As a note, the `ErrorEnrichmentBolt` invariably ends up in the stack traces being printed (which is not handled by `ErrorEnrichmentBolt` or `GenericEnrichmentBolt`).

Given that the test explicitly calls `UnitTestHelper.verboseLogging()`, I'm not sure how to suppress that without killing actual errors at the same time is.  Open to suggestions if someone knows a more appropriate way to handle it (if we care).
