### PR TITLE
METRON-591: Make the website in compliance with ASF standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/apache/incubator-metron.svg?branch=master)](https://travis-ci.org/apache/incubator-metron)
 
-# Metron
+# Apache Metron (Incubating)
  
 Metron integrates a variety of open source big data technologies in order
 to offer a centralized tool for security monitoring and analysis. Metron

--- a/site/_includes/primary-nav-items.html
+++ b/site/_includes/primary-nav-items.html
@@ -10,6 +10,6 @@
     <li class="training-menu"><a href="/news/">News</a>
     </li>
     <li>
-        <button class="button-default button-green trigger-top-form"> <a href="https://github.com/apache/incubator-metron/releases" target="new">Download </a></button>
+        <button class="button-default button-green trigger-top-form"> <a href="https://dist.apache.org/repos/dist/release/incubator/metron/" target="new">Download </a></button>
     </li>
 </ul>

--- a/site/_posts/2016-01-08-debo-committer.md
+++ b/site/_posts/2016-01-08-debo-committer.md
@@ -7,7 +7,7 @@ categories: [team]
 ---
 
 I am very pleased to announce that the Podling Project Management
-Committee (PPMC) of Apache Metron has asked Debo Dutta to become an
+Committee (PPMC) of Apache Metron (Incubating) has asked Debo Dutta to become an
 Apache Metron committer, and he has already accepted.
 
 Debo has already made many contributions to Metron community, working

--- a/site/about/index.md
+++ b/site/about/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Apache Metron About
+title: Apache Metron (Incubating) About
 ---
 
 <section class="hero-second-level no-padding">
@@ -35,7 +35,7 @@ title: Apache Metron About
         <h2>Evolution</h2>
     </div>
     <div>
-        <img class="v-middle img82" src="/img/metron_evolution.png" alt="What Apache Metron Does" style="margin:0 auto;left: 0px;">
+        <img class="v-middle img82" src="/img/metron_evolution.png" alt="What Apache Metron (Incubating) Does" style="margin:0 auto;left: 0px;">
     </div>
     <div class="hover-btn text-center">
             <a class="button-default" href="https://cwiki.apache.org/confluence/display/METRON/Evolution+of+Apache+Metron" target="new">LEARN MORE</a>

--- a/site/community/index.md
+++ b/site/community/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Apache Metron Community
+title: Apache Metron (Incubating) Community
 ---
 
 <section class="hero-second-level no-padding">
@@ -85,7 +85,7 @@ title: Apache Metron Community
           <h2>Community Resources</h2>
         </div>
         <div class="content-960 hover-btn text-center">
-            <p>Apache Metron provides user and development mailing lists, a Github repository, a JIRA site, and list of community members to enable you to learn more about Metron. Feel free to join any of the mailing lists and the Metron IRC channel, and view the code on Github.</p>
+            <p>Apache Metron (Incubating) provides user and development mailing lists, a Github repository, a JIRA site, and list of community members to enable you to learn more about Metron. Feel free to join any of the mailing lists and the Metron IRC channel, and view the code on Github.</p>
             <a class="button-default" href="https://cwiki.apache.org/confluence/display/METRON/Community+Resources#CommunityResources-ApacheMetronCommunityResources" target="_blank">LEARN MORE</a>
         </div>
 </section>
@@ -95,7 +95,7 @@ title: Apache Metron Community
           <h2>Get Involved</h2>
         </div>
         <div class="content-960 hover-btn text-center">
-            <p> Do you want to contribute to Apache Metron? Follow these simple steps to subscribe to the user and development mailing lists, familiarize yourself with the Metron code, set up your development environment, and start contributing.</p>
+            <p> Do you want to contribute to Apache Metron (Incubating)? Follow these simple steps to subscribe to the user and development mailing lists, familiarize yourself with the Metron code, set up your development environment, and start contributing.</p>
             <a class="button-default" href="https://cwiki.apache.org/confluence/display/METRON/Community+Resources#CommunityResources-JointheCommunity-GetingStarted" target="_blank">Take Me There</a>
         </div>
 </section>

--- a/site/develop/bylaws.md
+++ b/site/develop/bylaws.md
@@ -1,11 +1,11 @@
 ---
 layout: page
-title: Apache Metron Bylaws
+title: Apache Metron (Incubating) Bylaws
 ---
 
 ## Introduction
 
-This document defines the bylaws under which the Apache Metron project
+This document defines the bylaws under which the Apache Metron (Incubating) project
 operates. It defines the roles and responsibilities of the project,
 who may vote, how voting works, how conflicts are resolved, etc.
 

--- a/site/documentation/index.md
+++ b/site/documentation/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Apache Metron Documentation
+title: Apache Metron (Incubating) Documentation
 ---
 
 <section class="hero-second-level no-padding">
@@ -34,7 +34,7 @@ title: Apache Metron Documentation
             <h2>Quick Start</h2>
         </div>
         <div class="content-960 hover-btn text-center">
-            <p>The Quick Start installation fully automates the provisioning and deployment of Apache Metron and all necessary prerequisites on a single, virtualized host running on VirtualBox.</p>
+            <p>The Quick Start installation fully automates the provisioning and deployment of Apache Metron (Incubating) and all necessary prerequisites on a single, virtualized host running on VirtualBox.</p>
             <br>
             <p> This image is designed for quick deployment of a single node Metron cluster running on VirtualBox. This platform is ideal for use by Metron developers. It uses a base image that has been pre-loaded with Ambari and HDP.</p>
             <a class="button-default" href="https://cwiki.apache.org/confluence/display/METRON/Quick+Start" target="_blank">LEARN MORE</a>

--- a/site/help/index.md
+++ b/site/help/index.md
@@ -17,7 +17,7 @@ subscribe to the user list, please send email to
 ## Bug Reports
 
 Please file any issues you encounter or fixes you'd like on the
-[Apache Metron Jira](https://issues.apache.org/jira/browse/metron). We welcome
+[Apache Metron (Incubating) Jira](https://issues.apache.org/jira/browse/metron). We welcome
 patches!
 
 ## StackOverflow

--- a/site/index.html
+++ b/site/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Apache Metron Big Data Security
+title: Apache Metron (Incubating) Big Data Security
 overview: true
 ---
 
@@ -40,15 +40,15 @@ overview: true
 
 <section class="hero-second-level no-padding" id="what">
     <div class="bg-img">
-        <img src="/img/metron_sky.png" alt="What Apache Metron Does" style="width: 100%; left: 0px;">
+        <img src="/img/metron_sky.png" alt="What Apache Metron (Incubating) Does" style="width: 100%; left: 0px;">
     </div>
     <div class="v-middle-wrapper">
         <div class="v-middle-inner">
             <div class="v-middle text-center">
-              <h1>What Apache Metron Does </h1>
+              <h1>What Apache Metron (Incubating) Does </h1>
               <br />
                       
-            <p>Apache Metron provides a scalable advanced security analytics framework built with the Hadoop Community evolving from the Cisco OpenSOC Project. A cyber security application framework that provides organizations the ability to detect cyber anomalies and enable organizations to rapidly respond to identified anomalies.</p>
+            <p>Apache Metron (Incubating) provides a scalable advanced security analytics framework built with the Hadoop Community evolving from the Cisco OpenSOC Project. A cyber security application framework that provides organizations the ability to detect cyber anomalies and enable organizations to rapidly respond to identified anomalies.</p>
                 <div class="hover-btn text-center">
                         <a class="button-default" href="https://cwiki.apache.org/confluence/display/METRON/About+Metron" target="_blank"> MORE</a>
                 </div>   

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Apache Metron Community
+title: Apache Metron (Incubating) Community
 ---
 
 <section class="hero-second-level no-padding">


### PR DESCRIPTION
It has come to my attention that the website is out of compliance in the following ways:
* Our "Download" link is to the github repository releases page, which may or may not be officially apache releases (every tag and RC results in a release there). It should go to the official Apache releases website for Metron.
* We are insufficiently prominent with our "Incubating" status. Really, when we refer to "Apache Metron" it should come with the parenthetical "Incubating."  It appears that this requirement is a bit fluid, so outside of the index page, just the first mention of Metron is corrected.

