### PR TITLE
METRON-644 RPM builds only work with Docker for Mac

### DIFF
--- a/metron-deployment/README.md
+++ b/metron-deployment/README.md
@@ -163,7 +163,6 @@ Components in the RPMs:
 
 ### Prerequisites
 - Docker.  The image detailed in: `metron-deployment/packaging/docker/rpm-docker/README.md` will automatically be built (or rebuilt if necessary).
-- On Mac, Docker Toolbox's handling of ownership causes permissions issues in the Docker container.  Please use Docker for Mac instead.
 - Artifacts for metron-platform have been produced.  E.g. `mvn clean package -DskipTests` in `metron-platform`
 
 ### Building RPMs

--- a/metron-deployment/packaging/docker/rpm-docker/build.sh
+++ b/metron-deployment/packaging/docker/rpm-docker/build.sh
@@ -28,7 +28,7 @@ PRERELEASE=$(echo ${FULL_VERSION} | tr -d '"'"'[:digit:]\.'"'"')
 echo "PRERELEASE: ${PRERELEASE}"
 
 # Account for non-existent file owner in container
-# Ignore UID=0, Docker for Mac returns non-zero
+# Ignore UID=0, root exists in all containers
 OWNER_UID=`ls -n SPECS/metron.spec | awk -F' ' '{ print $3 }'`
 id $OWNER_UID >/dev/null 2>&1
 if [ $? -ne 0 ] && [ $OWNER_UID -ne 0 ]; then

--- a/metron-deployment/packaging/docker/rpm-docker/build.sh
+++ b/metron-deployment/packaging/docker/rpm-docker/build.sh
@@ -27,6 +27,16 @@ echo "VERSION: ${VERSION}"
 PRERELEASE=$(echo ${FULL_VERSION} | tr -d '"'"'[:digit:]\.'"'"')
 echo "PRERELEASE: ${PRERELEASE}"
 
+# Account for non-existent file owner in container
+OWNER_UID=`ls -n SPECS/metron.spec | awk -F' ' '{ print $3 }'`
+id $OWNER_UID >/dev/null 2>&1
+if [ $? -ne 0 ]; then
+  useradd -u $OWNER_UID builder
+fi
+
 rm -rf SRPMS/ RPMS/ && \
 rpmbuild -v -ba --define "_topdir $(pwd)" --define "_version ${VERSION}" --define "_prerelease ${PRERELEASE}" SPECS/metron.spec && \
 rpmlint -i SPECS/metron.spec RPMS/*/metron* SRPMS/metron
+
+# Ensure original user permissions are maintained after build
+chown -R $OWNER_UID *


### PR DESCRIPTION
Currently using the rpm-docker image to build the project RPMs will only succeed using Docker for Mac due to the way it handles permissions. When using docker-machine/boot2docker, "Bad owner/group" build errors occur due to the SPEC and SOURCE files having an owner uid which does not map to an existing user within the container.

Some background. When using Docker for Mac any volume mounted from the host into the container is munged into being owned by the running user within the container. Hence there are no permissions issues like we see with docker-machine/boot2docker.

Modified the build.sh script to ensure the owner uid of the metron.spec file maps to an existing user in the container and that the rpms post-build are owned by the same user.

Tested on Docker for Mac, docker-machine/boot2docker, and a local docker-engine on Linux. RPMs build as expected in each case.
