### PR TITLE
METRON-322 Global Batching and Flushing

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/IndexingConfigurations.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/IndexingConfigurations.java
@@ -25,7 +25,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
-import java.util.function.Supplier;
 
 public class IndexingConfigurations extends Configurations {
   public static final String BATCH_SIZE_CONF = "batchSize";
@@ -44,7 +43,6 @@ public class IndexingConfigurations extends Configurations {
       return writerConfig != null?writerConfig:new HashMap<>();
     }
   }
-
 
   public void updateSensorIndexingConfig(String sensorType, byte[] data) throws IOException {
     updateSensorIndexingConfig(sensorType, new ByteArrayInputStream(data));
@@ -116,18 +114,18 @@ public class IndexingConfigurations extends Configurations {
 
   public static int getBatchSize(Map<String, Object> conf) {
     return getAs( BATCH_SIZE_CONF
-            ,conf
-            , 1
-            , Integer.class
-    );
+                 ,conf
+                , 1
+                , Integer.class
+                );
   }
 
   public static int getBatchTimeout(Map<String, Object> conf) {
     return getAs( BATCH_TIMEOUT_CONF
-            ,conf
-            , 0
-            , Integer.class
-    );
+                 ,conf
+                , 0
+                , Integer.class
+                );
   }
 
   public static String getIndex(Map<String, Object> conf, String sensorName) {

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/IndexingConfigurations.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/IndexingConfigurations.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 public class IndexingConfigurations extends Configurations {
   public static final String BATCH_SIZE_CONF = "batchSize";
+  public static final String BATCH_TIMEOUT_CONF = "batchTimeout";
   public static final String ENABLED_CONF = "enabled";
   public static final String INDEX_CONF = "index";
 
@@ -73,7 +74,11 @@ public class IndexingConfigurations extends Configurations {
   }
 
   public int getBatchSize(String sensorName, String writerName ) {
-     return getBatchSize(getSensorIndexingConfig(sensorName, writerName));
+    return getBatchSize(getSensorIndexingConfig(sensorName, writerName));
+  }
+
+  public int getBatchTimeout(String sensorName, String writerName ) {
+    return getBatchTimeout(getSensorIndexingConfig(sensorName, writerName));
   }
 
   public String getIndex(String sensorName, String writerName) {
@@ -94,10 +99,18 @@ public class IndexingConfigurations extends Configurations {
 
   public static int getBatchSize(Map<String, Object> conf) {
     return getAs( BATCH_SIZE_CONF
-                 ,conf
-                , 1
-                , Integer.class
-                );
+            ,conf
+            , 1
+            , Integer.class
+    );
+  }
+
+  public static int getBatchTimeout(Map<String, Object> conf) {
+    return getAs( BATCH_TIMEOUT_CONF
+            ,conf
+            , 0
+            , Integer.class
+    );
   }
 
   public static String getIndex(Map<String, Object> conf, String sensorName) {
@@ -116,6 +129,12 @@ public class IndexingConfigurations extends Configurations {
   public static Map<String, Object> setBatchSize(Map<String, Object> conf, int batchSize) {
     Map<String, Object> ret = conf == null?new HashMap<>():conf;
     ret.put(BATCH_SIZE_CONF, batchSize);
+    return ret;
+  }
+
+  public static Map<String, Object> setBatchTimeout(Map<String, Object> conf, int batchTimeout) {
+    Map<String, Object> ret = conf == null?new HashMap<>():conf;
+    ret.put(BATCH_TIMEOUT_CONF, batchTimeout);
     return ret;
   }
 

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/IndexingWriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/IndexingWriterConfiguration.java
@@ -22,8 +22,10 @@ import org.apache.metron.common.configuration.EnrichmentConfigurations;
 import org.apache.metron.common.configuration.IndexingConfigurations;
 import org.apache.metron.common.utils.ConversionUtils;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public class IndexingWriterConfiguration implements WriterConfiguration{
   private Optional<IndexingConfigurations> config;
@@ -42,6 +44,11 @@ public class IndexingWriterConfiguration implements WriterConfiguration{
   @Override
   public int getBatchTimeout(String sensorName) {
     return config.orElse(new IndexingConfigurations()).getBatchTimeout(sensorName, writerName);
+  }
+
+  @Override
+  public List<Integer> getAllConfiguredTimeouts() {
+      return config.orElse(new IndexingConfigurations()).getAllConfiguredTimeouts(writerName);
   }
 
   @Override

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/IndexingWriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/IndexingWriterConfiguration.java
@@ -40,6 +40,11 @@ public class IndexingWriterConfiguration implements WriterConfiguration{
   }
 
   @Override
+  public int getBatchTimeout(String sensorName) {
+    return config.orElse(new IndexingConfigurations()).getBatchTimeout(sensorName, writerName);
+  }
+
+  @Override
   public String getIndex(String sensorName) {
     return config.orElse(new IndexingConfigurations()).getIndex(sensorName, writerName);
   }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/IndexingWriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/IndexingWriterConfiguration.java
@@ -25,7 +25,6 @@ import org.apache.metron.common.utils.ConversionUtils;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 public class IndexingWriterConfiguration implements WriterConfiguration{
   private Optional<IndexingConfigurations> config;

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/ParserWriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/ParserWriterConfiguration.java
@@ -22,6 +22,8 @@ import org.apache.metron.common.configuration.IndexingConfigurations;
 import org.apache.metron.common.configuration.ParserConfigurations;
 import org.apache.metron.common.utils.ConversionUtils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class ParserWriterConfiguration implements WriterConfiguration {
@@ -51,6 +53,12 @@ public class ParserWriterConfiguration implements WriterConfiguration {
       return batchObj == null ? 0 : ConversionUtils.convert(batchObj, Integer.class);
     }
     return 0;
+  }
+
+  @Override
+  public List<Integer> getAllConfiguredTimeouts() {
+    // TODO - stub implementation
+    return new ArrayList<Integer>();
   }
 
   @Override

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/ParserWriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/ParserWriterConfiguration.java
@@ -32,13 +32,25 @@ public class ParserWriterConfiguration implements WriterConfiguration {
   @Override
   public int getBatchSize(String sensorName) {
     if(config != null
-    && config.getSensorParserConfig(sensorName) != null
-    && config.getSensorParserConfig(sensorName).getParserConfig() != null
-      ) {
+            && config.getSensorParserConfig(sensorName) != null
+            && config.getSensorParserConfig(sensorName).getParserConfig() != null
+            ) {
       Object batchObj = config.getSensorParserConfig(sensorName).getParserConfig().get(IndexingConfigurations.BATCH_SIZE_CONF);
       return batchObj == null ? 1 : ConversionUtils.convert(batchObj, Integer.class);
     }
     return 1;
+  }
+
+  @Override
+  public int getBatchTimeout(String sensorName) {
+    if(config != null
+            && config.getSensorParserConfig(sensorName) != null
+            && config.getSensorParserConfig(sensorName).getParserConfig() != null
+            ) {
+      Object batchObj = config.getSensorParserConfig(sensorName).getParserConfig().get(IndexingConfigurations.BATCH_TIMEOUT_CONF);
+      return batchObj == null ? 0 : ConversionUtils.convert(batchObj, Integer.class);
+    }
+    return 0;
   }
 
   @Override

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/SingleBatchConfigurationFacade.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/SingleBatchConfigurationFacade.java
@@ -18,6 +18,8 @@
 
 package org.apache.metron.common.configuration.writer;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class SingleBatchConfigurationFacade implements WriterConfiguration {
@@ -34,6 +36,12 @@ public class SingleBatchConfigurationFacade implements WriterConfiguration {
   @Override
   public int getBatchTimeout(String sensorName) {
     return 0;
+  }
+
+  @Override
+  public List<Integer> getAllConfiguredTimeouts() {
+    // null implementation since batching is disabled
+    return new ArrayList<Integer>();
   }
 
   @Override

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/SingleBatchConfigurationFacade.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/SingleBatchConfigurationFacade.java
@@ -32,6 +32,11 @@ public class SingleBatchConfigurationFacade implements WriterConfiguration {
   }
 
   @Override
+  public int getBatchTimeout(String sensorName) {
+    return 0;
+  }
+
+  @Override
   public String getIndex(String sensorName) {
     return config.getIndex(sensorName);
   }

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/WriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/WriterConfiguration.java
@@ -19,11 +19,14 @@
 package org.apache.metron.common.configuration.writer;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public interface WriterConfiguration extends Serializable {
   int getBatchSize(String sensorName);
-  default int getBatchTimeout(String sensorName) {return 0;}
+  int getBatchTimeout(String sensorName);
+  List<Integer> getAllConfiguredTimeouts();
   String getIndex(String sensorName);
   boolean isEnabled(String sensorName);
   Map<String, Object> getSensorConfig(String sensorName);

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/WriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/WriterConfiguration.java
@@ -21,7 +21,6 @@ package org.apache.metron.common.configuration.writer;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 public interface WriterConfiguration extends Serializable {
   int getBatchSize(String sensorName);

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/WriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/WriterConfiguration.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 public interface WriterConfiguration extends Serializable {
   int getBatchSize(String sensorName);
+  int getBatchTimeout(String sensorName);
   String getIndex(String sensorName);
   boolean isEnabled(String sensorName);
   Map<String, Object> getSensorConfig(String sensorName);

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/WriterConfiguration.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/configuration/writer/WriterConfiguration.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 public interface WriterConfiguration extends Serializable {
   int getBatchSize(String sensorName);
-  int getBatchTimeout(String sensorName);
+  default int getBatchTimeout(String sensorName) {return 0;}
   String getIndex(String sensorName);
   boolean isEnabled(String sensorName);
   Map<String, Object> getSensorConfig(String sensorName);

--- a/metron-platform/metron-indexing/README.md
+++ b/metron-platform/metron-indexing/README.md
@@ -40,7 +40,10 @@ elasticsearch or solr and hdfs writers running.
 
 The configuration for an individual writer-specific configuration is a JSON map with the following fields:
 * `index` : The name of the index to write to (defaulted to the name of the sensor).
-* `batchSize` : The size of the batch that is written to the indices at once (defaulted to `1`).
+* `batchSize` : The size of the batch that is written to the indices at once. Defaults to `1` (no batching).
+* `batchTimeout` : The timeout after which a batch will be flushed even if batchSize has not been met.  Optional.
+If unspecified, or set to `0`, it defaults to a system-determined duration which is a fraction of the Storm 
+parameter `topology.message.timeout.secs`.  Ignored if batchSize is `1`, since this disables batching.
 * `enabled` : Whether the writer is enabled (default `true`).
 
 ### Indexing Configuration Examples
@@ -72,11 +75,13 @@ Storm console.  e.g.:
    "elasticsearch": {
       "index": "foo",
       "batchSize" : 100,
+      "batchTimeout" : 0,
       "enabled" : true 
     },
    "hdfs": {
       "index": "foo",
       "batchSize": 1,
+      "batchTimeout" : 0,
       "enabled" : true
     }
 }
@@ -100,6 +105,7 @@ Storm console.  e.g.:
    "hdfs": {
       "index": "foo",
       "batchSize": 100,
+      "batchTimeout" : 0,
       "enabled" : false
     }
 }

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/IndexingConfigFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/IndexingConfigFunctions.java
@@ -39,10 +39,11 @@ public class IndexingConfigFunctions {
   @Stellar(
            namespace = "INDEXING"
           ,name = "SET_BATCH"
-          ,description = "Set batch size"
+          ,description = "Set batch size and timeout"
           ,params = {"sensorConfig - Sensor config to add transformation to."
                     ,"writer - The writer to update (e.g. elasticsearch, solr or hdfs)"
-                    ,"size - batch size (integer)"
+                    ,"size - batch size (integer), defaults to 5"
+                    ,"timeout - (optional) batch timeout in seconds (integer), defaults to 0, meaning system default"
                     }
           ,returns = "The String representation of the config in zookeeper"
           )
@@ -74,6 +75,11 @@ public class IndexingConfigFunctions {
         batchSize = ConversionUtils.convert(args.get(i++), Integer.class);
       }
       configObj.put(writer, IndexingConfigurations.setBatchSize((Map<String, Object>) configObj.get(writer), batchSize));
+      int batchTimeout = 0;
+      if(args.size() > 3) {
+        batchTimeout = ConversionUtils.convert(args.get(i++), Integer.class);
+      }
+      configObj.put(writer, IndexingConfigurations.setBatchTimeout((Map<String, Object>) configObj.get(writer), batchTimeout));
       try {
         return JSONUtils.INSTANCE.toJSON(configObj, true);
       } catch (JsonProcessingException e) {

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/SimpleHBaseEnrichmentWriterTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/writers/SimpleHBaseEnrichmentWriterTest.java
@@ -158,6 +158,12 @@ public class SimpleHBaseEnrichmentWriterTest {
       }
 
       @Override
+      public int getBatchTimeout(String sensorName) {
+        //TODO - enable unit testing
+        return 0;
+      }
+
+      @Override
       public String getIndex(String sensorName) {
         return SENSOR_TYPE;
       }

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 public class BulkWriterComponent<MESSAGE_T> {
   public static final Logger LOG = LoggerFactory
@@ -179,7 +180,7 @@ public class BulkWriterComponent<MESSAGE_T> {
       Long batchCreateTime = batchLastCreateTimeNs.get(sensorType);
       if (batchCreateTime == null) batchCreateTime = 0L; //shouldn't happen
       long ageNs = System.nanoTime() - batchCreateTime;
-      if (ageNs >= batchTimeout*(1e9)) {
+      if (ageNs >= TimeUnit.SECONDS.toNanos(batchTimeout)) {
         LOG.debug("Flushing " + sensorType + " batch queue due to age " + ageNs + "ns > " + batchTimeout + " secs");
         flush(sensorType, bulkMessageWriter, configurations,
                 sensorTupleMap.get(sensorType), sensorMessageMap.get(sensorType));

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
@@ -174,6 +174,8 @@ public class BulkWriterComponent<MESSAGE_T> {
           ) throws Exception
   {
     // Flushes all queues older than their batchTimeouts.
+    // This strategy does not guarantee each queue to be flushed at the exact batchTimeout.  Rather,
+    // the latency will be between the sensorType's batchTimeout and batchTimeout + tick.tuple.freq.secs.
     // Note queues with batchSize == 1 don't get batched, so they never persist in the sensorTupleMap.
     for (String sensorType : sensorTupleMap.keySet()) {
       int batchTimeout = configurations.getBatchTimeout(sensorType);

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/BulkWriterComponent.java
@@ -36,9 +36,11 @@ public class BulkWriterComponent<MESSAGE_T> {
             .getLogger(BulkWriterComponent.class);
   private Map<String, Collection<Tuple>> sensorTupleMap = new HashMap<>();
   private Map<String, List<MESSAGE_T>> sensorMessageMap = new HashMap<>();
+  private Map<String, Long> batchLastCreateTimeNs = new HashMap<>();
   private OutputCollector collector;
   private boolean handleCommit = true;
   private boolean handleError = true;
+
   public BulkWriterComponent(OutputCollector collector) {
     this.collector = collector;
   }
@@ -79,7 +81,6 @@ public class BulkWriterComponent<MESSAGE_T> {
     return new ArrayList<>();
   }
 
-
   public void errorAll(Throwable e) {
     for(Map.Entry<String, Collection<Tuple>> kv : sensorTupleMap.entrySet()) {
       error(e, kv.getValue());
@@ -93,6 +94,7 @@ public class BulkWriterComponent<MESSAGE_T> {
     sensorTupleMap.remove(sensorType);
     sensorMessageMap.remove(sensorType);
   }
+
   public void write( String sensorType
                    , Tuple tuple
                    , MESSAGE_T message
@@ -100,54 +102,88 @@ public class BulkWriterComponent<MESSAGE_T> {
                    , WriterConfiguration configurations
                    ) throws Exception
   {
-    if(!configurations.isEnabled(sensorType)) {
+    if (!configurations.isEnabled(sensorType)) {
       return;
     }
     int batchSize = configurations.getBatchSize(sensorType);
     Collection<Tuple> tupleList = sensorTupleMap.get(sensorType);
     if (tupleList == null) {
       tupleList = createTupleCollection();
+      if (batchSize > 1) {
+        sensorTupleMap.put(sensorType, tupleList);
+        batchLastCreateTimeNs.put(sensorType, System.nanoTime());
+      }
     }
     tupleList.add(tuple);
     List<MESSAGE_T> messageList = sensorMessageMap.get(sensorType);
     if (messageList == null) {
       messageList = new ArrayList<>();
+      if (batchSize > 1) {
+        sensorMessageMap.put(sensorType, messageList);
+      }
     }
     messageList.add(message);
 
-    if (tupleList.size() < batchSize) {
-      sensorTupleMap.put(sensorType, tupleList);
-      sensorMessageMap.put(sensorType, messageList);
-    } else {
-      long startTime = System.nanoTime();
-      try {
-        BulkWriterResponse response = bulkMessageWriter.write(sensorType, configurations, tupleList, messageList);
+    if (tupleList.size() >= batchSize) {
+      flush(sensorType, bulkMessageWriter, configurations, tupleList, messageList);
+    }
+  }
 
-        // Commit or error piecemeal.
-        if(handleCommit) {
-          commit(response);
-        }
+  private void flush( String sensorType
+                    , BulkMessageWriter<MESSAGE_T> bulkMessageWriter
+                    , WriterConfiguration configurations
+                    , Collection<Tuple> tupleList
+                    , List<MESSAGE_T> messageList
+                    ) throws Exception
+  {
+    long startTime = System.nanoTime();
+    try {
+      BulkWriterResponse response = bulkMessageWriter.write(sensorType, configurations, tupleList, messageList);
 
-        if(handleError) {
-          error(response);
-        } else if (response.hasErrors()) {
-          throw new IllegalStateException("Unhandled bulk errors in response: " + response.getErrors());
-        }
-      } catch (Throwable e) {
-        if(handleError) {
-          error(e, tupleList);
-        }
-        else {
-          throw e;
-        }
+      // Commit or error piecemeal.
+      if(handleCommit) {
+        commit(response);
       }
-      finally {
-        sensorTupleMap.remove(sensorType);
-        sensorMessageMap.remove(sensorType);
+
+      if(handleError) {
+        error(response);
+      } else if (response.hasErrors()) {
+        throw new IllegalStateException("Unhandled bulk errors in response: " + response.getErrors());
       }
-      long endTime = System.nanoTime();
-      long elapsed = endTime - startTime;
-      LOG.debug("Bulk batch completed in ~" + elapsed + " ns");
+    } catch (Throwable e) {
+      if(handleError) {
+        error(e, tupleList);
+      }
+      else {
+        throw e;
+      }
+    }
+    finally {
+      sensorTupleMap.remove(sensorType);
+      sensorMessageMap.remove(sensorType);
+    }
+    long endTime = System.nanoTime();
+    long elapsed = endTime - startTime;
+    LOG.debug("Bulk batch for sensor " + sensorType + " completed in ~" + elapsed + " ns");
+  }
+
+  public void flushTimeouts(
+            BulkMessageWriter<MESSAGE_T> bulkMessageWriter
+          , WriterConfiguration configurations
+          ) throws Exception
+  {
+    // Flushes all queues older than their batchTimeouts.
+    // Note queues with batchSize == 1 don't get batched, so they never persist in the sensorTupleMap.
+    for (String sensorType : sensorTupleMap.keySet()) {
+      int batchTimeout = configurations.getBatchTimeout(sensorType);
+      Long batchCreateTime = batchLastCreateTimeNs.get(sensorType);
+      if (batchCreateTime == null) batchCreateTime = 0L; //shouldn't happen
+      long ageNs = System.nanoTime() - batchCreateTime;
+      if (ageNs >= batchTimeout*(1e9)) {
+        LOG.debug("Flushing " + sensorType + " batch queue due to age " + ageNs + "ns > " + batchTimeout + " secs");
+        flush(sensorType, bulkMessageWriter, configurations,
+                sensorTupleMap.get(sensorType), sensorMessageMap.get(sensorType));
+      }
     }
   }
 }

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/bolt/BatchTimeoutHelper.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/bolt/BatchTimeoutHelper.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.metron.writer.bolt;
+
+import org.apache.metron.common.configuration.Configurations;
+import org.apache.metron.common.configuration.writer.WriterConfiguration;
+import org.apache.storm.Config;
+import org.apache.storm.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * Routines to help figure out the effective batchTimeout(s), using information from
+ * multiple configuration sources, topology.message.timeout.secs, and batchTimeoutDivisor,
+ * and use it to calculate defaultBatchTimeout and appropriate topology.tick.tuple.freq.secs.
+ *
+ * These methods cause no side effects outside of setting the internal member variables.
+ * "base" config are from defaults and storm.yaml (subordinate to Component config settings)
+ * "cli" config are from CLI arguments (superior to Component config settings)
+ * 0 or Integer.MAX_VALUE means disabled, except in batchTimeout values, where
+ * 0 means use the default.
+ *
+ * These lookups are fairly expensive, and changing the result values currently require
+ * a restart of the Storm topology anyway, so we just calculate at first use, and cache
+ * the results in the BatchTimeoutHelper instance.  If you want different results,
+ * you'll need a new instance or a restart.
+ */
+public class BatchTimeoutHelper {
+
+  private static final Logger LOG = LoggerFactory
+          .getLogger(BulkMessageWriterBolt.class);
+  private boolean initialized = false;
+  private Supplier<List<Integer>> listAllConfiguredTimeouts;
+  protected int batchTimeoutDivisor;
+  protected int baseMessageTimeoutSecs;
+  protected int cliMessageTimeoutSecs;
+  protected int baseTickTupleFreqSecs;
+  protected int cliTickTupleFreqSecs;
+  protected int effectiveMessageTimeoutSecs;
+  protected int maxBatchTimeoutAllowedSecs; //derived from MessageTimeoutSecs value
+  protected int minBatchTimeoutRequestedSecs; //min of all sensorType configured batchTimeout requests
+  protected int recommendedTickIntervalSecs;  //the answer
+
+  BatchTimeoutHelper( Supplier<List<Integer>> listAllConfiguredTimeouts
+          , int batchTimeoutDivisor
+          )
+  {
+    // The two arguments to the constructor are information only available at the Bolt level (batchTimeoutDivisor)
+    // and WriterConfiguration level (listAllConfiguredTimeouts).
+    this.batchTimeoutDivisor = batchTimeoutDivisor;
+    this.listAllConfiguredTimeouts = listAllConfiguredTimeouts;
+    // Reads and calculations are deferred until first call, then frozen for the duration of this BatchTimeoutHelper instance.
+  }
+
+  private synchronized void init() {
+    if (initialized) return;
+    readGlobalTimeoutConfigs();
+    calcMaxBatchTimeoutAllowed();
+    readMinBatchTimeoutRequested();
+    calcRecommendedTickInterval();
+    initialized = true;
+  }
+
+  //modified from Utils.readStormConfig()
+  private Map readStormConfigWithoutCLI() {
+    Map ret = Utils.readDefaultConfig();
+    String confFile = System.getProperty("storm.conf.file");
+    Map storm;
+    if (confFile == null || confFile.equals("")) {
+      storm = Utils.findAndReadConfigFile("storm.yaml", false);
+    } else {
+      storm = Utils.findAndReadConfigFile(confFile, true);
+    }
+    ret.putAll(storm);
+    return ret;
+  }
+
+  private void readGlobalTimeoutConfigs() {
+    Map stormConf = readStormConfigWithoutCLI();
+    Map cliConf   = Utils.readCommandLineOpts();
+    baseMessageTimeoutSecs = Integer.parseInt(
+            (String)stormConf.getOrDefault(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS, "0"));
+    cliMessageTimeoutSecs = Integer.parseInt(
+            (String)  cliConf.getOrDefault(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS, "0"));
+    baseTickTupleFreqSecs = Integer.parseInt(
+            (String)stormConf.getOrDefault(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS, "0"));
+    cliTickTupleFreqSecs = Integer.parseInt(
+            (String)  cliConf.getOrDefault(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS, "0"));
+  }
+
+  private void calcMaxBatchTimeoutAllowed() {
+    // The max batchTimeout allowed also becomes the default batchTimeout.
+    effectiveMessageTimeoutSecs = (cliMessageTimeoutSecs == 0 ? baseMessageTimeoutSecs : cliMessageTimeoutSecs);
+    if (effectiveMessageTimeoutSecs == 0) {
+      LOG.info("topology.message.timeout.secs is disabled in both Storm config and CLI.  Allowing unlimited batchTimeouts.");
+      maxBatchTimeoutAllowedSecs = Integer.MAX_VALUE;
+    }
+    else {
+      //Recommended value for safe batchTimeout is 1/2 * TOPOLOGY_MESSAGE_TIMEOUT_SECS.
+      //We further divide this by batchTimeoutDivisor for the particular Writer Bolt we are in,
+      //and subtract a delta of 1 second for surety (as well as rounding down)
+      maxBatchTimeoutAllowedSecs = effectiveMessageTimeoutSecs / (2 * batchTimeoutDivisor) - 1;
+    }
+  }
+
+  /**
+   * @return the max batchTimeout allowed, in seconds
+   */
+  protected int getDefaultBatchTimeout() {
+    if (!initialized) {this.init();}
+    return maxBatchTimeoutAllowedSecs;
+  }
+
+  private void readMinBatchTimeoutRequested() {
+    // The knowledge of how to list the currently configured batchTimeouts
+    // is delegated to the WriterConfiguration for the bolt that called us.
+    List<Integer> configuredTimeouts = listAllConfiguredTimeouts.get();
+
+    // Discard zero values, which mean "use default"
+    int minval = Integer.MAX_VALUE;
+    for (int k : configuredTimeouts) {
+      if (k < minval && k > 0) minval = k;
+    }
+    minBatchTimeoutRequestedSecs = minval;
+  }
+
+  private void calcRecommendedTickInterval() {
+    recommendedTickIntervalSecs = Integer.min(minBatchTimeoutRequestedSecs, maxBatchTimeoutAllowedSecs);
+    //If needed, we can +=1 to assure triggering on each cycle, but this shouldn't be necessary.
+    //Note that this strategy means that sensors with batchTimeout requested less frequently
+    //may now have latency of "their requested batchTimeout" + "this recommended tick interval",
+    //in the worst case.
+  }
+
+  protected int getRecommendedTickInterval() {
+    if (!initialized) {this.init();}
+    // Remember that parameter settings in the CLI override parameter settings set by the Storm component.
+    // We shouldn't have to deal with this in the Metron environment, but just in case,
+    // warn if our recommended value will be overridden by cliTickTupleFreqSecs.
+    if (cliTickTupleFreqSecs > 0 && cliTickTupleFreqSecs < recommendedTickIntervalSecs) {
+      LOG.warn("Parameter '" + Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS + "' has been forced to value '" +
+              Integer.toString(cliTickTupleFreqSecs) + "' via CLI configuration.  This will override the desired " +
+              "setting of '" + Integer.toString(recommendedTickIntervalSecs) +
+              "' and may lead to delayed batch flushing.");
+    }
+    return recommendedTickIntervalSecs;
+  }
+}

--- a/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/bolt/BatchTimeoutHelper.java
+++ b/metron-platform/metron-writer/src/main/java/org/apache/metron/writer/bolt/BatchTimeoutHelper.java
@@ -17,17 +17,13 @@
  */
 package org.apache.metron.writer.bolt;
 
-import org.apache.metron.common.configuration.Configurations;
-import org.apache.metron.common.configuration.writer.WriterConfiguration;
 import org.apache.storm.Config;
 import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
 
 /**


### PR DESCRIPTION
DO NOT INTEGRATE YET.  This is a preliminary review request.
This Jira Ticket is to add timeout flushing to all Writers that do batch writes.  Currently most of them will wait indefinitely for a batch to fill, resulting in message recycling due to `topology.message.timeout.secs`.  This changeset so far implements timeout flushing for the BulkMessageWriterBolt.

I am now starting to work on unit tests, so while this code compiles and passes existing unit tests, the new functionality has not yet been tested.  However, I would be grateful for a quick review of the basic approach, focusing on changes in:
* BulkMessageWriterBolt
* BulkWriterComponent
* BatchTimeoutHelper (new), and 
* IndexingConfigurations.  

All of the other changes are basically boilerplate, just laying "getBatchTimeout()" facade methods alongside existing "getBatchSize()" facade methods.  (There's a lot of layers!)

The flush-on-timeout logic is fairly straightforward.  It was implemented by a refactoring of BulkWriterComponent and basic Tick Tuple reception in BulkMessageWriterBolt.

The tricky part was figuring out the appropriate setting for 'topology.tick.tuple.freq.secs' if the administrator configures non-default batchTimeouts.  It is necessary to enumerate the batchTimeout settings for all configured sensorNames, which is implemented in IndexingConfigurations$getAllConfiguredTimeouts().  Then multiple other factors must be taken into account to determine the allowed and recommended settings, which is implemented in BatchTimeoutHelper.  If there are better ways to accomplish these things, please share your ideas.

After feedback is incorporated, I need to make similar changes to the ParserWriter, and possibly other places in the code where batching is used and timeouts are not yet implemented.  That is separable work, which I'm aware also needs to be done.  Thanks for taking time to look at this.