### PR TITLE
METRON-699: Update metron-statistics documentation

### DIFF
--- a/metron-analytics/metron-statistics/README.md
+++ b/metron-analytics/metron-statistics/README.md
@@ -12,27 +12,27 @@ functions can be used from everywhere where Stellar is used.
 
 ### Approximation Statistics
 
-### `HLLP_ADD`
+#### `HLLP_ADD`
   * Description: Add value to the HyperLogLogPlus estimator set. See [HLLP README](HLLP.md)
   * Input:
     * hyperLogLogPlus - the hllp estimator to add a value to
     * value+ - value to add to the set. Takes a single item or a list.
   * Returns: The HyperLogLogPlus set with a new value added
 
-### `HLLP_CARDINALITY`
+#### `HLLP_CARDINALITY`
   * Description: Returns HyperLogLogPlus-estimated cardinality for this set. See [HLLP README](HLLP.md)
   * Input:
     * hyperLogLogPlus - the hllp set
   * Returns: Long value representing the cardinality for this set
 
-### `HLLP_INIT`
+#### `HLLP_INIT`
   * Description: Initializes the HyperLogLogPlus estimator set. p must be a value between 4 and sp and sp must be less than 32 and greater than 4. See [HLLP README](HLLP.md)
   * Input:
     * p - the precision value for the normal set
     * sp - the precision value for the sparse set. If p is set, but sp is 0 or not specified, the sparse set will be disabled.
   * Returns: A new HyperLogLogPlus set
 
-### `HLLP_MERGE`
+#### `HLLP_MERGE`
   * Description: Merge hllp sets together. The resulting estimator is initialized with p and sp precision values from the first provided hllp estimator set. See [HLLP README](HLLP.md)
   * Input:
     * hllp - List of hllp estimators to merge. Takes a single hllp set or a list.


### PR DESCRIPTION
Update the metron-statistics documentation. Currently some of the documentation is not properly hierarchical.