### PR TITLE
METRON-666 Fix javadoc doclint errors

### DIFF
--- a/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileSplitterBolt.java
+++ b/metron-analytics/metron-profiler/src/main/java/org/apache/metron/profiler/bolt/ProfileSplitterBolt.java
@@ -147,11 +147,13 @@ public class ProfileSplitterBolt extends ConfiguredProfilerBolt {
 
   /**
    * Each emitted tuple contains the following fields.
-   * <p><ol>
+   * <p>
+   * <ol>
    * <li> entity - The name of the entity.  The actual result of executing the Stellar expression.
    * <li> profile - The profile definition that the message needs applied to.
    * <li> message - The message containing JSON-formatted data that needs applied to a profile.
-   * </ol></p>
+   * </ol>
+   * <p>
    */
   @Override
   public void declareOutputFields(OutputFieldsDeclarer declarer) {

--- a/metron-analytics/metron-statistics/src/main/java/org/apache/metron/statistics/OnlineStatisticsProvider.java
+++ b/metron-analytics/metron-statistics/src/main/java/org/apache/metron/statistics/OnlineStatisticsProvider.java
@@ -41,7 +41,7 @@ public class OnlineStatisticsProvider implements StatisticsProvider, KryoSeriali
    * A sensible default for compression to use in the T-Digest.
    * As per https://github.com/tdunning/t-digest/blob/master/src/main/java/com/tdunning/math/stats/TDigest.java#L86
    * 100 is a sensible default and the number of centroids retained (to construct the sketch)
-   * is usually a smallish (usually < 10) multiple of the compression.  However, we have found through some
+   * is usually a smallish (usually less than 10) multiple of the compression.  However, we have found through some
    * testing that 150 gives a bit finer granularity for smaller numbers of data points.
    */
   public static final int COMPRESSION = 150;

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/BaseStellarProcessor.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/BaseStellarProcessor.java
@@ -129,8 +129,8 @@ public class BaseStellarProcessor<T> {
 
   /**
    * This method determines if a given rule is valid or not. If the given rule is valid then true
-   * will be returned otherwise a {@link ParseException} is thrown. If it is desired that to return a boolean
-   * whether the rule is valid or not see {@link this#validate(String, boolean, Context)}. It is important
+   * will be returned otherwise a {@link ParseException} is thrown. If it is desired to return a boolean
+   * whether the rule is valid or not, use the {@link #validate(String, boolean, Context) validate} method. It is important
    * to note that all variables will resolve to 'null.'
    *
    * @param rule The rule to validate.

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/evaluators/ComparisonExpressionEvaluator.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/evaluators/ComparisonExpressionEvaluator.java
@@ -23,8 +23,9 @@ import org.apache.metron.common.stellar.generated.StellarParser;
 
 /**
  * This is used to determine what is needed to evaluate a Stellar comparison expression. A Stellar comparison
- * expression is an expression that uses operators such as '<', '<=', '>', '>=', '==', '!=' to compare
- * values in Stellar. There are two main types of comparisons in Stellar equality ('==', '!=') and comparison ('<', '<=', '>', '>=').
+ * expression is an expression that uses operators such as {@literal '<', '<=', '>', '>=', '==', '!=' } to compare
+ * values in Stellar. There are two main types of comparisons in Stellar,
+ * {@literal equality ('==', '!=') and comparison ('<', '<=', '>', '>='). }
  */
 public interface ComparisonExpressionEvaluator {
 
@@ -33,8 +34,8 @@ public interface ComparisonExpressionEvaluator {
    * to return.
    * @param left  The token representing the left side of a comparison expression.
    * @param right The token representing the right side of a comparison expression.
-   * @param op    This is a representation of a comparison operator (eg. <, <=, >, >=, ==, !=)
-   * @return True if the the if the expressions is evaluated to be true, otherwise false. An example of expressions that
+   * @param op    This is a representation of a comparison operator {@literal (eg. <, <=, >, >=, ==, !=) }
+   * @return True if the expression is evaluated to be true, otherwise false. An example of expressions that
    * should be true are {@code 1 == 1}, {@code 1f > 0}, etc.
    */
   boolean evaluate(Token<?> left, Token<?> right, StellarParser.ComparisonOpContext op);

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/evaluators/ComparisonOperatorsEvaluator.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/evaluators/ComparisonOperatorsEvaluator.java
@@ -23,8 +23,8 @@ import org.apache.metron.common.dsl.Token;
 import org.apache.metron.common.stellar.generated.StellarParser;
 
 /**
- * {@link ComparisonOperatorsEvaluator} is used to evaluate comparison expressions using the following operator '<', '<=', '>',
- * or '>='. There are four major cases when evaluating a comparison expression.
+ * {@link ComparisonOperatorsEvaluator} is used to evaluate comparison expressions using the following
+ * operator {@literal '<', '<=', '>', or '>='.} There are four major cases when evaluating a comparison expression.
  */
 public class ComparisonOperatorsEvaluator implements ComparisonExpressionEvaluator {
 
@@ -40,7 +40,7 @@ public class ComparisonOperatorsEvaluator implements ComparisonExpressionEvaluat
    *
    * @param left  The token representing the left side of a comparison expression.
    * @param right The token representing the right side of a comparison expression.
-   * @param op    This is a representation of a comparison operator (eg. <, <=, >, >=, ==, !=)
+   * @param op    This is a representation of a comparison operator {@literal (eg. <, <=, >, >=, ==, !=) }
    * @return A boolean value based on the comparison of {@code left} and {@code right}.
    */
   @Override

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/evaluators/EqualityOperatorsEvaluator.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/evaluators/EqualityOperatorsEvaluator.java
@@ -38,7 +38,7 @@ public class EqualityOperatorsEvaluator implements ComparisonExpressionEvaluator
    * 3. Otherwise use {@code equals} method compare the left side with the right side.
    * @param left  The token representing the left side of a comparison expression.
    * @param right The token representing the right side of a comparison expression.
-   * @param op    This is a representation of a comparison operator (eg. <, <=, >, >=, ==, !=)
+   * @param op    This is a representation of a comparison operator {@literal (eg. <, <=, >, >=, ==, !=) }
    * @return A boolean value based on the comparison of {@code left} and {@code right}.
    */
   @Override

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/PausableInput.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/shell/PausableInput.java
@@ -44,7 +44,6 @@ public class PausableInput extends InputStream {
 
   /**
    * Stop mirroring stdin
-   * @throws IOException
    */
   public void pause() {
     paused = true;

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/GenericEnrichmentBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/GenericEnrichmentBolt.java
@@ -47,19 +47,17 @@ import java.util.concurrent.TimeUnit;
 /**
  * Uses an adapter to enrich telemetry messages with additional metadata
  * entries. For a list of available enrichment adapters see
- * org.apache.metron.enrichment.adapters.
- * <p/>
+ * {@link org.apache.metron.enrichment.adapters}.
+ * <p>
  * At the moment of release the following enrichment adapters are available:
- * <p/>
+ * <p>
  * <ul>
- * <p/>
  * <li>geo = attaches geo coordinates to IPs
  * <li>whois = attaches whois information to domains
  * <li>host = attaches reputation information to known hosts
  * <li>CIF = attaches information from threat intelligence feeds
- * <ul>
- * <p/>
- * <p/>
+ * </ul>
+ * <p>
  * Enrichments are optional
  **/
 

--- a/metron-platform/metron-hbase/src/main/java/org/apache/metron/hbase/client/HBaseClient.java
+++ b/metron-platform/metron-hbase/src/main/java/org/apache/metron/hbase/client/HBaseClient.java
@@ -78,7 +78,6 @@ public class HBaseClient implements Closeable {
    * @param rowKey     The row key of the Mutation.
    * @param cols       The columns affected by the Mutation.
    * @param durability The durability of the mutation.
-   * @return
    */
   public void addMutation(byte[] rowKey, ColumnList cols, Durability durability) {
 

--- a/metron-platform/metron-pcap-backend/src/main/java/org/apache/metron/spout/pcap/HDFSWriterCallback.java
+++ b/metron-platform/metron-pcap-backend/src/main/java/org/apache/metron/spout/pcap/HDFSWriterCallback.java
@@ -140,34 +140,34 @@ public class HDFSWriterCallback implements Callback {
      * Closes this resource, relinquishing any underlying resources.
      * This method is invoked automatically on objects managed by the
      * {@code try}-with-resources statement.
-     * <p/>
+     *
      * <p>While this interface method is declared to throw {@code
      * Exception}, implementers are <em>strongly</em> encouraged to
      * declare concrete implementations of the {@code close} method to
      * throw more specific exceptions, or to throw no exception at all
      * if the close operation cannot fail.
-     * <p/>
+     *
      * <p><em>Implementers of this interface are also strongly advised
      * to not have the {@code close} method throw {@link
      * InterruptedException}.</em>
-     * <p/>
-     * This exception interacts with a thread's interrupted status,
+     *
+     * <p>This exception interacts with a thread's interrupted status,
      * and runtime misbehavior is likely to occur if an {@code
      * InterruptedException} is {@linkplain Throwable#addSuppressed
      * suppressed}.
-     * <p/>
-     * More generally, if it would cause problems for an
+     *
+     * <p>More generally, if it would cause problems for an
      * exception to be suppressed, the {@code AutoCloseable.close}
      * method should not throw it.
-     * <p/>
+     *
      * <p>Note that unlike the {@link Closeable#close close}
      * method of {@link Closeable}, this {@code close} method
      * is <em>not</em> required to be idempotent.  In other words,
      * calling this {@code close} method more than once may have some
      * visible side effect, unlike {@code Closeable.close} which is
      * required to have no effect if called more than once.
-     * <p/>
-     * However, implementers of this interface are strongly encouraged
+     *
+     * <p>However, implementers of this interface are strongly encouraged
      * to make their {@code close} methods idempotent.
      *
      * @throws Exception if this resource cannot be closed

--- a/metron-platform/metron-pcap/src/main/java/org/apache/storm/kafka/CallbackCollector.java
+++ b/metron-platform/metron-pcap/src/main/java/org/apache/storm/kafka/CallbackCollector.java
@@ -149,9 +149,9 @@ public class CallbackCollector extends SpoutOutputCollector implements Serializa
      * stream must have been declared as a direct stream, and the specified task must
      * use a direct grouping on this stream to receive the message. The emitted values must be
      * immutable.
-     * <p/>
+     *
      * <p> Because no message id is specified, Storm will not track this message
-     * so ack and fail will never be called for this tuple.</p>
+     * so ack and fail will never be called for this tuple.
      *
      * @param taskId
      * @param streamId
@@ -170,9 +170,9 @@ public class CallbackCollector extends SpoutOutputCollector implements Serializa
      * stream must have been declared as a direct stream, and the specified task must
      * use a direct grouping on this stream to receive the message. The emitted values must be
      * immutable.
-     * <p/>
+     *
      * <p> Because no message id is specified, Storm will not track this message
-     * so ack and fail will never be called for this tuple.</p>
+     * so ack and fail will never be called for this tuple.
      *
      * @param taskId
      * @param tuple

--- a/metron-platform/metron-test-utilities/src/main/java/org/apache/metron/test/mock/MockHTable.java
+++ b/metron-platform/metron-test-utilities/src/main/java/org/apache/metron/test/mock/MockHTable.java
@@ -191,13 +191,11 @@ public class MockHTable implements HTableInterface {
 
   /**
    * Test for the existence of columns in the table, as specified by the Gets.
-   * <p/>
-   * <p/>
-   * This will return an array of booleans. Each value will be true if the related Get matches
+   *
+   * <p>This will return an array of booleans. Each value will be true if the related Get matches
    * one or more keys, false if not.
-   * <p/>
-   * <p/>
-   * This is a server-side call so it prevents any data from being transferred to
+   *
+   * <p>This is a server-side call so it prevents any data from being transferred to
    * the client.
    *
    * @param gets the Gets


### PR DESCRIPTION
Fixes for Java 8 javadocs automatic doclint problems:
- replaced many uses of `<p/>` and `</p>` with simple uses of `<p>`
- wrapped uses of `<` or `>`  in `{@literal}` or equivalent
- a couple actual errors like \@return with no description or \@throws when nothing thrown
