### PR TITLE
METRON-597 Sporadic Failures of Profiler Integration Tests

### DIFF
--- a/metron-analytics/metron-profiler/pom.xml
+++ b/metron-analytics/metron-profiler/pom.xml
@@ -260,6 +260,10 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.12.4</version>
                 <configuration>
+                    <excludes>
+                      <!-- TODO need to re-enable these test per METRON-597 -->
+                      <exclude>**/ProfilerIntegrationTest.java</exclude>
+                    </excludes>
                     <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
                     <argLine>-Xmx2048m</argLine>
                     <skip>true</skip>

--- a/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/integration/ProfilerIntegrationTest.java
+++ b/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/integration/ProfilerIntegrationTest.java
@@ -126,7 +126,8 @@ public class ProfilerIntegrationTest extends BaseIntegrationTest {
   /**
    * Tests the first example contained within the README.
    */
-  @Test
+  //@Test
+  // TODO need to re-enable these test per METRON-597
   public void testExample1() throws Exception {
 
     setup(TEST_RESOURCES + "/config/zookeeper/readme-example-1");
@@ -151,7 +152,8 @@ public class ProfilerIntegrationTest extends BaseIntegrationTest {
   /**
    * Tests the second example contained within the README.
    */
-  @Test
+  //@Test
+  // TODO need to re-enable these test per METRON-597
   public void testExample2() throws Exception {
 
     setup(TEST_RESOURCES + "/config/zookeeper/readme-example-2");
@@ -181,7 +183,8 @@ public class ProfilerIntegrationTest extends BaseIntegrationTest {
   /**
    * Tests the third example contained within the README.
    */
-  @Test
+  //@Test
+  // TODO need to re-enable these test per METRON-597
   public void testExample3() throws Exception {
 
     setup(TEST_RESOURCES + "/config/zookeeper/readme-example-3");
@@ -203,7 +206,8 @@ public class ProfilerIntegrationTest extends BaseIntegrationTest {
     Assert.assertEquals(20.0, actual, 0.01);
   }
 
-  @Test
+  //@Test
+  // TODO need to re-enable these test per METRON-597
   public void testWriteInteger() throws Exception {
 
     setup(TEST_RESOURCES + "/config/zookeeper/write-integer");
@@ -227,7 +231,8 @@ public class ProfilerIntegrationTest extends BaseIntegrationTest {
     actuals.forEach(actual -> Assert.assertEquals(10.0, actual, 0.01));
   }
 
-  @Test
+  //@Test
+  // TODO need to re-enable these test per METRON-597
   public void testPercentiles() throws Exception {
 
     setup(TEST_RESOURCES + "/config/zookeeper/percentiles");

--- a/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/integration/ProfilerIntegrationTest.java
+++ b/metron-analytics/metron-profiler/src/test/java/org/apache/metron/profiler/integration/ProfilerIntegrationTest.java
@@ -126,8 +126,7 @@ public class ProfilerIntegrationTest extends BaseIntegrationTest {
   /**
    * Tests the first example contained within the README.
    */
-  //@Test
-  // TODO need to re-enable these test per METRON-597
+  @Test
   public void testExample1() throws Exception {
 
     setup(TEST_RESOURCES + "/config/zookeeper/readme-example-1");
@@ -152,8 +151,7 @@ public class ProfilerIntegrationTest extends BaseIntegrationTest {
   /**
    * Tests the second example contained within the README.
    */
-  //@Test
-  // TODO need to re-enable these test per METRON-597
+  @Test
   public void testExample2() throws Exception {
 
     setup(TEST_RESOURCES + "/config/zookeeper/readme-example-2");
@@ -183,8 +181,7 @@ public class ProfilerIntegrationTest extends BaseIntegrationTest {
   /**
    * Tests the third example contained within the README.
    */
-  //@Test
-  // TODO need to re-enable these test per METRON-597
+  @Test
   public void testExample3() throws Exception {
 
     setup(TEST_RESOURCES + "/config/zookeeper/readme-example-3");
@@ -206,8 +203,7 @@ public class ProfilerIntegrationTest extends BaseIntegrationTest {
     Assert.assertEquals(20.0, actual, 0.01);
   }
 
-  //@Test
-  // TODO need to re-enable these test per METRON-597
+  @Test
   public void testWriteInteger() throws Exception {
 
     setup(TEST_RESOURCES + "/config/zookeeper/write-integer");
@@ -231,8 +227,7 @@ public class ProfilerIntegrationTest extends BaseIntegrationTest {
     actuals.forEach(actual -> Assert.assertEquals(10.0, actual, 0.01));
   }
 
-  //@Test
-  // TODO need to re-enable these test per METRON-597
+  @Test
   public void testPercentiles() throws Exception {
 
     setup(TEST_RESOURCES + "/config/zookeeper/percentiles");


### PR DESCRIPTION
Disabling the Profiler integration tests which are failing sporadically.  Short-term work around to ease some pain.  Will re-enable once a true fix has been found.