### PR TITLE
METRON-710 Rev MPack Version to 0.3.1.0

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/pom.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.metron.packaging.mpacks</groupId>
     <artifactId>metron_mpack</artifactId>
-    <version>1.0.0.0-SNAPSHOT</version>
+    <version>0.3.1.0</version>
     <name>Metron Ambari Management Pack</name>
 
     <parent>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/mpack.json
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/mpack.json
@@ -1,7 +1,7 @@
 {
   "type": "full-release",
   "name": "metron-ambari.mpack",
-  "version": "1.0.0.0",
+  "version": "0.3.1.0",
   "description": "Ambari Management Pack for Apache Metron",
   "prerequisites": {
     "min-ambari-version": "2.4.0.0",


### PR DESCRIPTION
Updating the version number in the mpack stuff (nothing automated, just manually changed it).

Built a new version of the mpack locally, and it has the 0.3.1.0 version number attached to the artifacts.

I have not spun it up on a cluster to ensure Ambari reports the version number (it's grabbed from the mpack.json).  If anybody wants it spun up outside, I can go ahead and do it, but I wanted the PR up early given the release timing.