### PR TITLE
METRON-588: Remove ASF License Headers from directly copied Chef Bento Files

### DIFF
--- a/metron-deployment/packer-build/bin/bento
+++ b/metron-deployment/packer-build/bin/bento
@@ -1,20 +1,4 @@
 #!/usr/bin/env ruby
-#
-#  Licensed to the Apache Software Foundation (ASF) under one or more
-#  contributor license agreements.  See the NOTICE file distributed with
-#  this work for additional information regarding copyright ownership.
-#  The ASF licenses this file to You under the Apache License, Version 2.0
-#  (the "License"); you may not use this file except in compliance with
-#  the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
 # -*- encoding: utf-8 -*-
 
 Signal.trap("INT") { exit 1 }

--- a/metron-deployment/packer-build/scripts/centos/cleanup.sh
+++ b/metron-deployment/packer-build/scripts/centos/cleanup.sh
@@ -1,20 +1,4 @@
 #!/bin/sh -eux
-#
-#  Licensed to the Apache Software Foundation (ASF) under one or more
-#  contributor license agreements.  See the NOTICE file distributed with
-#  this work for additional information regarding copyright ownership.
-#  The ASF licenses this file to You under the Apache License, Version 2.0
-#  (the "License"); you may not use this file except in compliance with
-#  the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
 
 # should output one of 'redhat' 'centos' 'oraclelinux'
 distro="`rpm -qf --queryformat '%{NAME}' /etc/redhat-release | cut -f 1 -d '-'`"

--- a/metron-deployment/packer-build/scripts/centos/networking.sh
+++ b/metron-deployment/packer-build/scripts/centos/networking.sh
@@ -1,20 +1,4 @@
 #!/bin/sh -eux
-#
-#  Licensed to the Apache Software Foundation (ASF) under one or more
-#  contributor license agreements.  See the NOTICE file distributed with
-#  this work for additional information regarding copyright ownership.
-#  The ASF licenses this file to You under the Apache License, Version 2.0
-#  (the "License"); you may not use this file except in compliance with
-#  the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
 
 case "$PACKER_BUILDER_TYPE" in
 

--- a/metron-deployment/packer-build/scripts/common/metadata.sh
+++ b/metron-deployment/packer-build/scripts/common/metadata.sh
@@ -1,20 +1,4 @@
 #!/bin/sh -eux
-#
-#  Licensed to the Apache Software Foundation (ASF) under one or more
-#  contributor license agreements.  See the NOTICE file distributed with
-#  this work for additional information regarding copyright ownership.
-#  The ASF licenses this file to You under the Apache License, Version 2.0
-#  (the "License"); you may not use this file except in compliance with
-#  the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
 
 mkdir -p /etc;
 cp /tmp/bento-metadata.json /etc/bento-metadata.json;

--- a/metron-deployment/packer-build/scripts/common/minimize.sh
+++ b/metron-deployment/packer-build/scripts/common/minimize.sh
@@ -1,20 +1,4 @@
 #!/bin/sh -eux
-#
-#  Licensed to the Apache Software Foundation (ASF) under one or more
-#  contributor license agreements.  See the NOTICE file distributed with
-#  this work for additional information regarding copyright ownership.
-#  The ASF licenses this file to You under the Apache License, Version 2.0
-#  (the "License"); you may not use this file except in compliance with
-#  the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
 
 case "$PACKER_BUILDER_TYPE" in
   qemu) exit 0 ;;

--- a/metron-deployment/packer-build/scripts/common/sshd.sh
+++ b/metron-deployment/packer-build/scripts/common/sshd.sh
@@ -1,20 +1,4 @@
 #!/bin/sh -eux
-#
-#  Licensed to the Apache Software Foundation (ASF) under one or more
-#  contributor license agreements.  See the NOTICE file distributed with
-#  this work for additional information regarding copyright ownership.
-#  The ASF licenses this file to You under the Apache License, Version 2.0
-#  (the "License"); you may not use this file except in compliance with
-#  the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
 
 SSHD_CONFIG="/etc/ssh/sshd_config"
 

--- a/metron-deployment/packer-build/scripts/common/sudoers.sh
+++ b/metron-deployment/packer-build/scripts/common/sudoers.sh
@@ -1,20 +1,4 @@
 #!/bin/bash -eux
-#
-#  Licensed to the Apache Software Foundation (ASF) under one or more
-#  contributor license agreements.  See the NOTICE file distributed with
-#  this work for additional information regarding copyright ownership.
-#  The ASF licenses this file to You under the Apache License, Version 2.0
-#  (the "License"); you may not use this file except in compliance with
-#  the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
 
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers
 sed -i -e 's/%sudo  ALL=(ALL:ALL) ALL/%sudo  ALL=NOPASSWD:ALL/g' /etc/sudoers

--- a/metron-deployment/packer-build/scripts/common/vagrant.sh
+++ b/metron-deployment/packer-build/scripts/common/vagrant.sh
@@ -1,20 +1,4 @@
 #!/bin/sh -eux
-#
-#  Licensed to the Apache Software Foundation (ASF) under one or more
-#  contributor license agreements.  See the NOTICE file distributed with
-#  this work for additional information regarding copyright ownership.
-#  The ASF licenses this file to You under the Apache License, Version 2.0
-#  (the "License"); you may not use this file except in compliance with
-#  the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
 
 # set a default HOME_DIR environment variable if not set
 HOME_DIR="${HOME_DIR:-/home/vagrant}";

--- a/metron-deployment/packer-build/scripts/common/vmtools.sh
+++ b/metron-deployment/packer-build/scripts/common/vmtools.sh
@@ -1,20 +1,4 @@
 #!/bin/sh -eux
-#
-#  Licensed to the Apache Software Foundation (ASF) under one or more
-#  contributor license agreements.  See the NOTICE file distributed with
-#  this work for additional information regarding copyright ownership.
-#  The ASF licenses this file to You under the Apache License, Version 2.0
-#  (the "License"); you may not use this file except in compliance with
-#  the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
 
 # set a default HOME_DIR environment variable if not set
 HOME_DIR="${HOME_DIR:-/home/vagrant}";

--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,11 @@
                         <exclude>**/files/opensoc-ui</exclude>
                         <!-- pickle file - binary format -->
                         <exclude>**/src/main/resources/common-services/KIBANA/4.5.1/package/scripts/dashboard/dashboard.p</exclude>
+                        <!-- Files from Chef/bento -->
+                        <exclude>**/packer-build/scripts/**</exclude>
+                        <exclude>**/packer-build/bin/**</exclude>
+                        <!-- Packer/Bento non-source directory -->
+                        <exclude>**/packer_cache/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Removed per Billie's [feedback](http://mail-archives.apache.org/mod_mbox/incubator-general/201611.mbox/%3CCAF1jEfCRYvuDfcGYyjRjXq%2Bmr1R6Sr9%2BdPeeohzb8N2m8wPy5A%40mail.gmail.com%3E) on 0.3.0 release.
