### PR TITLE
METRON-654 Create RPM Installer for Profiler

### DIFF
--- a/metron-deployment/packaging/docker/rpm-docker/SPECS/metron.spec
+++ b/metron-deployment/packaging/docker/rpm-docker/SPECS/metron.spec
@@ -49,6 +49,7 @@ Source4:        metron-solr-%{full_version}-archive.tar.gz
 Source5:        metron-enrichment-%{full_version}-archive.tar.gz
 Source6:        metron-indexing-%{full_version}-archive.tar.gz
 Source7:        metron-pcap-backend-%{full_version}-archive.tar.gz
+Source8:        metron-profiler-%{full_version}-archive.tar.gz
 
 %description
 Apache Metron provides a scalable advanced security analytics framework
@@ -78,6 +79,7 @@ tar -xzf %{SOURCE4} -C %{buildroot}%{metron_home}
 tar -xzf %{SOURCE5} -C %{buildroot}%{metron_home}
 tar -xzf %{SOURCE6} -C %{buildroot}%{metron_home}
 tar -xzf %{SOURCE7} -C %{buildroot}%{metron_home}
+tar -xzf %{SOURCE8} -C %{buildroot}%{metron_home}
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -281,6 +283,31 @@ This package installs the Metron PCAP files %{metron_home}
 %{metron_home}/bin/start_pcap_topology.sh
 %{metron_home}/flux/pcap/remote.yaml
 %attr(0644,root,root) %{metron_home}/lib/metron-pcap-backend-%{full_version}.jar
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+%package        profiler
+Summary:        Metron Profiler
+Group:          Applications/Internet
+Provides:       profiler = %{version}
+
+%description    profiler
+This package installs the Metron Profiler %{metron_home}
+
+%files          profiler
+%defattr(-,root,root,755)
+%dir %{metron_root}
+%dir %{metron_home}
+%dir %{metron_home}/config
+%dir %{metron_home}/bin
+%dir %{metron_home}/flux
+%dir %{metron_home}/flux/profiler
+%dir %{metron_home}/lib
+%{metron_home}/config/profiler.properties
+%{metron_home}/bin/start_profiler_topology.sh
+%{metron_home}/flux/profiler/remote.yaml
+%attr(0644,root,root) %{metron_home}/lib/metron-profiler-%{full_version}-uber.jar
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/metron-deployment/packaging/docker/rpm-docker/pom.xml
+++ b/metron-deployment/packaging/docker/rpm-docker/pom.xml
@@ -193,6 +193,12 @@
                                         <include>*.tar.gz</include>
                                     </includes>
                                 </resource>
+                                <resource>
+                                    <directory>${metron_dir}/metron-analytics/metron-profiler/target/</directory>
+                                    <includes>
+                                        <include>*.tar.gz</include>
+                                    </includes>
+                                </resource>
                             </resources>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### [METRON-654](https://issues.apache.org/jira/browse/METRON-654)

The Profiler currently must be installed using the Ansible deployment scripts. Prior to getting the Profiler integrated with the rest of the Ambari installation process, we need to package the Profiler in an RPM.

### Testing

I tested this change by doing the following.

(1) Build the RPMs by running the following command.
```
cd metron-deployment
mvn clean package -Pbuild-rpms
```

(2) Stand-up a host running CentOS.  I used the Bento base that is used for the Quick Dev environment.

(3) Copy the RPMs to the host.
```
scp metron-deployment/packaging/docker/rpm-docker/RPMS/noarch/metron-*.rpm vagrant@node1:/tmp/    
```

(4) Install the RPMs.
```
[root@node1 ~]# rpm -ivh metron-*.rpm
Preparing...                ########################################### [100%]
   1:metron-solr            ########################################### [ 11%]
   2:metron-profiler        ########################################### [ 22%]
   3:metron-pcap            ########################################### [ 33%]
   4:metron-parsers         ########################################### [ 44%]
   5:metron-indexing        ########################################### [ 56%]
   6:metron-enrichment      ########################################### [ 67%]
   7:metron-elasticsearch   ########################################### [ 78%]
   8:metron-data-management ########################################### [ 89%]
   9:metron-common          ########################################### [100%]
```

(5) Validate that all of the Profiler's required files exist and are valid.
```
[root@node1 ~]# ls -l /usr/metron/0.3.0/config/profiler.properties
-rw-r--r--. 1 root root 1257 Jan  3 14:59 /usr/metron/0.3.0/config/profiler.properties

[root@node1 ~]# ls -l /usr/metron/0.3.0/bin/start_profiler_topology.sh
-rwxr-xr-x. 1 root root 1080 Nov 22 22:36 /usr/metron/0.3.0/bin/start_profiler_topology.sh

[root@node1 ~]# ls -l /usr/metron/0.3.0/flux/profiler/remote.yaml
-rw-r--r--. 1 root root 3937 Jan  3 14:59 /usr/metron/0.3.0/flux/profiler/remote.yaml

[root@node1 ~]# ls -l /usr/metron/0.3.0/lib/metron-profiler-0.3.0-uber.jar
-rw-r--r--. 1 root root 62959781 Jan  9 18:26 /usr/metron/0.3.0/lib/metron-profiler-0.3.0-uber.jar
```