### PR TITLE
METRON-670 Monit Incorrectly Reports Status

### DIFF
--- a/metron-deployment/roles/monit/defaults/main.yml
+++ b/metron-deployment/roles/monit/defaults/main.yml
@@ -21,6 +21,7 @@ monit_user: admin
 monit_pass: monit
 topology_start_timeout: 120
 topology_stop_timeout: 120
+topology_status_timeout: 60
 
 bro_pid_file: /usr/local/bro/spool/bro/.pid
 elasticsearch_pid_file: /var/run/elasticsearch/elasticsearch.pid

--- a/metron-deployment/roles/monit/templates/monit/enrichment.monit
+++ b/metron-deployment/roles/monit/templates/monit/enrichment.monit
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-check program enrichment with path "{{ monit_home }}/status_enrichment_topology.sh"
+check program enrichment with path "{{ monit_home }}/status_enrichment_topology.sh" with timeout {{ topology_status_timeout }} seconds
   start program "{{ metron_directory }}/bin/start_enrichment_topology.sh" with timeout {{ topology_start_timeout }} seconds
   stop program "{{ monit_home }}/stop_enrichment_topology.sh" with timeout {{ topology_stop_timeout }} seconds
   if status != 0 then restart

--- a/metron-deployment/roles/monit/templates/monit/indexing-elasticsearch.monit
+++ b/metron-deployment/roles/monit/templates/monit/indexing-elasticsearch.monit
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-check program indexing with path "{{ monit_home }}/status_indexing_topology.sh"
+check program indexing with path "{{ monit_home }}/status_indexing_topology.sh" with timeout {{ topology_status_timeout }} seconds
   start program "{{ metron_directory }}/bin/start_elasticsearch_topology.sh" with timeout {{ topology_start_timeout }} seconds
   stop program "{{ monit_home }}/stop_indexing_topology.sh" with timeout {{ topology_stop_timeout }} seconds
   if status != 0 then restart

--- a/metron-deployment/roles/monit/templates/monit/indexing-solr.monit
+++ b/metron-deployment/roles/monit/templates/monit/indexing-solr.monit
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-check program indexing with path "{{ monit_home }}/status_indexing_topology.sh"
+check program indexing with path "{{ monit_home }}/status_indexing_topology.sh" with timeout {{ topology_status_timeout }} seconds
   start program "{{ metron_directory }}/bin/start_solr_topology.sh" with timeout {{ topology_start_timeout }} seconds
   stop program "{{ monit_home }}/stop_indexing_topology.sh" with timeout {{ topology_stop_timeout }} seconds
   if status != 0 then restart

--- a/metron-deployment/roles/monit/templates/monit/parsers.monit
+++ b/metron-deployment/roles/monit/templates/monit/parsers.monit
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-check program pcap-parser with path "{{ monit_home }}/status_pcap_topology.sh"
+check program pcap-parser with path "{{ monit_home }}/status_pcap_topology.sh" with timeout {{ topology_status_timeout }} seconds
   start program "{{ metron_directory }}/bin/start_pcap_topology.sh" with timeout {{ topology_start_timeout }} seconds
   stop program "{{ monit_home }}/stop_pcap_topology.sh" with timeout {{ topology_stop_timeout }} seconds
   if status != 0 then restart
@@ -24,7 +24,7 @@ check program pcap-parser with path "{{ monit_home }}/status_pcap_topology.sh"
   group parsers
   group metron
 
-check program yaf-parser with path "{{ monit_home }}/status_yaf_topology.sh"
+check program yaf-parser with path "{{ monit_home }}/status_yaf_topology.sh" with timeout {{ topology_status_timeout }} seconds
   start program "{{ monit_home }}/start_yaf_topology.sh" with timeout {{ topology_start_timeout }} seconds
   stop program "{{ monit_home }}/stop_yaf_topology.sh" with timeout {{ topology_stop_timeout }} seconds
   if status != 0 then restart
@@ -32,7 +32,7 @@ check program yaf-parser with path "{{ monit_home }}/status_yaf_topology.sh"
   group parsers
   group metron
 
-check program bro-parser with path "{{ monit_home }}/status_bro_topology.sh"
+check program bro-parser with path "{{ monit_home }}/status_bro_topology.sh" with timeout {{ topology_status_timeout }} seconds
   start program "{{ monit_home }}/start_bro_topology.sh" with timeout {{ topology_start_timeout }} seconds
   stop program "{{ monit_home }}/stop_bro_topology.sh" with timeout {{ topology_stop_timeout }} seconds
   if status != 0 then restart
@@ -40,7 +40,7 @@ check program bro-parser with path "{{ monit_home }}/status_bro_topology.sh"
   group parsers
   group metron
 
-check program snort-parser with path "{{ monit_home }}/status_snort_topology.sh"
+check program snort-parser with path "{{ monit_home }}/status_snort_topology.sh" with timeout {{ topology_status_timeout }} seconds
   start program "{{ monit_home }}/start_snort_topology.sh" with timeout {{ topology_start_timeout }} seconds
   stop program "{{ monit_home }}/stop_snort_topology.sh" with timeout {{ topology_stop_timeout }} seconds
   if status != 0 then restart


### PR DESCRIPTION
In a constrained environment, like 'Quick Dev', Monit will often incorrectly report the status of a Metron topology. This occurs when the environment is under load and a query of topology status exceeds the default timeout of 30 seconds. 

Added a parameter so that the timeout for a status check can be extended under these conditions. This was previously done for starting and stopping a topology, but not for a status checks.

This was tested in 'Quick Dev' and made starting, stopping and reporting status of the topologies using Monit work much better.  Previously Monit would erroneously report some of the topologies as not running when they were.  This would also interfere with your ability to start/stop the same topologies.  

For example, starting all of the services required to consume Bro telemetry works much better with this change.
```
monit -g bro start
```