### PR TITLE
METRON-646: Add index templates to metron-docker

### DIFF
--- a/metron-docker/.gitignore
+++ b/metron-docker/.gitignore
@@ -1,4 +1,5 @@
 /compose/.env
+/compose/elasticsearch/es_templates/*.template
 /compose/kafkazk/common
 /compose/kafkazk/parser
 /compose/kafkazk/enrichment

--- a/metron-docker/.gitignore
+++ b/metron-docker/.gitignore
@@ -1,5 +1,5 @@
 /compose/.env
-/compose/elasticsearch/es_templates/*.template
+/compose/elasticsearch/es_templates
 /compose/kafkazk/common
 /compose/kafkazk/parser
 /compose/kafkazk/enrichment

--- a/metron-docker/README.md
+++ b/metron-docker/README.md
@@ -78,7 +78,7 @@ Then, assuming a host ip of `192.168.99.100`, the UIs and APIs are available at:
 
 * Storm - http://192.168.99.100:8080/
 * HBase - http://192.168.99.100:16010/
-* Elasticsearch - http://192.168.99.100:9200/
+* Elasticsearch - http://192.168.99.100:9200/_plugin/head/
 * Kibana - http://192.168.99.100:5601/
 
 The Storm logs can be useful when troubleshooting topologies.  They can be found on the Storm container in `/usr/share/apache-storm/logs`.

--- a/metron-docker/compose/docker-compose.yml
+++ b/metron-docker/compose/docker-compose.yml
@@ -57,10 +57,12 @@ services:
       - elasticsearch
     command: --daemon nimbus supervisor ui logviewer
   elasticsearch:
-    image: elasticsearch:2.3
+    build:
+      context: ./elasticsearch
     ports:
       - "9200:9200"
       - "9300:9300"
+    command: tail -f /dev/null
   kibana:
     build: ./kibana
     ports:

--- a/metron-docker/compose/elasticsearch/Dockerfile
+++ b/metron-docker/compose/elasticsearch/Dockerfile
@@ -21,5 +21,7 @@ RUN /usr/share/elasticsearch/bin/plugin install mobz/elasticsearch-head
 ADD ./es_templates /es_templates
 
 COPY ./wait-for-it.sh /
+RUN chmod 755 /wait-for-it.sh
+
 COPY ./docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/metron-docker/compose/elasticsearch/Dockerfile
+++ b/metron-docker/compose/elasticsearch/Dockerfile
@@ -1,0 +1,25 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+FROM elasticsearch:2.3
+
+RUN /usr/share/elasticsearch/bin/plugin install mobz/elasticsearch-head
+
+ADD ./es_templates /es_templates
+
+COPY ./wait-for-it.sh /
+COPY ./docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/metron-docker/compose/elasticsearch/docker-entrypoint.sh
+++ b/metron-docker/compose/elasticsearch/docker-entrypoint.sh
@@ -25,7 +25,7 @@ chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/logs
 gosu elasticsearch /usr/share/elasticsearch/bin/elasticsearch -d
 
 # wait for elasticsearch to start
-/wait-for-it.sh localhost:9200
+/wait-for-it.sh localhost:9200 -t 30
 
 # load elasticsearch templates
 for template_file in `ls -1 /es_templates`; do

--- a/metron-docker/compose/elasticsearch/docker-entrypoint.sh
+++ b/metron-docker/compose/elasticsearch/docker-entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# exit immediately on error
+set -e
+
+# start elasticsearch as non-root user
+chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/data
+chown -R elasticsearch:elasticsearch /usr/share/elasticsearch/logs
+gosu elasticsearch /usr/share/elasticsearch/bin/elasticsearch -d
+
+# wait for elasticsearch to start
+/wait-for-it.sh localhost:9200
+
+# load elasticsearch templates
+for template_file in `ls -1 /es_templates`; do
+    template_name=`echo $template_file | sed 's/\.template//g'`
+    curl -XPUT --data @/es_templates/$template_file http://localhost:9200/_template/$template_name
+done
+
+# pass through CMD as PID 1
+exec "$@"

--- a/metron-docker/pom.xml
+++ b/metron-docker/pom.xml
@@ -89,6 +89,24 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>copy-templates-to-elasticsearch</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/compose/elasticsearch/es_templates</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../metron-deployment/roles/metron_elasticsearch_templates/files/es_templates/</directory>
+                                    <includes>
+                                        <include>*.template</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>copy-data-management-to-hbase</id>
                         <phase>prepare-package</phase>
                         <goals>
@@ -223,6 +241,24 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${project.basedir}/compose/kafkazk/bin</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>./scripts</directory>
+                                    <includes>
+                                        <include>wait-for-it.sh</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-wait-for-it-to-elasticsearch</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/compose/elasticsearch</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>./scripts</directory>

--- a/metron-docker/pom.xml
+++ b/metron-docker/pom.xml
@@ -271,6 +271,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>compose</directory>
+                            <includes>
+                                <include>**/*.tar.gz</include>
+                                <include>**/wait-for-it.sh</include>
+                                <include>**/*.template</include>
+                            </includes>
+                            <excludes>
+                                <exclude>scripts/wait-for-it.sh</exclude>
+                            </excludes>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/metron-docker/pom.xml
+++ b/metron-docker/pom.xml
@@ -281,11 +281,9 @@
                             <includes>
                                 <include>**/*.tar.gz</include>
                                 <include>**/wait-for-it.sh</include>
+                                <include>.env</include>
                                 <include>**/*.template</include>
                             </includes>
-                            <excludes>
-                                <exclude>scripts/wait-for-it.sh</exclude>
-                            </excludes>
                         </fileset>
                     </filesets>
                 </configuration>


### PR DESCRIPTION
Enhance metron-docker environment by automatically deploying index templates to elasticsearch as part of the container startup.

I've also included a maven clean goal for the metron-docker project for easier build/rebuild.

Test plan and rebase with master to follow shortly.
