### PR TITLE
METRON-675: Make Threat Triage rules able to be assigned names and comments

### DIFF
--- a/metron-analytics/metron-maas-service/README.md
+++ b/metron-analytics/metron-maas-service/README.md
@@ -169,9 +169,12 @@ Now that we have a deployed model, let's adjust the configurations for the Squid
   "threatIntel" : {
     "fieldMap":{},
     "triageConfig" : {
-      "riskLevelRules" : {
-        "is_malicious == 'malicious'" : 100
-      },
+      "riskLevelRules" : [
+        {
+          "rule" : "is_malicious == 'malicious'",
+          "score" : 100
+        }
+      ],
       "aggregator" : "MAX"
     }
   }

--- a/metron-analytics/metron-statistics/README.md
+++ b/metron-analytics/metron-statistics/README.md
@@ -324,9 +324,12 @@ PROFILE_GET( 'sketchy_mad', 'global', 10, 'MINUTES') ), value)"
     "fieldMap": { },
     "fieldToTypeMap": { },
     "triageConfig" : {
-      "riskLevelRules" : {
-        "parser_score > 3.5" : 10
-      },
+      "riskLevelRules" : [
+        {
+          "rule" : "parser_score > 3.5",
+          "score" : 10
+        }
+      ],
       "aggregator" : "MAX"
     }
   }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/threatintel/RiskLevelRule.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/threatintel/RiskLevelRule.java
