### PR TITLE
METRON-592: Change popup to Warning message in Assign Master page for Client check

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/service_advisor.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/0.3.0/service_advisor.py
@@ -79,16 +79,16 @@ class METRON030ServiceAdvisor(service_advisor.ServiceAdvisor):
         # Enrichment Master also needs ZK Client, but this is already guaranteed by being colocated with Parsers Master
         if metronParsersHost not in zookeeperClientHosts:
             message = "Metron must be co-located with an instance of Zookeeper Client"
-            items.append({ "type": 'host-component', "level": 'ERROR', "message": message, "component-name": 'METRON_PARSERS', "host": metronParsersHost })
+            items.append({ "type": 'host-component', "level": 'WARN', "message": message, "component-name": 'METRON_PARSERS', "host": metronParsersHost })
 
             # Enrichment Master also needs HDFS clients, but this is already guaranteed by being colocated with Parsers Master
         if metronParsersHost not in hdfsClientHosts:
             message = "Metron must be co-located with an instance of HDFS Client"
-            items.append({ "type": 'host-component', "level": 'ERROR', "message": message, "component-name": 'METRON_PARSERS', "host": metronParsersHost })
+            items.append({ "type": 'host-component', "level": 'WARN', "message": message, "component-name": 'METRON_PARSERS', "host": metronParsersHost })
 
         if metronEnrichmentMaster not in hbaseClientHosts:
             message = "Metron Enrichment Master must be co-located with an instance of HBase Client"
-            items.append({ "type": 'host-component', "level": 'ERROR', "message": message, "component-name": 'METRON_ENRICHMENT_MASTER', "host": metronEnrichmentMaster })
+            items.append({ "type": 'host-component', "level": 'WARN', "message": message, "component-name": 'METRON_ENRICHMENT_MASTER', "host": metronEnrichmentMaster })
 
         return items
 


### PR DESCRIPTION
Testing Steps:
Created a Mpack from the modified log level and tested Ambari deploy.

Please see screenshots below where this change is reflected.
![enrichment-fixed-warning-popup](https://cloud.githubusercontent.com/assets/20395490/20700446/7075e7c4-b633-11e6-954a-206ed306253d.png)

![parsers-fixed-warning-popup](https://cloud.githubusercontent.com/assets/20395490/20700462/80fe3196-b633-11e6-97e0-aa2e4053a85a.png)
