### PR TITLE
METRON-522: Need to mandate Client installation on Metron Host

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/metainfo.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/metainfo.xml
@@ -84,6 +84,13 @@
               </auto-deploy>
             </dependency>
             <dependency>
+              <name>HBASE/HBASE_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+            <dependency>
               <name>ZOOKEEPER/ZOOKEEPER_SERVER</name>
               <scope>cluster</scope>
               <auto-deploy>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/service_advisor.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/service_advisor.py
@@ -50,11 +50,11 @@ class METRON030ServiceAdvisor(service_advisor.ServiceAdvisor):
 
         kafkaBrokers = self.getHosts(componentsList, "KAFKA_BROKER")
         stormSupervisors = self.getHosts(componentsList, "SUPERVISOR")
-        zookeeperServers = self.getHosts(componentsList, "ZOOKEEPER_SERVER")
+        zookeeperClientHosts = self.getHosts(componentsList, "ZOOKEEPER_CLIENT")
 
         items = []
 
-        #Metron Must Co-locate with KAFKA_BROKER and STORM_SUPERVISOR
+        # Metron Must Co-locate with KAFKA_BROKER and STORM_SUPERVISOR
         if metronParsersHost not in kafkaBrokers:
             message = "Metron must be colocated with an instance of KAFKA BROKER"
             items.append({ "type": 'host-component', "level": 'ERROR', "message": message, "component-name": 'METRON_PARSERS', "host": metronParsersHost })
@@ -75,9 +75,9 @@ class METRON030ServiceAdvisor(service_advisor.ServiceAdvisor):
             message = "Metron MySQL Server must be co-located with Metron Parsers on {0}".format(metronParsersHost)
             items.append({ "type": 'host-component', "level": 'ERROR', "message": message, "component-name": 'METRON_ENRICHMENT_MYSQL_SERVER', "host": metronEnrichmentMysqlServer })
 
-        # Enrichment Master also needs ZK Server, but this is already guaranteed by being colocated with Parsers Master
-        if metronParsersHost not in zookeeperServers:
-            message = "Metron must be co-located with an instance of Zookeeper Server"
+        # Enrichment Master also needs ZK Client, but this is already guaranteed by being colocated with Parsers Master
+        if metronParsersHost not in zookeeperClientHosts:
+            message = "Metron must be co-located with an instance of Zookeeper Client"
             items.append({ "type": 'host-component', "level": 'ERROR', "message": message, "component-name": 'METRON_PARSERS', "host": metronParsersHost })
 
         if metronEnrichmentMaster not in hbaseClientHosts:

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/service_advisor.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/service_advisor.py
@@ -45,12 +45,13 @@ class METRON030ServiceAdvisor(service_advisor.ServiceAdvisor):
         metronEnrichmentMaster = self.getHosts(componentsList, "METRON_ENRICHMENT_MASTER")[0]
         metronIndexingHost = self.getHosts(componentsList, "METRON_INDEXING")[0]
         metronEnrichmentMysqlServer = self.getHosts(componentsList, "METRON_ENRICHMENT_MYSQL_SERVER")[0]
+
         hbaseClientHosts = self.getHosts(componentsList, "HBASE_CLIENT")
         hdfsClientHosts = self.getHosts(componentsList, "HDFS_CLIENT")
+        zookeeperClientHosts = self.getHosts(componentsList, "ZOOKEEPER_CLIENT")
 
         kafkaBrokers = self.getHosts(componentsList, "KAFKA_BROKER")
         stormSupervisors = self.getHosts(componentsList, "SUPERVISOR")
-        zookeeperClientHosts = self.getHosts(componentsList, "ZOOKEEPER_CLIENT")
 
         items = []
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/service_advisor.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/service_advisor.py
@@ -81,14 +81,14 @@ class METRON030ServiceAdvisor(service_advisor.ServiceAdvisor):
             message = "Metron must be co-located with an instance of Zookeeper Client"
             items.append({ "type": 'host-component', "level": 'ERROR', "message": message, "component-name": 'METRON_PARSERS', "host": metronParsersHost })
 
-        if metronEnrichmentMaster not in hbaseClientHosts:
-            message = "Metron Enrichment Master must be co-located with an instance of HBase Client"
-            items.append({ "type": 'host-component', "level": 'ERROR', "message": message, "component-name": 'METRON_ENRICHMENT_MASTER', "host": metronEnrichmentMaster })
-
-        # Enrichment Master also needs HDFS clients, but this is already guaranteed by being colocated with Parsers Master
+            # Enrichment Master also needs HDFS clients, but this is already guaranteed by being colocated with Parsers Master
         if metronParsersHost not in hdfsClientHosts:
             message = "Metron must be co-located with an instance of HDFS Client"
             items.append({ "type": 'host-component', "level": 'ERROR', "message": message, "component-name": 'METRON_PARSERS', "host": metronParsersHost })
+
+        if metronEnrichmentMaster not in hbaseClientHosts:
+            message = "Metron Enrichment Master must be co-located with an instance of HBase Client"
+            items.append({ "type": 'host-component', "level": 'ERROR', "message": message, "component-name": 'METRON_ENRICHMENT_MASTER', "host": metronEnrichmentMaster })
 
         return items
 


### PR DESCRIPTION
Added metainfo.xml dependency on HBASE_CLIENT.  Modified service_advisor to force colocation of metron_parsers with ZOOKEEPER_CLIENT and HDFS_CLIENT, along with metron_enrichment colocating with HBASE_CLIENT.

Given that the enrichment master has to be colocated with parsers master in the current setup, I didn't duplicate the constraints there for brevity, although if anybody has a preference towards explicitly adding them in code (beyond the comments mentioning it) I could be pretty easily persuaded.

Tested by spinning a cluster as described in https://www.evernote.com/shard/s530/sh/c5551fbd-0ac1-4861-89ce-9c5e37065c52/b13e05f39eaac1a6

After setup, the cluster had to be modified to ensure each message could be hit in the appropriate location (e.g. ensure a given node has Kafka Broker + HDFS client, but not ZK client, etc.)