@@ -1,0 +1,73 @@
+package org.apache.metron.common.configuration.enrichment.threatintel;
+
+public class RiskLevelRule {
+  String name;
+  String comment;
+  String rule;
+  Number score;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getComment() {
+    return comment;
+  }
+
+  public void setComment(String comment) {
+    this.comment = comment;
+  }
+
+  public String getRule() {
+    return rule;
+  }
+
+  public void setRule(String rule) {
+    this.rule = rule;
+  }
+
+  public Number getScore() {
+    return score;
+  }
+
+  public void setScore(Number score) {
+    this.score = score;
+  }
+
+  @Override
+  public String toString() {
+    return "RiskLevelRule{" +
+            "name='" + name + '\'' +
+            ", comment='" + comment + '\'' +
+            ", rule='" + rule + '\'' +
+            ", score=" + score +
+            '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    RiskLevelRule that = (RiskLevelRule) o;
+
+    if (name != null ? !name.equals(that.name) : that.name != null) return false;
+    if (comment != null ? !comment.equals(that.comment) : that.comment != null) return false;
+    if (rule != null ? !rule.equals(that.rule) : that.rule != null) return false;
+    return score != null ? score.equals(that.score) : that.score == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = name != null ? name.hashCode() : 0;
+    result = 31 * result + (comment != null ? comment.hashCode() : 0);
+    result = 31 * result + (rule != null ? rule.hashCode() : 0);
+    result = 31 * result + (score != null ? score.hashCode() : 0);
+    return result;
+  }
+}

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/threatintel/RiskLevelRule.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/threatintel/RiskLevelRule.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.metron.common.configuration.enrichment.threatintel;
 
 public class RiskLevelRule {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/threatintel/ThreatTriageConfig.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/enrichment/threatintel/ThreatTriageConfig.java
@@ -24,24 +24,35 @@ import org.apache.metron.common.aggregator.Aggregators;
 import org.apache.metron.common.stellar.StellarPredicateProcessor;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class ThreatTriageConfig {
-  private Map<String, Number> riskLevelRules = new HashMap<>();
+  private List<RiskLevelRule> riskLevelRules = new ArrayList<>();
   private Aggregators aggregator = Aggregators.MAX;
   private Map<String, Object> aggregationConfig = new HashMap<>();
 
-  public Map<String, Number> getRiskLevelRules() {
+  public List<RiskLevelRule> getRiskLevelRules() {
     return riskLevelRules;
   }
 
-  public void setRiskLevelRules(Map<String, Number> riskLevelRules) {
-    this.riskLevelRules = riskLevelRules;
+  public void setRiskLevelRules(List<RiskLevelRule> riskLevelRules) {
+    List<RiskLevelRule> rules = new ArrayList<>();
+    Set<String> ruleIndex = new HashSet<>();
     StellarPredicateProcessor processor = new StellarPredicateProcessor();
-    for(String rule : riskLevelRules.keySet()) {
-      processor.validate(rule);
+    for(RiskLevelRule rule : riskLevelRules) {
+      if(rule.getRule() == null || rule.getScore() == null) {
+        throw new IllegalStateException("Risk level rules must contain both a rule and a score.");
+      }
+      if(ruleIndex.contains(rule.getRule())) {
+        continue;
+      }
+      else {
+        ruleIndex.add(rule.getRule());
+      }
+      processor.validate(rule.getRule());
+      rules.add(rule);
     }
+    this.riskLevelRules = rules;
   }
 
   public Aggregators getAggregator() {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/writer/test.json
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/writer/test.json
@@ -19,9 +19,12 @@
       "ip_dst_addr" : ["malicious_ip"]
     },
     "triageConfig" : {
-      "riskLevelRules" : {
-        "ip_src_addr == '31.24.30.31'" : "Test"
-      },
+      "riskLevelRules" : [
+        {
+          "rule" : "ip_src_addr == '31.24.30.31'",
+          "score" : 10
+        }
+      ],
       "aggregator" : "MAX"
     }
   }

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/SensorEnrichmentUpdateConfigTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/configuration/SensorEnrichmentUpdateConfigTest.java
@@ -47,9 +47,12 @@ public class SensorEnrichmentUpdateConfigTest {
          ,"ip_src_addr" : [ "malicious_ip" ]
                           },
         "triageConfig" : {
-          "riskLevelRules" : {
-            "not(IN_SUBNET(ip_dst_addr, '192.168.0.0/24'))" : 10
-                             },
+          "riskLevelRules" : [
+            {
+              "rule" : "not(IN_SUBNET(ip_dst_addr, '192.168.0.0/24'))",
+              "score" : 10
+            }
+                             ],
           "aggregator" : "MAX"
                         }
       }

--- a/metron-platform/metron-enrichment/README.md
+++ b/metron-platform/metron-enrichment/README.md
@@ -123,8 +123,26 @@ The `triageConfig` field is also a complex field and it bears some description:
 
 | Field            | Description                                                                                                                                             | Example                                                                  |
 |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
-| `riskLevelRules` | The mapping of Stellar (see above) queries to a score.                                                                                                  | `"riskLevelRules" : { "IN_SUBNET(ip_dst_addr, '192.168.0.0/24')" : 10 }` |
+| `riskLevelRules` | This is a list of rules (represented as Stellar expressions) associated with scores with optional names and comments                                    |  see below|
 | `aggregator`     | An aggregation function that takes all non-zero scores representing the matching queries from `riskLevelRules` and aggregates them into a single score. | `"MAX"`                                                                  |
+
+A risk level rule is of the following format:
+* `name` : The name of the threat triage rule
+* `comment` : A comment describing the rule
+* `rule` : The rule, represented as a Stellar statement
+* `score` : Associated threat triage score for the rule
+
+An example of a rule is as follows:
+```
+    "riskLevelRules" : [ 
+        { 
+          "name" : "is internal"
+        , "comment" : "determines if the destination is internal."
+        , rule" : "IN_SUBNET(ip_dst_addr, '192.168.0.0/24')"
+        , "score" : 10 
+        }
+                       ]
+```
 
 The supported aggregation functions are:
 * `MAX` : The max of all of the associated values for matching queries
@@ -177,9 +195,12 @@ An example configuration for the YAF sensor is as follows:
       ]
     },
     "triageConfig" : {
-      "riskLevelRules" : {
-        "ip_src_addr == '10.0.2.3' or ip_dst_addr == '10.0.2.3'" : 10
-      },
+      "riskLevelRules" : [ 
+        {
+          "rule" : "ip_src_addr == '10.0.2.3' or ip_dst_addr == '10.0.2.3'",
+          "score" : 10
+        }
+      ],
       "aggregator" : "MAX"
     }
   }

