### PR TITLE
METRON-705: Parallelize the build in travis to the extent that is obvious

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - oraclejdk8
 script:
   - |
-    mvn -q -DskipTests -T 1.5C install && mvn -q -T 1.5C test && mvn -q integration-test && build_utils/verify_licenses.sh
+    mvn -q -DskipTests -T 2C install && mvn -q -T 2C test && mvn -q -Dtest=\*IntegrationTest -DfailIfNoTests=false integration-test && build_utils/verify_licenses.sh
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - oraclejdk8
 script:
   - |
-    mvn apache-rat:check && mvn -q -T 2C test && mvn -q surefire:test@integration-tests && build_utils/verify_licenses.sh
+    mvn -q apache-rat:check && mvn -q -T 2C test && mvn -q surefire:test@integration-tests && build_utils/verify_licenses.sh
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - export PATH=$M2_HOME/bin:$PATH
 script:
   - |
-    mvn -q -T 2C -DskipTests install && mvn -q -T 2C surefire:test@unit-test && mvn -q surefire:test@integration-tests && build_utils/verify_licenses.sh
+    mvn -q -T 2C -DskipTests install && mvn -q -T 2C surefire:test@unit-tests && mvn -q surefire:test@integration-tests && build_utils/verify_licenses.sh
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - oraclejdk8
 script:
   - |
-    mvn -q apache-rat:check && mvn -q -T 2C test && mvn -q surefire:test@integration-tests && build_utils/verify_licenses.sh
+    mvn -q -T 2C -DskipTests install && mvn -q -T 2C test && mvn -q surefire:test@integration-tests && build_utils/verify_licenses.sh
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - oraclejdk8
 script:
   - |
-    mvn -q integration-test install && build_utils/verify_licenses.sh
+    mvn -q -DskipTests -T 1.5C install && mvn -q -T 1.5C test && mvn -q integration-test && build_utils/verify_licenses.sh
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,9 @@ before_install:
   - unzip -qq apache-maven-3.3.9-bin.zip
   - export M2_HOME=$PWD/apache-maven-3.3.9
   - export PATH=$M2_HOME/bin:$PATH
-env:
-  - TEST_SUITE="-T 2C surefire:test@unit-tests"
-  - TEST_SUITE="surefire:test@integration-tests"
 script:
   - |
-    time mvn -q -T 2C -DskipTests install && time mvn -q $TEST_SUITE && time build_utils/verify_licenses.sh
+    time mvn -q -T 2C -DskipTests install && time mvn -q -T 2C surefire:test@unit-tests && mvn -q surefire:test@integration-tests  && time build_utils/verify_licenses.sh
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - export M2_HOME=$PWD/apache-maven-3.3.9
   - export PATH=$M2_HOME/bin:$PATH
 env:
-  - TEST_SUITE=-T 2C surefire:test@unit-tests
+  - TEST_SUITE="-T 2C surefire:test@unit-tests"
   - TEST_SUITE=surefire:test@integration-tests
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ before_install:
   - export PATH=$M2_HOME/bin:$PATH
 env:
   - TEST_SUITE="-T 2C surefire:test@unit-tests"
-  - TEST_SUITE=surefire:test@integration-tests
+  - TEST_SUITE="surefire:test@integration-tests"
 script:
   - |
-    mvn -q -T 2C -DskipTests install && mvn -q $(echo $TEST_SUITE) && build_utils/verify_licenses.sh
+    time mvn -q -T 2C -DskipTests install && time mvn -q $TEST_SUITE && time build_utils/verify_licenses.sh
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   - TEST_SUITE=surefire:test@integration-tests
 script:
   - |
-    mvn -q -T 2C -DskipTests install && mvn -q $TEST_SUITE && build_utils/verify_licenses.sh
+    mvn -q -T 2C -DskipTests install && mvn -q $(echo $TEST_SUITE) && build_utils/verify_licenses.sh
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ before_install:
   - unzip -qq apache-maven-3.3.9-bin.zip
   - export M2_HOME=$PWD/apache-maven-3.3.9
   - export PATH=$M2_HOME/bin:$PATH
+env:
+  - TEST_SUITE=-T 2C surefire:test@unit-tests
+  - TEST_SUITE=surefire:test@integration-tests
 script:
   - |
-    mvn -q -T 2C -DskipTests install && mvn -q -T 2C surefire:test@unit-tests && mvn -q surefire:test@integration-tests && build_utils/verify_licenses.sh
+    mvn -q -T 2C -DskipTests install && mvn -q $TEST_SUITE && build_utils/verify_licenses.sh
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - export PATH=$M2_HOME/bin:$PATH
 script:
   - |
-    mvn -q -T 2C -DskipTests install && mvn -q -T 2C test && mvn -q surefire:test@integration-tests && build_utils/verify_licenses.sh
+    mvn -q -T 2C -DskipTests install && mvn -q -T 2C surefire:test@unit-test && mvn -q surefire:test@integration-tests && build_utils/verify_licenses.sh
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ install: true
 language: java
 jdk:
   - oraclejdk8
+before_install:
+  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
+  - unzip -qq apache-maven-3.3.9-bin.zip
+  - export M2_HOME=$PWD/apache-maven-3.3.9
+  - export PATH=$M2_HOME/bin:$PATH
 script:
   - |
     mvn -q -T 2C -DskipTests install && mvn -q -T 2C test && mvn -q surefire:test@integration-tests && build_utils/verify_licenses.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - oraclejdk8
 script:
   - |
-    mvn -q -DskipTests -T 2C install && mvn -q -T 2C test && mvn -q -Dtest=\*IntegrationTest -DfailIfNoTests=false integration-test && build_utils/verify_licenses.sh
+    mvn apache-rat:check && mvn -q -T 2C test && mvn -q surefire:test@integration-tests && build_utils/verify_licenses.sh
 cache:
   directories:
   - $HOME/.m2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/apache/incubator-metron.svg?branch=master)](https://travis-ci.org/apache/incubator-metron)
-
+ 
 # Apache Metron (Incubating)
  
 Metron integrates a variety of open source big data technologies in order

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,7 @@
                 <configuration>
                   <excludes>
                         <exclude>dependencies_with_url.csv</exclude>
+                        <exclude>apache-maven-3.3.9/**</exclude>
                         <exclude>**/*.md</exclude>
                         <exclude>**/VERSION</exclude>
                         <exclude>**/*.json</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,7 @@
                 <configuration>
                   <excludes>
                         <exclude>dependencies_with_url.csv</exclude>
+                        <!-- In travis we need to pull down maven 3.3.9, so we should exclude it here as it is not our code. -->
                         <exclude>apache-maven-3.3.9/**</exclude>
                         <exclude>**/*.md</exclude>
                         <exclude>**/VERSION</exclude>


### PR DESCRIPTION
Travis suggests [here](https://blog.travis-ci.com/2012-11-28-speeding-up-your-tests-by-parallelizing-them/) that for situations where the integration get chunky, one can parallelize them using their build matrix functionality. Also, if we can separate those out, we can also process-parallelize the unit and build.

Currently the build time is cut roughly in half to 24 minutes wall-clock.

**NOTE: This is just a stopgap that requires no code changes to lower build wall-clock times.  This is not intended to replace work parallelizing the integration tests or making the build take less time.**