### PR TITLE
METRON-635: Vagrant provisioning fails on CentOS hosts

### DIFF
--- a/metron-deployment/vagrant/full-dev-platform/ansible.cfg
+++ b/metron-deployment/vagrant/full-dev-platform/ansible.cfg
@@ -23,5 +23,7 @@ log_path = ./ansible.log
 
 
 # fix for "ssh throws 'unix domain socket too long' " problem
+# and provisioning issues with certain host OSs
 [ssh_connection]
 control_path = %(directory)s/%%h-%%p-%%r
+scp_if_ssh = True

--- a/metron-deployment/vagrant/quick-dev-platform/ansible.cfg
+++ b/metron-deployment/vagrant/quick-dev-platform/ansible.cfg
@@ -23,5 +23,7 @@ log_path = ./ansible.log
 
 
 # fix for "ssh throws 'unix domain socket too long' " problem
+# and provisioning issues with certain host OSs
 [ssh_connection]
 control_path = %(directory)s/%%h-%%p-%%r
+scp_if_ssh = True


### PR DESCRIPTION
## Problem
Vagrant provisioning of full or quick-dev fails when using various hosts (specifically tested on CentOS 6.8) with the following error message. 
```
fatal: [node1]: FAILED! => {"failed": true, "msg": "ERROR! failed to transfer file to /home/vagrant/.ansible/tmp/ansible-tmp-1483495876.66-189750710960299/setup:\n\nsftp: illegal option -- i\nusage: sftp [-1Cv] [-B buffer_size] [-b batchfile] [-F ssh_config]\n            [-o ssh_option] [-P sftp_server_path] [-R num_requests]\n            [-S program] [-s subsystem | sftp_server] host\n            sftp [user@]host[:file ...]\n            sftp [user@]host[:dir[/]]\n            sftp -b batchfile [user@]host\n"}
```

## Solution
Add `scp_if_ssh = True` in the appropriate ansible.cfg.

## Testing

Tested by running up full-dev-platform, quick-dev-platform, codelab-platform, and fastcapa-test-platform (testing fastcapa required merging [the PR](https://github.com/apache/incubator-metron/pull/410) for [METRON-645](https://issues.apache.org/jira/browse/METRON-645)) with and without the modifications in this PR.  I found that codelab and fastcapa did not require the modification in my environment to be successfully provisioned.