### PR TITLE
METRON-601 MockHTable Put Log is Not Thread Safe

### DIFF
--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/stellar/DefaultStellarExecutor.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/stellar/DefaultStellarExecutor.java
@@ -20,7 +20,6 @@
 
 package org.apache.metron.profiler.stellar;
 
-import org.apache.commons.lang.ClassUtils;
 import org.apache.metron.common.dsl.Context;
 import org.apache.metron.common.dsl.functions.resolver.FunctionResolver;
 import org.apache.metron.common.dsl.MapVariableResolver;
@@ -115,7 +114,7 @@ public class DefaultStellarExecutor implements StellarExecutor, Serializable {
     T result = ConversionUtils.convert(resultObject, clazz);
     if (result == null) {
       throw new IllegalArgumentException(String.format("Unexpected type: expected=%s, actual=%s, expression=%s",
-              clazz.getSimpleName(), ClassUtils.getShortClassName(resultObject, "null"), expression));
+              clazz.getSimpleName(), resultObject.getClass().getSimpleName(), expression));
     }
 
     return result;

--- a/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/stellar/DefaultStellarExecutor.java
+++ b/metron-analytics/metron-profiler-common/src/main/java/org/apache/metron/profiler/stellar/DefaultStellarExecutor.java
@@ -20,6 +20,7 @@
 
 package org.apache.metron.profiler.stellar;
 
+import org.apache.commons.lang.ClassUtils;
 import org.apache.metron.common.dsl.Context;
 import org.apache.metron.common.dsl.functions.resolver.FunctionResolver;
 import org.apache.metron.common.dsl.MapVariableResolver;
@@ -114,7 +115,7 @@ public class DefaultStellarExecutor implements StellarExecutor, Serializable {
     T result = ConversionUtils.convert(resultObject, clazz);
     if (result == null) {
       throw new IllegalArgumentException(String.format("Unexpected type: expected=%s, actual=%s, expression=%s",
-              clazz.getSimpleName(), resultObject.getClass().getSimpleName(), expression));
+              clazz.getSimpleName(), ClassUtils.getShortClassName(resultObject, "null"), expression));
     }
 
     return result;

--- a/metron-platform/metron-test-utilities/src/main/java/org/apache/metron/test/mock/MockHTable.java
+++ b/metron-platform/metron-test-utilities/src/main/java/org/apache/metron/test/mock/MockHTable.java
@@ -463,12 +463,12 @@ public class MockHTable implements HTableInterface {
   }
 
   public List<Put> getPutLog() {
-    return ImmutableList.copyOf(putLog.get());
+    return ImmutableList.copyOf(putLog);
   }
 
   @Override
   public void put(Put put) throws IOException {
-    putLog.get().add(put);
+    putLog.add(put);
 
     byte[] row = put.getRow();
     NavigableMap<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>> rowData = forceFind(data, row, new TreeMap<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>>(Bytes.BYTES_COMPARATOR));

--- a/metron-platform/metron-test-utilities/src/main/java/org/apache/metron/test/mock/MockHTable.java
+++ b/metron-platform/metron-test-utilities/src/main/java/org/apache/metron/test/mock/MockHTable.java
@@ -18,8 +18,6 @@
 package org.apache.metron.test.mock;
 
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
@@ -52,6 +50,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -94,7 +93,7 @@ public class MockHTable implements HTableInterface {
   private final String tableName;
   private final List<String> columnFamilies = new ArrayList<>();
   private HColumnDescriptor[] descriptors;
-  private Supplier<List<Put>> putLog;
+  private List<Put> putLog;
   private NavigableMap<byte[], NavigableMap<byte[], NavigableMap<byte[], NavigableMap<Long, byte[]>>>> data
           = new TreeMap<>(Bytes.BYTES_COMPARATOR);
 
@@ -123,7 +122,7 @@ public class MockHTable implements HTableInterface {
   }
   public MockHTable(String tableName) {
     this.tableName = tableName;
-    this.putLog = Suppliers.memoize(() -> new ArrayList<Put>());
+    this.putLog = Collections.synchronizedList(new ArrayList<>());
   }
 
   public MockHTable(String tableName, String... columnFamilies) {


### PR DESCRIPTION
[METRON-601](https://issues.apache.org/jira/browse/METRON-601)

The MockHTable uses an ArrayList to store a log of Puts that have been submitted against the MockHTable. The MockHTable, along with the put log, is accessed from multiple threads during the integration tests. Access to the Put log is not thread safe, which is likely at least one cause of [METRON-597](https://issues.apache.org/jira/browse/METRON-597).

The Put log is used by multiple tests, but more so by the ProfilerIntegrationTest. This tests polls the list to block the thread until the expected number of Puts have been submitted. This is likely why this test is more impacted by this issue than others.

The Put Log needs to made thread safe.  See `org.apache.metron.test.mock.MockHTable.putLog`.  This is the smallest change that I could think of that would address the issue.

I have triggered this code to run in Travis CI many times without seeing a failure.  Prior to this the Travis CI builds would more likely fail than not.  I have also continually run the impacted tests over many hours without replicating the problem.  In all fairness, on the current master branch without this fix, I was only able to replicate the problem once on my local machine (after running many hours.)