### PR TITLE
METRON-672: SolrIndexingIntegrationTest fails intermittently

### DIFF
--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/integration/components/ConfigUploadComponent.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/integration/components/ConfigUploadComponent.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static org.apache.metron.common.configuration.ConfigurationsUtils.*;
@@ -39,7 +40,7 @@ public class ConfigUploadComponent implements InMemoryComponent {
   private String enrichmentConfigsPath;
   private String indexingConfigsPath;
   private String profilerConfigPath;
-  private Optional<Function<ConfigUploadComponent, Void>> postStartCallback = Optional.empty();
+  private Optional<Consumer<ConfigUploadComponent>> postStartCallback = Optional.empty();
   private Optional<String> globalConfig = Optional.empty();
   private Map<String, SensorParserConfig> parserSensorConfigs = new HashMap<>();
   public ConfigUploadComponent withTopologyProperties(Properties topologyProperties) {
@@ -80,7 +81,7 @@ public class ConfigUploadComponent implements InMemoryComponent {
     return this;
   }
 
-  public ConfigUploadComponent withPostStartCallback(Function<ConfigUploadComponent, Void> f) {
+  public ConfigUploadComponent withPostStartCallback(Consumer<ConfigUploadComponent> f) {
         this.postStartCallback = Optional.ofNullable(f);
         return this;
   }
@@ -109,7 +110,7 @@ public class ConfigUploadComponent implements InMemoryComponent {
     return profilerConfigPath;
   }
 
-  public Optional<Function<ConfigUploadComponent, Void>> getPostStartCallback() {
+  public Optional<Consumer<ConfigUploadComponent>> getPostStartCallback() {
     return postStartCallback;
   }
 
@@ -143,7 +144,7 @@ public class ConfigUploadComponent implements InMemoryComponent {
         writeGlobalConfigToZookeeper(globalConfig.get().getBytes(), zookeeperUrl);
       }
       if(postStartCallback.isPresent()) {
-        postStartCallback.get().apply(this);
+        postStartCallback.get().accept(this);
       }
 
     } catch (Exception e) {

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/integration/components/ConfigUploadComponent.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/integration/components/ConfigUploadComponent.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Function;
 
 import static org.apache.metron.common.configuration.ConfigurationsUtils.*;
 
@@ -38,6 +39,7 @@ public class ConfigUploadComponent implements InMemoryComponent {
   private String enrichmentConfigsPath;
   private String indexingConfigsPath;
   private String profilerConfigPath;
+  private Optional<Function<ConfigUploadComponent, Void>> postStartCallback = Optional.empty();
   private Optional<String> globalConfig = Optional.empty();
   private Map<String, SensorParserConfig> parserSensorConfigs = new HashMap<>();
   public ConfigUploadComponent withTopologyProperties(Properties topologyProperties) {
@@ -78,6 +80,47 @@ public class ConfigUploadComponent implements InMemoryComponent {
     return this;
   }
 
+  public ConfigUploadComponent withPostStartCallback(Function<ConfigUploadComponent, Void> f) {
+        this.postStartCallback = Optional.ofNullable(f);
+        return this;
+  }
+
+  public Properties getTopologyProperties() {
+    return topologyProperties;
+  }
+
+  public String getGlobalConfigPath() {
+    return globalConfigPath;
+  }
+
+  public String getParserConfigsPath() {
+    return parserConfigsPath;
+  }
+
+  public String getEnrichmentConfigsPath() {
+    return enrichmentConfigsPath;
+  }
+
+  public String getIndexingConfigsPath() {
+    return indexingConfigsPath;
+  }
+
+  public String getProfilerConfigPath() {
+    return profilerConfigPath;
+  }
+
+  public Optional<Function<ConfigUploadComponent, Void>> getPostStartCallback() {
+    return postStartCallback;
+  }
+
+  public Optional<String> getGlobalConfig() {
+    return globalConfig;
+  }
+
+  public Map<String, SensorParserConfig> getParserSensorConfigs() {
+    return parserSensorConfigs;
+  }
+
   @Override
   public void start() throws UnableToStartException {
     try {
@@ -98,6 +141,9 @@ public class ConfigUploadComponent implements InMemoryComponent {
 
       if(globalConfig.isPresent()) {
         writeGlobalConfigToZookeeper(globalConfig.get().getBytes(), zookeeperUrl);
+      }
+      if(postStartCallback.isPresent()) {
+        postStartCallback.get().apply(this);
       }
 
     } catch (Exception e) {

--- a/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
+++ b/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
@@ -159,10 +159,9 @@ public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
                 e.printStackTrace();
               }
               isLoaded.set(true);
-              return null;
               }
             );
-            ;
+
     FluxTopologyComponent fluxComponent = new FluxTopologyComponent.Builder()
             .withTopologyLocation(new File(fluxPath))
             .withTopologyName("test")
@@ -217,10 +216,7 @@ public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
         }
       }
       while(bytes == null || bytes.length == 0);
-      return;
     }
-
-
   }
 
   public List<Map<String, Object>> cleanDocs(ProcessorResult<List<Map<String, Object>>> result) {

--- a/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
+++ b/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
@@ -21,8 +21,10 @@ package org.apache.metron.indexing.integration;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
+import org.apache.curator.framework.CuratorFramework;
 import org.apache.metron.TestConstants;
 import org.apache.metron.common.Constants;
+import org.apache.metron.common.configuration.ConfigurationsUtils;
 import org.apache.metron.common.interfaces.FieldNameConverter;
 import org.apache.metron.common.spout.kafka.SpoutConfig;
 import org.apache.metron.common.utils.JSONUtils;
@@ -37,13 +39,18 @@ import org.apache.metron.integration.components.KafkaComponent;
 import org.apache.metron.integration.components.ZKServerComponent;
 import org.apache.metron.integration.utils.TestUtils;
 import org.apache.storm.hdfs.bolt.rotation.TimedRotationPolicy;
+import org.apache.zookeeper.KeeperException;
 import org.junit.Assert;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.apache.metron.common.configuration.ConfigurationsUtils.getClient;
 
 public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
   protected String hdfsDir = "target/indexingIntegrationTest/hdfs";
@@ -139,11 +146,22 @@ public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
       inputDocs.add(m);
 
     }
+    final AtomicBoolean isLoaded = new AtomicBoolean(false);
     ConfigUploadComponent configUploadComponent = new ConfigUploadComponent()
             .withTopologyProperties(topologyProperties)
             .withGlobalConfigsPath(TestConstants.SAMPLE_CONFIG_PATH)
             .withEnrichmentConfigsPath(TestConstants.SAMPLE_CONFIG_PATH)
             .withIndexingConfigsPath(TestConstants.SAMPLE_CONFIG_PATH)
+            .withPostStartCallback(component -> {
+              try {
+                waitForIndex(component.getTopologyProperties().getProperty(ZKServerComponent.ZOOKEEPER_PROPERTY));
+              } catch (Exception e) {
+                e.printStackTrace();
+              }
+              isLoaded.set(true);
+              return null;
+              }
+            );
             ;
     FluxTopologyComponent fluxComponent = new FluxTopologyComponent.Builder()
             .withTopologyLocation(new File(fluxPath))
@@ -166,10 +184,11 @@ public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
     runner.start();
 
     try {
+      while(!isLoaded.get()) {
+        Thread.sleep(100);
+      }
       fluxComponent.submitTopology();
-
       kafkaComponent.writeMessages(Constants.INDEXING_TOPIC, inputMessages);
-      StringBuffer buffer = new StringBuffer();
       List<Map<String, Object>> docs = cleanDocs(runner.process(getProcessor(inputMessages)));
       Assert.assertEquals(docs.size(), inputMessages.size());
       //assert that our input docs are equivalent to the output docs, converting the input docs keys based
@@ -182,6 +201,26 @@ public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
         runner.stop();
       }
     }
+  }
+
+  private void waitForIndex(String zookeeperQuorum) throws Exception {
+    try(CuratorFramework client = getClient(zookeeperQuorum)) {
+      client.start();
+      byte[] bytes = null;
+      do {
+        try {
+          bytes = ConfigurationsUtils.readSensorIndexingConfigBytesFromZookeeper(testSensorType, client);
+          Thread.sleep(1000);
+        }
+        catch(KeeperException.NoNodeException nne) {
+          //kindly ignore because the path might not exist just yet.
+        }
+      }
+      while(bytes == null || bytes.length == 0);
+      return;
+    }
+
+
   }
 
   public List<Map<String, Object>> cleanDocs(ProcessorResult<List<Map<String, Object>>> result) {

--- a/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/BaseIntegrationTest.java
+++ b/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/BaseIntegrationTest.java
@@ -33,13 +33,7 @@ public abstract class BaseIntegrationTest {
 
     protected static ZKServerComponent getZKServerComponent(final Properties topologyProperties) {
         return new ZKServerComponent()
-                .withPostStartCallback(new Function<ZKServerComponent, Void>() {
-                    @Nullable
-                    @Override
-                    public Void apply(@Nullable ZKServerComponent zkComponent) {
-                        topologyProperties.setProperty(ZKServerComponent.ZOOKEEPER_PROPERTY, zkComponent.getConnectionString());
-                        return null;
-                    }
-                });
+                .withPostStartCallback((zkComponent) -> topologyProperties.setProperty(ZKServerComponent.ZOOKEEPER_PROPERTY, zkComponent.getConnectionString())
+                );
     }
 }

--- a/metron-platform/metron-pcap-backend/src/test/java/org/apache/metron/pcap/integration/PcapTopologyIntegrationTest.java
+++ b/metron-platform/metron-pcap-backend/src/test/java/org/apache/metron/pcap/integration/PcapTopologyIntegrationTest.java
@@ -215,14 +215,9 @@ public class PcapTopologyIntegrationTest {
     }};
     updatePropertiesCallback.apply(topologyProperties);
 