--- a/metron-platform/metron-enrichment/src/main/config/zookeeper/enrichments/snort.json
+++ b/metron-platform/metron-enrichment/src/main/config/zookeeper/enrichments/snort.json
@@ -17,9 +17,12 @@
       "ip_dst_addr" : ["malicious_ip"]
     },
     "triageConfig" : {
-      "riskLevelRules" : {
-        "not(IN_SUBNET(ip_dst_addr, '192.168.0.0/24'))" : 10
-      },
+      "riskLevelRules" : [
+        {
+          "rule" : "not(IN_SUBNET(ip_dst_addr, '192.168.0.0/24'))",
+          "score" : 10
+        }
+      ],
       "aggregator" : "MAX"
     }
   }

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/ThreatIntelJoinBolt.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/bolt/ThreatIntelJoinBolt.java
@@ -132,7 +132,7 @@ public class ThreatIntelJoinBolt extends EnrichmentJoinBolt {
         ThreatTriageProcessor threatTriageProcessor = new ThreatTriageProcessor(config, functionResolver, stellarContext);
         Double triageLevel = threatTriageProcessor.apply(ret);
         if(LOG.isDebugEnabled()) {
-          String rules = Joiner.on('\n').join(triageConfig.getRiskLevelRules().entrySet());
+          String rules = Joiner.on('\n').join(triageConfig.getRiskLevelRules());
           LOG.debug("Marked " + sourceType + " as triage level " + triageLevel + " with rules " + rules);
         }
         if(triageLevel != null && triageLevel > 0) {

--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/threatintel/triage/ThreatTriageProcessor.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/threatintel/triage/ThreatTriageProcessor.java
@@ -20,6 +20,7 @@ package org.apache.metron.threatintel.triage;
 
 import com.google.common.base.Function;
 import org.apache.metron.common.configuration.enrichment.SensorEnrichmentConfig;
+import org.apache.metron.common.configuration.enrichment.threatintel.RiskLevelRule;
 import org.apache.metron.common.configuration.enrichment.threatintel.ThreatIntelConfig;
 import org.apache.metron.common.configuration.enrichment.threatintel.ThreatTriageConfig;
 import org.apache.metron.common.dsl.*;
@@ -55,9 +56,9 @@ public class ThreatTriageProcessor implements Function<Map, Double> {
     List<Number> scores = new ArrayList<>();
     StellarPredicateProcessor predicateProcessor = new StellarPredicateProcessor();
     VariableResolver resolver = new MapVariableResolver(input, sensorConfig.getConfiguration(), threatIntelConfig.getConfig());
-    for(Map.Entry<String, Number> kv : threatTriageConfig.getRiskLevelRules().entrySet()) {
-      if(predicateProcessor.parse(kv.getKey(), resolver, functionResolver, context)) {
-        scores.add(kv.getValue());
+    for(RiskLevelRule rule : threatTriageConfig.getRiskLevelRules()) {
+      if(predicateProcessor.parse(rule.getRule(), resolver, functionResolver, context)) {
+        scores.add(rule.getScore());
       }
     }
     return threatTriageConfig.getAggregator().aggregate(scores, threatTriageConfig.getAggregationConfig());

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/bolt/ThreatIntelJoinBoltTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/bolt/ThreatIntelJoinBoltTest.java
@@ -85,9 +85,12 @@ public class ThreatIntelJoinBoltTest extends BaseEnrichmentBoltTest {
 
   /**
    * {
-   *  "riskLevelRules" : {
-   *    "enrichedField1 == 'enrichedValue1'" : 10
-   *  },
+   *  "riskLevelRules" : [
+   *   {
+   *    "rule" : "enrichedField1 == 'enrichedValue1'",
+   *    "score" : 10
+   *   }
+   *  ],
    *  "aggregator" : "MAX"
    * }
    */
@@ -101,9 +104,12 @@ public class ThreatIntelJoinBoltTest extends BaseEnrichmentBoltTest {
 
   /**
    * {
-   *  "riskLevelRules" : {
-   *    "enrichedField1 == 'enrichedValue1": 10
-   *  },
+   *  "riskLevelRules" : [
+   *  {
+   *    "rule" : "enrichedField1 == 'enrichedValue1",
+   *    "score" : 10
+   *  }
+   *  ],
    *  "aggregator" : "MAX"
    * }
    */
@@ -122,9 +128,12 @@ public class ThreatIntelJoinBoltTest extends BaseEnrichmentBoltTest {
 
   /**
    * {
-   *   "riskLevelRules": {
-   *      "not(IN_SUBNET(ip_dst_addr, '192.168.0.0/24'))": 10
-   *   },
+   *   "riskLevelRules": [
+   *   {
+   *      "rule" : "not(IN_SUBNET(ip_dst_addr, '192.168.0.0/24'))",
+   *      "score" : 10
+   *   }
+   *   ],
    *   "aggregator": "MAX"
    * }
    */

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/threatintel/triage/ThreatTriageTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/threatintel/triage/ThreatTriageTest.java
@@ -34,12 +34,26 @@ public class ThreatTriageTest {
    * {
    *  "threatIntel": {
    *    "triageConfig": {
-   *      "riskLevelRules" : {
-   *        "user.type in [ 'admin', 'power' ] and asset.type == 'web'" : 10,
-   *        "asset.type == 'web'" : 5,
-   *        "user.type == 'normal'  and asset.type == 'web'" : 0,
-   *        "user.type in whitelist" : -1
-   *      },
+   *      "riskLevelRules" : [
+   *        {
+   *          "name" : "rule 1",
+   *          "rule" : "user.type in [ 'admin', 'power' ] and asset.type == 'web'",
+   *          "score" : 10
+   *        },
+   *        {
+   *         "comment" : "web type!",
+   *         "rule" : "asset.type == 'web'",
+   *         "score" : 5
+   *        },
+   *        {
+   *          "rule" : "user.type == 'normal'  and asset.type == 'web'",
+   *          "score" : 0
+   *        },
+   *        {
+   *          "rule" : "user.type in whitelist",
+   *          "score" : -1
+   *        }
+   *      ],
    *      "aggregator" : "MAX"
    *    },
    *    "config": {
@@ -115,11 +129,20 @@ public class ThreatTriageTest {
    * {
    *  "threatIntel": {
    *  "triageConfig": {
-   *    "riskLevelRules" : {
-   *      "user.type in [ 'admin', 'power' ] and asset.type == 'web'" : 10,
-   *      "asset.type == 'web'" : 5,
-   *      "user.type == 'normal' and asset.type == 'web'" : 0
-   *     },
+   *    "riskLevelRules" : [
+   *      {
+   *        "rule" : "user.type in [ 'admin', 'power' ] and asset.type == 'web'",
+   *        "score" : 10
+   *      },
+   *      {
+   *        "rule" : "asset.type == 'web'",
+   *        "score" : 5
+   *      },
+   *      {
+   *        "rule" : "user.type == 'normal' and asset.type == 'web'",
+   *        "score" : 0
+   *      }
+   *     ],
    *     "aggregator" : "POSITIVE_MEAN"
    *    }
    *  }
@@ -167,9 +190,12 @@ public class ThreatTriageTest {
    * {
    *    "threatIntel" : {
    *      "triageConfig": {
-   *        "riskLevelRules": {
-   *          "not(IN_SUBNET(ip_dst_addr, '192.168.0.0/24'))" : 10
-   *        },
+   *        "riskLevelRules": [
+   *          {
+   *            "rule" : "not(IN_SUBNET(ip_dst_addr, '192.168.0.0/24'))",
+   *            "score" : 10
+   *          }
+   *        ],
    *        "aggregator" : "MAX"
    *      }
    *    }

--- a/metron-platform/metron-integration-test/src/main/config/zookeeper/enrichments/test.json
+++ b/metron-platform/metron-integration-test/src/main/config/zookeeper/enrichments/test.json
@@ -59,9 +59,12 @@
       ]
     },
     "triageConfig" : {
-      "riskLevelRules" : {
-        "ip_src_addr == '10.0.2.3' or ip_dst_addr == '10.0.2.3'" : 10
-      },
+      "riskLevelRules" : [
+        {
+          "rule" : "ip_src_addr == '10.0.2.3' or ip_dst_addr == '10.0.2.3'",
+          "score": 10
+        }
+      ],
       "aggregator" : "MAX"
     }
   }

--- a/metron-platform/metron-management/README.md
+++ b/metron-platform/metron-management/README.md
@@ -533,8 +533,6 @@ Functions loaded, you may refer to functions now...
 [Stellar]>>> # Just to make sure it looks right, we can view the JSON
 [Stellar]>>> squid_enrichment_config
 {
-  "index" : "squid",
-  "batchSize" : 0,
   "enrichment" : {
     "fieldMap" : { },
     "fieldToTypeMap" : { },
@@ -552,9 +550,6 @@ Functions loaded, you may refer to functions now...
   },
   "configuration" : { }
 }
-[Stellar]>>> # Wait, that batch size looks terrible.  That is because it did not exist in zookeeper, so it is the default.
-[Stellar]>>> # We can correct it, thankfully. 
-[Stellar]>>> squid_enrichment_config := INDEXING_SET_BATCH( squid_enrichment_config, 100)
 [Stellar]>>> # Now that we have a config, we can add an enrichment to the Stellar adapter
 [Stellar]>>> # We should make sure that the current enrichment does not have any already
 [Stellar]>>> ?ENRICHMENT_STELLAR_TRANSFORM_PRINT
@@ -769,8 +764,6 @@ Please note that functions are loading lazily in the background and will be unav
 26751 [Thread-1] INFO  o.r.Reflections - Reflections took 24407 ms to scan 22 urls, producing 17898 keys and 121520 values 
 26828 [Thread-1] INFO  o.a.m.c.d.FunctionResolverSingleton - Found 84 Stellar Functions...
 Functions loaded, you may refer to functions now...
-[Stellar]>>> # Just as in the previous example, we should adjust the batch size
-[Stellar]>>> squid_enrichment_config := INDEXING_SET_BATCH( squid_enrichment_config, 100)
 [Stellar]>>> # We should not have any threat triage rules
 [Stellar]>>> THREAT_TRIAGE_PRINT(squid_enrichment_config)
 ╔═════════════╤═══════╗
@@ -853,7 +846,7 @@ Returns: A Map associated with the indicator and enrichment type.  Empty otherwi
 [Stellar]>>> non_us := whois_info.home_country != 'US'
 [Stellar]>>> is_local := IN_SUBNET( if IS_IP(ip_src_addr) then ip_src_addr else NULL, '192.168.0.0/21')
 [Stellar]>>> is_both := whois_info.home_country != 'US' && IN_SUBNET( if IS_IP(ip_src_addr) then ip_src_addr else NULL, '192.168.0.0/21')
-[Stellar]>>> rules := { SHELL_GET_EXPRESSION('non_us') : 10, SHELL_GET_EXPRESSION('is_local') : 20, SHELL_GET_EXPRESSION('is_both') : 50 }
+[Stellar]>>> rules := [ { 'rule' : SHELL_GET_EXPRESSION('non_us'), 'score' : 10 } , { 'rule' : SHELL_GET_EXPRESSION('is_local'), 'score' : 20 } , { 'rule' : SHELL_GET_EXPRESSION('is_both'), 'score' : 50 } ]
 [Stellar]>>> # Now that we have our rules staged, we can add them to our config.
 [Stellar]>>> squid_enrichment_config_new := THREAT_TRIAGE_ADD( squid_enrichment_config_new, rules )
 [Stellar]>>> THREAT_TRIAGE_PRINT(squid_enrichment_config_new)

--- a/metron-platform/metron-management/README.md
+++ b/metron-platform/metron-management/README.md
@@ -166,7 +166,7 @@ The functions are split roughly into a few sections:
   * Returns: The String representation of the config in zookeeper
 
 
-### Enrichment Functions
+### Indexing Functions
 
 * `INDEXING_SET_BATCH`
   * Description: Set batch size
@@ -189,6 +189,9 @@ The functions are split roughly into a few sections:
     * writer - The writer to update (e.g. elasticsearch, solr or hdfs)
     * sensor - sensor name
   * Returns: The String representation of the config in zookeeper
+
+### Enrichment Functions
+
 * `ENRICHMENT_STELLAR_TRANSFORM_ADD`
   * Description: Add stellar field transformation.
   * Input:
@@ -219,6 +222,7 @@ The functions are split roughly into a few sections:
   * Input:
     * sensorConfig - Sensor config to add transformation to.
     * stellarTransforms - A Map associating stellar rules to scores
+    * triageRules - Map (or list of Maps) representing a triage rule.  It must contain 'rule' and 'score' keys, the stellar expression for the rule and triage score respectively.  It may contain 'name' and 'comment', the name of the rule and comment associated with the rule respectively."
   * Returns: The String representation of the threat triage rules
 * `THREAT_TRIAGE_PRINT`
   * Description: Retrieve stellar enrichment transformations.
@@ -229,7 +233,7 @@ The functions are split roughly into a few sections:
   * Description: Remove stellar threat triage rule(s).
   * Input:
     * sensorConfig - Sensor config to add transformation to.
-    * stellarTransforms - A list of stellar rules to remove
+    * rules - A list of stellar rules or rule names to remove
   * Returns: The String representation of the enrichment config
 * `THREAT_TRIAGE_SET_AGGREGATOR`
   * Description: Set the threat triage aggregator.
@@ -541,7 +545,7 @@ Functions loaded, you may refer to functions now...
     "fieldToTypeMap" : { },
     "config" : { },
     "triageConfig" : {
-      "riskLevelRules" : { },
+      "riskLevelRules" : [ ],
       "aggregator" : "MAX",
       "aggregationConfig" : { }
     }
@@ -659,7 +663,7 @@ Returns: The String representation of the config in zookeeper
     "fieldToTypeMap" : { },
     "config" : { },
     "triageConfig" : {
-      "riskLevelRules" : { },
+      "riskLevelRules" : [ ],
       "aggregator" : "MAX",
       "aggregationConfig" : { }
     }
@@ -689,7 +693,7 @@ Returns: The String representation of the config in zookeeper
     "fieldToTypeMap" : { },
     "config" : { },
     "triageConfig" : {
-      "riskLevelRules" : { },
+      "riskLevelRules" : [ ],
       "aggregator" : "MAX",
       "aggregationConfig" : { }
     }
@@ -741,7 +745,7 @@ Returns: The String representation of the config in zookeeper
     "fieldToTypeMap" : { },
     "config" : { },
     "triageConfig" : {
-      "riskLevelRules" : { },
+      "riskLevelRules" : [ ],
       "aggregator" : "MAX",
       "aggregationConfig" : { }
     }
@@ -894,11 +898,20 @@ Aggregation: MAX
     "fieldToTypeMap" : { },
     "config" : { },
     "triageConfig" : {
-      "riskLevelRules" : {
-        "whois_info.home_country != 'US' && IN_SUBNET( if IS_IP(ip_src_addr) then ip_src_addr else NULL, '192.168.0.0/21')" : 50.0,
-        "IN_SUBNET( if IS_IP(ip_src_addr) then ip_src_addr else NULL, '192.168.0.0/21')" : 20.0,
-        "whois_info.home_country != 'US'" : 10.0
-      },
+      "riskLevelRules" : [
+        {
+          "rule" : "whois_info.home_country != 'US' && IN_SUBNET( if IS_IP(ip_src_addr) then ip_src_addr else NULL, '192.168.0.0/21')",
+          "score" : 50.0
+        },
+        {
+          "rule" : "IN_SUBNET( if IS_IP(ip_src_addr) then ip_src_addr else NULL, '192.168.0.0/21')",
+          "score" : 20.0
+        },
+        {
+          "rule" : "whois_info.home_country != 'US'",
+          "score" : 10.0
+        }
+      ],
       "aggregator" : "MAX",
       "aggregationConfig" : { }
     }
@@ -944,7 +957,7 @@ SION('is_both') ] )
     "fieldToTypeMap" : { },
     "config" : { },
     "triageConfig" : {
-      "riskLevelRules" : { },
+      "riskLevelRules" : [ ],
       "aggregator" : "MAX",
       "aggregationConfig" : { }
     }

--- a/metron-platform/metron-management/src/test/java/org/apache/metron/management/ConfigurationFunctionsTest.java
+++ b/metron-platform/metron-management/src/test/java/org/apache/metron/management/ConfigurationFunctionsTest.java
@@ -131,7 +131,7 @@ public class ConfigurationFunctionsTest {
         "fieldToTypeMap" : { },
         "config" : { },
         "triageConfig" : {
-          "riskLevelRules" : { },
+          "riskLevelRules" : [ ],
           "aggregator" : "MAX",
           "aggregationConfig" : { }
         }


### PR DESCRIPTION
There may be many, many threat triage rules. To help organize these, we should make them slightly more complex than a simple key/value as we have it now. We should add optional name and optional comment fields.

This essentially makes the risk level rules slightly more complex.  The format goes from:
```
"riskLevelRules" : {
  "stellar expression" : numeric score
}
```
to:
```
"riskLevelRules" : [
  {
     "name" : "optional name",
     "comment" : "optional comment",
     "rule" : "stellar expression",
     "score" : numeric score
  }
]
```
This is NOT backwards compatible, but I think it's more explicit and a bit more clear.

Testing plan to come in a follow-on comment.