### PR TITLE
METRON-585 Pcap Replay Fails to Stop

### DIFF
--- a/metron-deployment/roles/pcap_replay/templates/pcap-replay
+++ b/metron-deployment/roles/pcap_replay/templates/pcap-replay
@@ -73,9 +73,14 @@ case "$1" in
     PID=`cat $PIDFILE`
     cd $DAEMON_PATH
     if [ -f $PIDFILE ]; then
-        kill -HUP $PID
-        printf "%s\n" "Ok"
-        rm -f $PIDFILE
+      while sleep 1
+        echo -n "."
+        kill -0 $PID >/dev/null 2>&1
+      do
+        kill $PID
+      done
+      printf "%s\n" "Ok"
+      rm -f $PIDFILE
     else
         printf "%s\n" "pidfile not found"
     fi


### PR DESCRIPTION
The service script for Pcap Replay often fails to actually stop the `tcpreplay` process.

The `tcpreplay` process is a huge consumer of resources when running on Quick Dev and actually having it stop when asked, would be super nice.

Needed to kill it until it was good and dead.  Tested the change on Quick Dev.