### PR TITLE
METRON-680: GeoLiteDatabase incorrectly using country geoname_id instead of city

### DIFF
--- a/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/geo/GeoLiteDatabase.java
+++ b/metron-platform/metron-enrichment/src/main/java/org/apache/metron/enrichment/adapters/geo/GeoLiteDatabase.java
@@ -141,7 +141,7 @@ public enum GeoLiteDatabase {
       Postal postal = cityResponse.getPostal();
       Location location = cityResponse.getLocation();
 
-      geoInfo.put("locID", convertNullToEmptyString(country.getGeoNameId()));
+      geoInfo.put("locID", convertNullToEmptyString(city.getGeoNameId()));
       geoInfo.put("country", convertNullToEmptyString(country.getIsoCode()));
       geoInfo.put("city", convertNullToEmptyString(city.getName()));
       geoInfo.put("postalCode", convertNullToEmptyString(postal.getCode()));

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/geo/GeoAdapterTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/geo/GeoAdapterTest.java
@@ -36,7 +36,7 @@ public class GeoAdapterTest {
 
   /**
    * {
-   * "locID":"6252001",
+   * "locID":"5803556",
    * "country":"US",
    * "city":"Milton",
    * "postalCode":"98354",

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/geo/GeoLiteDatabaseTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/adapters/geo/GeoLiteDatabaseTest.java
@@ -43,7 +43,7 @@ public class GeoLiteDatabaseTest {
 
   /**
    * {
-   * "locID":"6252001",
+   * "locID":"5803556",
    * "country":"US",
    * "city":"Milton",
    * "postalCode":"98354",
@@ -60,7 +60,7 @@ public class GeoLiteDatabaseTest {
 
   /**
    * {
-   * "locID":"2635167",
+   * "locID":"2643743",
    * "country":"GB",
    * "city":"London",
    * "postalCode":"",

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/stellar/GeoEnrichmentFunctionsTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/stellar/GeoEnrichmentFunctionsTest.java
@@ -43,7 +43,7 @@ public class GeoEnrichmentFunctionsTest {
 
   /**
    * {
-   * "locID":"6252001",
+   * "locID":"5803556",
    * "country":"US",
    * "city":"Milton",
    * "postalCode":"98354",
@@ -122,7 +122,7 @@ public class GeoEnrichmentFunctionsTest {
   public void testGetRemote() throws Exception {
     String stellar = "GEO_GET('216.160.83.56')";
     Object result = run(stellar, ImmutableMap.of());
-    Assert.assertEquals("Remote Local IP should return result based on DB", expectedMessage, result);
+    Assert.assertEquals("Remote IP should return result based on DB", expectedMessage, result);
   }
 
   @Test
@@ -130,7 +130,7 @@ public class GeoEnrichmentFunctionsTest {
   public void testGetRemoteSingleField() throws Exception {
     String stellar = "GEO_GET('216.160.83.56', ['country'])";
     Object result = run(stellar, ImmutableMap.of());
-    Assert.assertEquals("Remote Local IP should return country result based on DB", "US", result);
+    Assert.assertEquals("Remote IP should return country result based on DB", "US", result);
   }
 
   @Test
@@ -138,7 +138,7 @@ public class GeoEnrichmentFunctionsTest {
   public void testGetRemoteMultipleFields() throws Exception {
     String stellar = "GEO_GET('216.160.83.56', ['country', 'city', 'dmaCode', 'location_point'])";
     Object result = run(stellar, ImmutableMap.of());
-    Assert.assertEquals("Remote Local IP should return country result based on DB", expectedSubsetMessage, result);
+    Assert.assertEquals("Remote IP should return country result based on DB", expectedSubsetMessage, result);
   }
 
   @Test(expected=org.apache.metron.common.dsl.ParseException.class)


### PR DESCRIPTION
Swaps out country's geoname_id for city's geoname_id.  Both ids are the same in format (they're the ids for the geonames.org dataset).

The only direct effect I know of from this is the Kibana dashboard uses this field for unique locations (so changing what feeds this changes the dashboard output).  The main wrinkle is that city can be unpopulated, even though a country exists (e.g. if an IP is just assigned to the U.S., it may not have a city).  This isn't always true that (at least one IP range for Japan appears to fill in Japan as the city's geoname id).

I'm opening the PR with just the direct change, but it's definitely open to discussion if we want to adjust.