### PR TITLE
METRON-687 Create String Formatting Function for Stellar

### DIFF
--- a/metron-platform/metron-common/README.md
+++ b/metron-platform/metron-common/README.md
@@ -96,6 +96,7 @@ The `!=` operator is the negation of the above.
 | [ `ENRICHMENT_GET`](#enrichment_get)                                                               |
 | [ `FILL_LEFT`](#fill_left)                                                                         |
 | [ `FILL_RIGHT`](#fill_right)                                                                       |
+| [ `FORMAT`](#format)                                                                       |
 | [ `HLLP_CARDINALITY`](../../metron-analytics/metron-statistics#hllp_cardinality)                   |
 | [ `HLLP_INIT`](../../metron-analytics/metron-statistics#hllp_init)                                 |
 | [ `HLLP_MERGE`](../../metron-analytics/metron-statistics#hllp_merge)                               |
@@ -269,6 +270,13 @@ The `!=` operator is the negation of the above.
     * fill - the fill character string
     * len - the required length
   * Returns: Last element of the list
+
+### `FORMAT`
+  * Description: Returns a formatted string using the specified format string and arguments.
+  * Input:
+    * format - string
+    * arguments... - object(s)
+  * Returns: A formatted string.
 
 ### `GEO_GET`
   * Description: Look up an IPV4 address and returns geographic information about it

--- a/metron-platform/metron-common/README.md
+++ b/metron-platform/metron-common/README.md
@@ -272,7 +272,7 @@ The `!=` operator is the negation of the above.
   * Returns: Last element of the list
 
 ### `FORMAT`
-  * Description: Returns a formatted string using the specified format string and arguments.
+  * Description: Returns a formatted string using the specified format string and arguments. Uses Java's string formatting conventions.
   * Input:
     * format - string
     * arguments... - object(s)

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/StringFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/StringFunctions.java
@@ -322,4 +322,25 @@ public class StringFunctions {
       return ret;
     }
   }
+
+  @Stellar( name="FORMAT"
+          , description = "Returns a formatted string using the specified format string and arguments. Uses Java's string formatting conventions."
+          , params = { "format - string", "arguments... - object(s)" }
+          , returns = "A formatted string."
+  )
+  public static class Format extends BaseStellarFunction {
+
+    @Override
+    public Object apply(List<Object> args) {
+
+      if(args.size() == 0) {
+        throw new IllegalArgumentException("[FORMAT] missing argument: format string");
+      }
+
+      String format = ConversionUtils.convert(args.get(0), String.class);
+      Object[] formatArgs = args.subList(1, args.size()).toArray();
+
+      return String.format(format, formatArgs);
+    }
+  }
 }

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/dsl/functions/StringFunctionsTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/dsl/functions/StringFunctionsTest.java
@@ -21,10 +21,13 @@ package org.apache.metron.common.dsl.functions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.collections.map.HashedMap;
+import org.apache.commons.collections.map.SingletonMap;
 import org.apache.metron.common.dsl.ParseException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Calendar;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -171,5 +174,37 @@ public class StringFunctionsTest {
       -0.5*-1 - 0.25*-2 - 0.25*-2 = 1.5
      */
     Assert.assertEquals(1.5, (Double)run("STRING_ENTROPY(foo)", ImmutableMap.of("foo", "aaaaaaaaaabbbbbccccc")), 0.0);
+  }
+
+  @Test
+  public void testFormat() throws Exception {
+
+    Map<String, Object> vars = ImmutableMap.of(
+            "cal", new Calendar.Builder().setDate(2017, 02, 02).build(),
+            "x", 234,
+            "y", 3);
+
+    Assert.assertEquals("no args",        run("FORMAT('no args')", vars));
+    Assert.assertEquals("234.0",          run("FORMAT('%.1f', TO_DOUBLE(234))", vars));
+    Assert.assertEquals("000234",         run("FORMAT('%06d', 234)", vars));
+    Assert.assertEquals("03 2,2017",      run("FORMAT('%1$tm %1$te,%1$tY', cal)", vars));
+    Assert.assertEquals("234 > 3",        run("FORMAT('%d > %d', x, y)", vars));
+    Assert.assertEquals("missing: null",  run("FORMAT('missing: %d', missing)", vars));
+  }
+
+  /**
+   * FORMAT - Not passing a format string will throw an exception
+   */
+  @Test(expected = ParseException.class)
+  public void testFormatWithNoArguments() throws Exception {
+    run("FORMAT()", Collections.emptyMap());
+  }
+
+  /**
+   * FORMAT - Forgetting to pass an argument required by the format string will throw an exception.
+   */
+  @Test(expected = ParseException.class)
+  public void testFormatWithMissingArguments() throws Exception {
+    run("FORMAT('missing arg: %d')", Collections.emptyMap());
   }
 }


### PR DESCRIPTION
Created a string formatting function for Stellar. 
* Uses Java's String formatting conventions.  
* Any non-existent variables will be formatted as 'null'.  This failure scenario would arise from a data quality issue.
* Forgetting to pass an argument required by the format string will throw an exception.  
* Not passing a format string will throw an exception.

#### FORMAT
* Description: Returns a formatted string using the specified format string and arguments.  Uses Java's string formatting conventions.
* Input:
    * format - string
    * arguments... - object(s)
* Returns: A formatted string.