-    final ZKServerComponent zkServerComponent = new ZKServerComponent().withPostStartCallback(new Function<ZKServerComponent, Void>() {
-      @Nullable
-      @Override
-      public Void apply(@Nullable ZKServerComponent zkComponent) {
-        topologyProperties.setProperty(ZKServerComponent.ZOOKEEPER_PROPERTY, zkComponent.getConnectionString());
-        return null;
-      }
-    });
+    final ZKServerComponent zkServerComponent = new ZKServerComponent().withPostStartCallback(
+            (zkComponent) -> topologyProperties.setProperty(ZKServerComponent.ZOOKEEPER_PROPERTY, zkComponent.getConnectionString())
+    );
     final KafkaComponent kafkaComponent = new KafkaComponent().withTopics(new ArrayList<KafkaComponent.Topic>() {{
       add(new KafkaComponent.Topic(KAFKA_TOPIC, 1));
     }}).withTopologyProperties(topologyProperties);


### PR DESCRIPTION
This failure is due to a change in default behavior when indexing was split off into a separate configuration file.  The default batch size was changed from `5` to `1` in particular.  This, by itself, is not a problem, but the `IndexingIntegrationTest` (base class for Solr and Elastic search integration tests):
* submits the configs
* starts the indexing topology
* writes the input data

The writing of the input data may happen before the topology fully loads or the configuration fully loads, especially if the machine running the unit tests is under load (like with travis).  As a result, the first record may end up with the default batch size (of 1) and write out immediately because the indexing configs haven't loaded into zookeeper just yet.  In that circumstance, eventually the configs load and the batch size is set to `5`.  Meanwhile we've written 10 records and are expecting 10 in return, but because you wrote the first out already and then the next 5, we have another 4 pending to be written by the `BulkMessageWriterBolt`.

So, the failure scenario is as follows:
* Message 1 is received and the indexing config hasn't loaded yet, so the batch size is 1 and it immediately gets written out
* Message 2 - 5 are each received and the indexing config has loaded, so the batch size is 5 and it queues up
* Message 6 is received and the batch writes out
* Messages 7 - 10 are received, but never make a full batch, so we time out waiting for them to write out

The fix is to ensure that we don't write out messages to kafka until the configs are loaded, which is what this PR does.