### PR TITLE
METRON-707: Correct ansible to execute threat intel bulk loading via the flat file script

### DIFF
--- a/metron-deployment/roles/metron_streaming/defaults/main.yml
+++ b/metron-deployment/roles/metron_streaming/defaults/main.yml
@@ -67,7 +67,7 @@ pcap_hdfs_path: "/apps/metron/pcap"
 geo_hdfs_path: "/apps/metron/geo/default"
 
 threat_intel_bulk_load: True
-threat_intel_bin: "{{ metron_directory }}/bin/threatintel_bulk_load.sh"
+threat_intel_bin: "{{ metron_directory }}/bin/flatfile_loader.sh"
 threat_intel_work_dir: /tmp/ti_bulk
 threat_intel_csv_filename: "threat_ip.csv"
 threat_intel_csv_filepath: "{{ threat_intel_csv_filename }}"

--- a/metron-deployment/roles/metron_streaming/tasks/threat_intel.yml
+++ b/metron-deployment/roles/metron_streaming/tasks/threat_intel.yml
@@ -37,7 +37,7 @@
   command: "hdfs dfs -put -f {{ threat_intel_work_dir }}/{{ threat_intel_csv_filename }} ."
 
 - name: Run Threat Intel Bulk Load
-  shell: "{{ threat_intel_bin }} -f t --table {{threatintel_hbase_table}} -e {{ threat_intel_work_dir }}/extractor.json  -i /user/root && touch {{ threat_intel_work_dir }}/loaded"
+  shell: "{{ threat_intel_bin }} -c t -t {{threatintel_hbase_table}} -e {{ threat_intel_work_dir }}/extractor.json -i /user/root -m MR && touch {{ threat_intel_work_dir }}/loaded"
   args:
     creates: "{{ threat_intel_work_dir }}/loaded"
 


### PR DESCRIPTION
Ansible deployments in aws or in vagrant with `threat_intel_bulk_load` turned on in its inventorywill fail currently due to an executable renaming.

To test this:
* Run it up in AWS or in vagrant with `threat_intel_bulk_load`set to `True` in `metron-deployment/inventory/quick-dev-platform`
* After the deployment verify that the `threatintel` hbase table has data in it via `echo "scan 'threatintel'" | hbase shell`