### PR TITLE
METRON-678: Multithread the flat file loader

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/file/ReaderSpliterator.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/file/ReaderSpliterator.java
@@ -215,7 +215,11 @@ public class ReaderSpliterator implements Spliterator<String> {
   }
 
   public static Stream<String> lineStream(BufferedReader in, int batchSize) {
-    return StreamSupport.stream(new ReaderSpliterator(in, batchSize), false)
+    return lineStream(in, batchSize, false);
+  }
+
+  public static Stream<String> lineStream(BufferedReader in, int batchSize, boolean isParallel) {
+    return StreamSupport.stream(new ReaderSpliterator(in, batchSize), isParallel)
                         .onClose(() -> {
                           try {
                             in.close();

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/file/ReaderSpliterator.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/file/ReaderSpliterator.java
@@ -1,0 +1,218 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.common.utils.file;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static java.util.Spliterators.spliterator;
+
+public class ReaderSpliterator implements Spliterator<String> {
+  private static int characteristics = NONNULL | ORDERED | IMMUTABLE;
+  private int batchSize ;
+  private BufferedReader reader;
+  public ReaderSpliterator(BufferedReader reader) {
+    this(reader, 128);
+  }
+
+  public ReaderSpliterator(BufferedReader reader, int batchSize) {
+    this.batchSize = batchSize;
+    this.reader = reader;
+  }
+
+  @Override
+  public void forEachRemaining(Consumer<? super String> action) {
+    if (action == null) {
+      throw new NullPointerException();
+    }
+    try {
+      for (String line = null; (line = reader.readLine()) != null;) {
+        action.accept(line);
+      }
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+  /**
+   * If a remaining element exists, performs the given action on it,
+   * returning {@code true}; else returns {@code false}.  If this
+   * Spliterator is {@link #ORDERED} the action is performed on the
+   * next element in encounter order.  Exceptions thrown by the
+   * action are relayed to the caller.
+   *
+   * @param action The action
+   * @return {@code false} if no remaining elements existed
+   * upon entry to this method, else {@code true}.
+   * @throws NullPointerException if the specified action is null
+   */
+  @Override
+  public boolean tryAdvance(Consumer<? super String> action) {
+    if (action == null) {
+      throw new NullPointerException();
+    }
+    try {
+      final String line = reader.readLine();
+      if (line == null) {
+        return false;
+      }
+      action.accept(line);
+      return true;
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /**
+   * If this spliterator can be partitioned, returns a Spliterator
+   * covering elements, that will, upon return from this method, not
+   * be covered by this Spliterator.
+   * <p>
+   * <p>If this Spliterator is {@link #ORDERED}, the returned Spliterator
+   * must cover a strict prefix of the elements.
+   * <p>
+   * <p>Unless this Spliterator covers an infinite number of elements,
+   * repeated calls to {@code trySplit()} must eventually return {@code null}.
+   * Upon non-null return:
+   * <ul>
+   * <li>the value reported for {@code estimateSize()} before splitting,
+   * must, after splitting, be greater than or equal to {@code estimateSize()}
+   * for this and the returned Spliterator; and</li>
+   * <li>if this Spliterator is {@code SUBSIZED}, then {@code estimateSize()}
+   * for this spliterator before splitting must be equal to the sum of
+   * {@code estimateSize()} for this and the returned Spliterator after
+   * splitting.</li>
+   * </ul>
+   * <p>
+   * <p>This method may return {@code null} for any reason,
+   * including emptiness, inability to split after traversal has
+   * commenced, data structure constraints, and efficiency
+   * considerations.
+   *
+   * @return a {@code Spliterator} covering some portion of the
+   * elements, or {@code null} if this spliterator cannot be split
+   * @apiNote An ideal {@code trySplit} method efficiently (without
+   * traversal) divides its elements exactly in half, allowing
+   * balanced parallel computation.  Many departures from this ideal
+   * remain highly effective; for example, only approximately
+   * splitting an approximately balanced tree, or for a tree in
+   * which leaf nodes may contain either one or two elements,
+   * failing to further split these nodes.  However, large
+   * deviations in balance and/or overly inefficient {@code
+   * trySplit} mechanics typically result in poor parallel
+   * performance.
+   */
+  @Override
+  public Spliterator<String> trySplit() {
+    final HoldingConsumer<String> holder = new HoldingConsumer<>();
+    if (!tryAdvance(holder)) {
+      return null;
+    }
+    final String[] batch = new String[batchSize];
+    int j = 0;
+    do {
+      batch[j] = holder.value;
+    }
+    while (++j < batchSize && tryAdvance(holder));
+    return spliterator(batch, 0, j, characteristics() | SIZED);
+  }
+
+  /**
+   * Returns an estimate of the number of elements that would be
+   * encountered by a {@link #forEachRemaining} traversal, or returns {@link
+   * Long#MAX_VALUE} if infinite, unknown, or too expensive to compute.
+   * <p>
+   * <p>If this Spliterator is {@link #SIZED} and has not yet been partially
+   * traversed or split, or this Spliterator is {@link #SUBSIZED} and has
+   * not yet been partially traversed, this estimate must be an accurate
+   * count of elements that would be encountered by a complete traversal.
+   * Otherwise, this estimate may be arbitrarily inaccurate, but must decrease
+   * as specified across invocations of {@link #trySplit}.
+   *
+   * @return the estimated size, or {@code Long.MAX_VALUE} if infinite,
+   * unknown, or too expensive to compute.
+   * @apiNote Even an inexact estimate is often useful and inexpensive to compute.
+   * For example, a sub-spliterator of an approximately balanced binary tree
+   * may return a value that estimates the number of elements to be half of
+   * that of its parent; if the root Spliterator does not maintain an
+   * accurate count, it could estimate size to be the power of two
+   * corresponding to its maximum depth.
+   */
+  @Override
+  public long estimateSize() {
+    return Long.MAX_VALUE;
+  }
+
+  /**
+   * Returns a set of characteristics of this Spliterator and its
+   * elements. The result is represented as ORed values from {@link
+   * #ORDERED}, {@link #DISTINCT}, {@link #SORTED}, {@link #SIZED},
+   * {@link #NONNULL}, {@link #IMMUTABLE}, {@link #CONCURRENT},
+   * {@link #SUBSIZED}.  Repeated calls to {@code characteristics()} on
+   * a given spliterator, prior to or in-between calls to {@code trySplit},
+   * should always return the same result.
+   * <p>
+   * <p>If a Spliterator reports an inconsistent set of
+   * characteristics (either those returned from a single invocation
+   * or across multiple invocations), no guarantees can be made
+   * about any computation using this Spliterator.
+   *
+   * @return a representation of characteristics
+   * @apiNote The characteristics of a given spliterator before splitting
+   * may differ from the characteristics after splitting.  For specific
+   * examples see the characteristic values {@link #SIZED}, {@link #SUBSIZED}
+   * and {@link #CONCURRENT}.
+   */
+  @Override
+  public int characteristics() {
+    return characteristics;
+  }
+
+  static class HoldingConsumer<String> implements Consumer<String> {
+    String value;
+    /**
+     * Performs this operation on the given argument.
+     *
+     * @param string the input argument
+     */
+    @Override
+    public void accept(String string) {
+      this.value = string;
+    }
+  }
+
+  public static Stream<String> lineStream(BufferedReader in, int batchSize) {
+    return StreamSupport.stream(new ReaderSpliterator(in, batchSize), false)
+                        .onClose(() -> {
+                          try {
+                            in.close();
+                          } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                          }
+                                       }
+                                );
+  }
+}

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/utils/file/ReaderSpliteratorTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/utils/file/ReaderSpliteratorTest.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.common.utils.file;
+
+import org.adrianwalker.multilinestring.Multiline;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ReaderSpliteratorTest {
+  /**
+   foo
+   bar
+   grok
+   foo
+   the
+   and
+   grok
+   foo
+   bar
+   */
+  @Multiline
+  public static String data;
+
+  @Test
+  public void testParallelStreamSmallBatch() {
+    Stream<String> stream = ReaderSpliterator.lineStream(new BufferedReader(new StringReader(data)), 2);
+    Map<String, Integer> count =
+            stream.parallel().map( s -> s.trim())
+                             .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
+    Assert.assertEquals(5, count.size());
+    Assert.assertEquals(3, (int)count.get("foo"));
+    Assert.assertEquals(2, (int)count.get("bar"));
+    Assert.assertEquals(1, (int)count.get("and"));
+    Assert.assertEquals(1, (int)count.get("the"));
+  }
+
+  @Test
+  public void testParallelStreamLargeBatch() {
+    Stream<String> stream = ReaderSpliterator.lineStream(new BufferedReader(new StringReader(data)), 100);
+    Map<String, Integer> count =
+            stream.parallel().map( s -> s.trim())
+                             .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
+    Assert.assertEquals(5, count.size());
+    Assert.assertEquals(3, (int)count.get("foo"));
+    Assert.assertEquals(2, (int)count.get("bar"));
+    Assert.assertEquals(1, (int)count.get("and"));
+    Assert.assertEquals(1, (int)count.get("the"));
+  }
+
+  @Test
+  public void testSequentialStreamLargeBatch() {
+    Stream<String> stream = ReaderSpliterator.lineStream(new BufferedReader(new StringReader(data)), 100);
+    Map<String, Integer> count =
+            stream.map( s -> s.trim())
+                  .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
+    Assert.assertEquals(5, count.size());
+    Assert.assertEquals(3, (int)count.get("foo"));
+    Assert.assertEquals(2, (int)count.get("bar"));
+    Assert.assertEquals(1, (int)count.get("and"));
+    Assert.assertEquals(1, (int)count.get("the"));
+  }
+
+  @Test
+  public void testActuallyParallel() throws ExecutionException, InterruptedException {
+    //With 9 elements and a batch of 2, we should only ceil(9/2) = 5 batches, so at most min(5, 2) = 2 threads will be used
+    Stream<String> stream = ReaderSpliterator.lineStream(new BufferedReader(new StringReader(data)), 2);
+    ForkJoinPool forkJoinPool = new ForkJoinPool(2);
+    forkJoinPool.submit(() -> {
+              Map<String, Integer> threads=
+                      stream.parallel().map(s -> Thread.currentThread().getName())
+                              .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
+              Assert.assertTrue(threads.size() <= 2);
+            }
+    ).get();
+  }
+
+  @Test
+  public void testActuallyParallel_mediumBatch() throws ExecutionException, InterruptedException {
+    //With 9 elements and a batch of 2, we should only ceil(9/2) = 5 batches, so at most 5 threads of the pool of 10 will be used
+    Stream<String> stream = ReaderSpliterator.lineStream(new BufferedReader(new StringReader(data)), 2);
+    ForkJoinPool forkJoinPool = new ForkJoinPool(10);
+    forkJoinPool.submit(() -> {
+              Map<String, Integer> threads=
+                      stream.parallel().map(s -> Thread.currentThread().getName())
+                              .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
+              Assert.assertTrue(threads.size() <= (int)Math.ceil(9.0/2) && threads.size() > 1);
+            }
+    ).get();
+  }
+
+  @Test
+  public void testActuallyParallel_bigBatch() throws ExecutionException, InterruptedException {
+    //With 9 elements and a batch of 10, we should only have one batch, so only one thread will be used
+    //despite the thread pool size of 2.
+    Stream<String> stream = ReaderSpliterator.lineStream(new BufferedReader(new StringReader(data)), 10);
+    ForkJoinPool forkJoinPool = new ForkJoinPool(2);
+    forkJoinPool.submit(() -> {
+              Map<String, Integer> threads=
+                      stream.parallel().map(s -> Thread.currentThread().getName())
+                              .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
+              Assert.assertEquals(1, threads.size());
+            }
+    ).get();
+  }
+}

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/utils/file/ReaderSpliteratorTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/utils/file/ReaderSpliteratorTest.java
@@ -19,10 +19,14 @@ package org.apache.metron.common.utils.file;
 
 import org.adrianwalker.multilinestring.Multiline;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.BufferedReader;
-import java.io.StringReader;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.StandardOpenOption;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
@@ -43,86 +47,108 @@ public class ReaderSpliteratorTest {
    */
   @Multiline
   public static String data;
+  public static final File dataFile = new File("target/readerspliteratortest.data");
 
-  @Test
-  public void testParallelStreamSmallBatch() {
-    Stream<String> stream = ReaderSpliterator.lineStream(new BufferedReader(new StringReader(data)), 2);
-    Map<String, Integer> count =
-            stream.parallel().map( s -> s.trim())
-                             .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
-    Assert.assertEquals(5, count.size());
-    Assert.assertEquals(3, (int)count.get("foo"));
-    Assert.assertEquals(2, (int)count.get("bar"));
-    Assert.assertEquals(1, (int)count.get("and"));
-    Assert.assertEquals(1, (int)count.get("the"));
+  @BeforeClass
+  public static void setup() throws IOException {
+    if(dataFile.exists()) {
+      dataFile.delete();
+    }
+    Files.write(dataFile.toPath(), data.getBytes(), StandardOpenOption.CREATE_NEW, StandardOpenOption.TRUNCATE_EXISTING);
+    dataFile.deleteOnExit();
+  }
+
+  public static BufferedReader getReader() throws FileNotFoundException {
+    return new BufferedReader(new FileReader(dataFile));
   }
 
   @Test
-  public void testParallelStreamLargeBatch() {
-    Stream<String> stream = ReaderSpliterator.lineStream(new BufferedReader(new StringReader(data)), 100);
-    Map<String, Integer> count =
-            stream.parallel().map( s -> s.trim())
-                             .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
-    Assert.assertEquals(5, count.size());
-    Assert.assertEquals(3, (int)count.get("foo"));
-    Assert.assertEquals(2, (int)count.get("bar"));
-    Assert.assertEquals(1, (int)count.get("and"));
-    Assert.assertEquals(1, (int)count.get("the"));
+  public void testParallelStreamSmallBatch() throws FileNotFoundException {
+    try( Stream<String> stream = ReaderSpliterator.lineStream(getReader(), 2)) {
+
+      Map<String, Integer> count =
+              stream.parallel().map( s -> s.trim())
+                      .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
+      Assert.assertEquals(5, count.size());
+      Assert.assertEquals(3, (int)count.get("foo"));
+      Assert.assertEquals(2, (int)count.get("bar"));
+      Assert.assertEquals(1, (int)count.get("and"));
+      Assert.assertEquals(1, (int)count.get("the"));
+    }
   }
 
   @Test
-  public void testSequentialStreamLargeBatch() {
-    Stream<String> stream = ReaderSpliterator.lineStream(new BufferedReader(new StringReader(data)), 100);
-    Map<String, Integer> count =
-            stream.map( s -> s.trim())
-                  .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
-    Assert.assertEquals(5, count.size());
-    Assert.assertEquals(3, (int)count.get("foo"));
-    Assert.assertEquals(2, (int)count.get("bar"));
-    Assert.assertEquals(1, (int)count.get("and"));
-    Assert.assertEquals(1, (int)count.get("the"));
+  public void testParallelStreamLargeBatch() throws FileNotFoundException {
+    try( Stream<String> stream = ReaderSpliterator.lineStream(getReader(), 100)) {
+      Map<String, Integer> count =
+              stream.parallel().map(s -> s.trim())
+                      .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
+      Assert.assertEquals(5, count.size());
+      Assert.assertEquals(3, (int) count.get("foo"));
+      Assert.assertEquals(2, (int) count.get("bar"));
+      Assert.assertEquals(1, (int) count.get("and"));
+      Assert.assertEquals(1, (int) count.get("the"));
+    }
   }
 
   @Test
-  public void testActuallyParallel() throws ExecutionException, InterruptedException {
+  public void testSequentialStreamLargeBatch() throws FileNotFoundException {
+    try( Stream<String> stream = ReaderSpliterator.lineStream(getReader(), 100)) {
+      Map<String, Integer> count =
+              stream.map(s -> s.trim())
+                      .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
+      Assert.assertEquals(5, count.size());
+      Assert.assertEquals(3, (int) count.get("foo"));
+      Assert.assertEquals(2, (int) count.get("bar"));
+      Assert.assertEquals(1, (int) count.get("and"));
+      Assert.assertEquals(1, (int) count.get("the"));
+    }
+  }
+
+  @Test
+  public void testActuallyParallel() throws ExecutionException, InterruptedException, FileNotFoundException {
     //With 9 elements and a batch of 2, we should only ceil(9/2) = 5 batches, so at most min(5, 2) = 2 threads will be used
-    Stream<String> stream = ReaderSpliterator.lineStream(new BufferedReader(new StringReader(data)), 2);
-    ForkJoinPool forkJoinPool = new ForkJoinPool(2);
-    forkJoinPool.submit(() -> {
-              Map<String, Integer> threads=
-                      stream.parallel().map(s -> Thread.currentThread().getName())
-                              .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
-              Assert.assertTrue(threads.size() <= 2);
-            }
-    ).get();
+    try( Stream<String> stream = ReaderSpliterator.lineStream(getReader(), 2)) {
+      ForkJoinPool forkJoinPool = new ForkJoinPool(2);
+      forkJoinPool.submit(() -> {
+                Map<String, Integer> threads =
+                        stream.parallel().map(s -> Thread.currentThread().getName())
+                                .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
+                Assert.assertTrue(threads.size() <= 2);
+              }
+      ).get();
+    }
   }
 
   @Test
-  public void testActuallyParallel_mediumBatch() throws ExecutionException, InterruptedException {
+  public void testActuallyParallel_mediumBatch() throws ExecutionException, InterruptedException, FileNotFoundException {
     //With 9 elements and a batch of 2, we should only ceil(9/2) = 5 batches, so at most 5 threads of the pool of 10 will be used
-    Stream<String> stream = ReaderSpliterator.lineStream(new BufferedReader(new StringReader(data)), 2);
-    ForkJoinPool forkJoinPool = new ForkJoinPool(10);
-    forkJoinPool.submit(() -> {
-              Map<String, Integer> threads=
-                      stream.parallel().map(s -> Thread.currentThread().getName())
-                              .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
-              Assert.assertTrue(threads.size() <= (int)Math.ceil(9.0/2) && threads.size() > 1);
-            }
-    ).get();
+    try( Stream<String> stream = ReaderSpliterator.lineStream(getReader(), 2)) {
+      ForkJoinPool forkJoinPool = new ForkJoinPool(10);
+      forkJoinPool.submit(() -> {
+                Map<String, Integer> threads =
+                        stream.parallel().map(s -> Thread.currentThread().getName())
+                                .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
+                Assert.assertTrue(threads.size() <= (int) Math.ceil(9.0 / 2) && threads.size() > 1);
+              }
+      ).get();
+    }
   }
 
   @Test
-  public void testActuallyParallel_bigBatch() throws ExecutionException, InterruptedException {
+  public void testActuallyParallel_bigBatch() throws ExecutionException, InterruptedException, FileNotFoundException {
     //With 9 elements and a batch of 10, we should only have one batch, so only one thread will be used
     //despite the thread pool size of 2.
-    Stream<String> stream = ReaderSpliterator.lineStream(new BufferedReader(new StringReader(data)), 10);
-    ForkJoinPool forkJoinPool = new ForkJoinPool(2);
-    forkJoinPool.submit(() -> {
-              Map<String, Integer> threads=
-                      stream.parallel().map(s -> Thread.currentThread().getName())
-                              .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
-              Assert.assertEquals(1, threads.size());
-            }
-    ).get();
+    try( Stream<String> stream = ReaderSpliterator.lineStream(getReader(), 10)) {
+      ForkJoinPool forkJoinPool = new ForkJoinPool(2);
+      forkJoinPool.submit(() -> {
+                Map<String, Integer> threads =
+                        stream.parallel().map(s -> Thread.currentThread().getName())
+                                .collect(Collectors.toMap(s -> s, s -> 1, Integer::sum));
+                Assert.assertEquals(1, threads.size());
+              }
+      ).get();
+    }
   }
+
 }

--- a/metron-platform/metron-data-management/README.md
+++ b/metron-platform/metron-data-management/README.md
@@ -249,8 +249,8 @@ The parameters for the utility are as follows:
 | -i         | --input             | Yes          | The input data location on local disk.  If this is a file, then that file will be loaded.  If this is a directory, then the files will be loaded recursively under that directory. |   |
 | -l         | --log4j             | No           | The log4j properties file to load                                                                                                                                                   |   |
 | -n         | --enrichment_config | No           | The JSON document describing the enrichments to configure.  Unlike other loaders, this is run first if specified.                                                                   |   |
-| -p         | --threads           | No           | The number of threads to use when extracting data                                                                                                                                   |   |
-| -b         | --batchSize         | No           | The batch size to use for HBase puts                                                                                                                                   |   |
+| -p         | --threads           | No           | The number of threads to use when extracting data.  The default is the number of cores.                                                                                             |   |
+| -b         | --batchSize         | No           | The batch size to use for HBase puts                                                                                                                                                |   |
 ### GeoLite2 Loader
 
 The shell script `$METRON_HOME/bin/geo_enrichment_load.sh` will retrieve MaxMind GeoLite2 data and load data into HDFS, and update the configuration.

--- a/metron-platform/metron-data-management/README.md
+++ b/metron-platform/metron-data-management/README.md
@@ -240,16 +240,17 @@ each document to be considered as input to the Extractor.
 
 The parameters for the utility are as follows:
 
-| Short Code | Long Code           | Is Required? | Description                                                                                                                                                                          |
-|------------|---------------------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| -h         |                     | No           | Generate the help screen/set of options                                                                                                                                              |
-| -e         | --extractor_config  | Yes          | JSON Document describing the extractor for this input data source                                                                                                                    |
-| -t         | --hbase_table       | Yes          | The HBase table to import into                                                                                                                                                       |
-| -c         | --hbase_cf          | Yes          | The HBase table column family to import into                                                                                                                                         |
-| -i         | --input             | Yes          | The input data location on local disk.  If this is a file, then that file will be loaded.  If this is a directory, then the files will be loaded recursively under that directory. |
-| -l         | --log4j             | No           | The log4j properties file to load                                                                                                                                                    |
-| -n         | --enrichment_config | No           | The JSON document describing the enrichments to configure.  Unlike other loaders, this is run first if specified.                                                                    |
-
+| Short Code | Long Code           | Is Required? | Description                                                                                                                                                                         |   |
+|------------|---------------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
+| -h         |                     | No           | Generate the help screen/set of options                                                                                                                                             |   |
+| -e         | --extractor_config  | Yes          | JSON Document describing the extractor for this input data source                                                                                                                   |   |
+| -t         | --hbase_table       | Yes          | The HBase table to import into                                                                                                                                                      |   |
+| -c         | --hbase_cf          | Yes          | The HBase table column family to import into                                                                                                                                        |   |
+| -i         | --input             | Yes          | The input data location on local disk.  If this is a file, then that file will be loaded.  If this is a directory, then the files will be loaded recursively under that directory. |   |
+| -l         | --log4j             | No           | The log4j properties file to load                                                                                                                                                   |   |
+| -n         | --enrichment_config | No           | The JSON document describing the enrichments to configure.  Unlike other loaders, this is run first if specified.                                                                   |   |
+| -p         | --threads           | No           | The number of threads to use when extracting data                                                                                                                                   |   |
+| -b         | --batchSize         | No           | The batch size to use for HBase puts                                                                                                                                   |   |
 ### GeoLite2 Loader
 
 The shell script `$METRON_HOME/bin/geo_enrichment_load.sh` will retrieve MaxMind GeoLite2 data and load data into HDFS, and update the configuration.

--- a/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/flatfile/ExtractorState.java
+++ b/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/flatfile/ExtractorState.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.dataloads.nonbulk.flatfile;
+
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.metron.dataloads.extractor.Extractor;
+import org.apache.metron.enrichment.converter.HbaseConverter;
+
+public class ExtractorState {
+  private HTableInterface table;
+  private Extractor extractor;
+  private HbaseConverter converter;
+
+  public ExtractorState(HTableInterface table, Extractor extractor, HbaseConverter converter) {
+    this.table = table;
+    this.extractor = extractor;
+    this.converter = converter;
+  }
+
+  public HTableInterface getTable() {
+    return table;
+  }
+
+  public Extractor getExtractor() {
+    return extractor;
+  }
+
+  public HbaseConverter getConverter() {
+    return converter;
+  }
+}

--- a/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/flatfile/SimpleEnrichmentFlatFileLoader.java
+++ b/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/flatfile/SimpleEnrichmentFlatFileLoader.java
@@ -118,7 +118,7 @@ public class SimpleEnrichmentFlatFileLoader {
       @Nullable
       @Override
       public Option apply(@Nullable String s) {
-        Option o = new Option(s, "threads", true, "The number of threads to use when extracting data");
+        Option o = new Option(s, "threads", true, "The number of threads to use when extracting data.  The default is the number of cores of your machine.");
         o.setArgName("NUM_THREADS");
         o.setRequired(false);
         return o;

--- a/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/flatfile/SimpleEnrichmentFlatFileLoader.java
+++ b/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/flatfile/SimpleEnrichmentFlatFileLoader.java
@@ -236,7 +236,6 @@ public class SimpleEnrichmentFlatFileLoader {
                   , int numThreads
                   )
   {
-    System.out.println("Number of threads: " + numThreads);
     for(Stream<String> stream : streams) {
       try {
         ForkJoinPool forkJoinPool = new ForkJoinPool(numThreads);

--- a/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/flatfile/SimpleEnrichmentFlatFileLoader.java
+++ b/metron-platform/metron-data-management/src/main/java/org/apache/metron/dataloads/nonbulk/flatfile/SimpleEnrichmentFlatFileLoader.java
@@ -118,7 +118,7 @@ public class SimpleEnrichmentFlatFileLoader {
       @Nullable
       @Override
       public Option apply(@Nullable String s) {
-        Option o = new Option(s, "threads", true, "The batch size to use for hbase puts");
+        Option o = new Option(s, "threads", true, "The number of threads to use when extracting data");
         o.setArgName("NUM_THREADS");
         o.setRequired(false);
         return o;
@@ -128,7 +128,7 @@ public class SimpleEnrichmentFlatFileLoader {
       @Nullable
       @Override
       public Option apply(@Nullable String s) {
-        Option o = new Option(s, "batchSize", true, "The batch size to use for hbase puts");
+        Option o = new Option(s, "batchSize", true, "The batch size to use for HBase puts");
         o.setArgName("SIZE");
         o.setRequired(false);
         return o;

--- a/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/integration/ElasticsearchIndexingIntegrationTest.java
+++ b/metron-platform/metron-elasticsearch/src/test/java/org/apache/metron/elasticsearch/integration/ElasticsearchIndexingIntegrationTest.java
@@ -85,6 +85,7 @@ public class ElasticsearchIndexingIntegrationTest extends IndexingIntegrationTes
             return ReadinessState.READY;
           }
         } else {
+          System.out.println("Missed index...");
           return ReadinessState.NOT_READY;
         }
       }

--- a/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
+++ b/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
@@ -205,6 +205,7 @@ public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
   private void waitForIndex(String zookeeperQuorum) throws Exception {
     try(CuratorFramework client = getClient(zookeeperQuorum)) {
       client.start();
+      System.out.println("Waiting for zookeeper...");
       byte[] bytes = null;
       do {
         try {
@@ -216,6 +217,7 @@ public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
         }
       }
       while(bytes == null || bytes.length == 0);
+      System.out.println("Found index config in zookeeper...");
     }
   }
 


### PR DESCRIPTION
Currently the flat file loader is single threaded in its writing to HBase. We could make this a lot faster by multithreading the HBase puts.

Executing this on single node vagrant with the following configuration for 100k 2-column CSV enrichment import:
* a batch size of 128
* number of threads varying between 1 and 6

A reasonable speedup was achieved:

| Number of Threads | Time (in seconds) |
|-------------------|-------------------|
| 1                 | 91.019            |
| 2                 | 76.07             |
| 3                 | 39.974            |
| 4                 | 35.039            |
| 5                 | 30.531            |
| 6                 | 30.559            |

![chart](https://cloud.githubusercontent.com/assets/540359/22392190/af852618-e4c4-11e6-9c03-a68b66e330ad.png)
