### PR TITLE
METRON-603 Update website to use Apache release repo

### DIFF
--- a/site/_includes/primary-nav-items.html
+++ b/site/_includes/primary-nav-items.html
@@ -10,6 +10,6 @@
     <li class="training-menu"><a href="/news/">News</a>
     </li>
     <li>
-        <button class="button-default button-green trigger-top-form"> <a href="https://github.com/apache/incubator-metron/releases" target="new">Download </a></button>
+        <button class="button-default button-green trigger-top-form"> <a href="https://dist.apache.org/repos/dist/release/incubator/metron/" target="new">Download </a></button>
     </li>
 </ul>


### PR DESCRIPTION
Update the DOWNLOAD link on the navigation menu of the website to point to the Apache release repository.

Verified site by following instructions on wiki [1].

NOTE: I'm holding off committing my recent PR (#382) to asf-site until this is fully merged to ensure consistency on the website.

[1] https://cwiki.apache.org/confluence/display/METRON/Website+PR+Merge
