### PR TITLE
METRON-680: GeoLiteDatabase incorrectly using country geoname_id instead of city

### DIFF
--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/geo/GeoLiteDatabase.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/geo/GeoLiteDatabase.java
@@ -141,7 +141,7 @@ public enum GeoLiteDatabase {
       Postal postal = cityResponse.getPostal();
       Location location = cityResponse.getLocation();
 
-      geoInfo.put("locID", convertNullToEmptyString(country.getGeoNameId()));
+      geoInfo.put("locID", convertNullToEmptyString(city.getGeoNameId()));
       geoInfo.put("country", convertNullToEmptyString(country.getIsoCode()));
       geoInfo.put("city", convertNullToEmptyString(city.getName()));
       geoInfo.put("postalCode", convertNullToEmptyString(postal.getCode()));

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/geo/GeoLiteDatabaseTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/geo/GeoLiteDatabaseTest.java
@@ -43,7 +43,7 @@ public class GeoLiteDatabaseTest {
 
   /**
    * {
-   * "locID":"6252001",
+   * "locID":"5803556",
    * "country":"US",
    * "city":"Milton",
    * "postalCode":"98354",
@@ -60,7 +60,7 @@ public class GeoLiteDatabaseTest {
 
   /**
    * {
-   * "locID":"2635167",
+   * "locID":"2643743",
    * "country":"GB",
    * "city":"London",
    * "postalCode":"",


### PR DESCRIPTION
See the discussion [METRON-680]( https://issues.apache.org/jira/browse/METRON-680) for more info.  This implements the easy country -> city change.  The two fields have the exact same format (they're both ids from geonames.org)

The main concern I have is what happens given that that the "Unique-Location(s)" visualization in Kibana uses locId directly.  Changing what gets passed to it affects what shows up in that field.