### PR TITLE
METRON-725: Javadoc is broken by the use of apiNote

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/file/ReaderSpliterator.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/utils/file/ReaderSpliterator.java
@@ -65,18 +65,7 @@ public class ReaderSpliterator implements Spliterator<String> {
       throw new IllegalStateException(e);
     }
   }
-  /**
-   * If a remaining element exists, performs the given action on it,
-   * returning {@code true}; else returns {@code false}.  If this
-   * Spliterator is {@link #ORDERED} the action is performed on the
-   * next element in encounter order.  Exceptions thrown by the
-   * action are relayed to the caller.
-   *
-   * @param action The action
-   * @return {@code false} if no remaining elements existed
-   * upon entry to this method, else {@code true}.
-   * @throws NullPointerException if the specified action is null
-   */
+
   @Override
   public boolean tryAdvance(Consumer<? super String> action) {
     if (action == null) {
@@ -96,45 +85,6 @@ public class ReaderSpliterator implements Spliterator<String> {
     }
   }
 
-  /**
-   * If this spliterator can be partitioned, returns a Spliterator
-   * covering elements, that will, upon return from this method, not
-   * be covered by this Spliterator.
-   * <p>
-   * <p>If this Spliterator is {@link #ORDERED}, the returned Spliterator
-   * must cover a strict prefix of the elements.
-   * <p>
-   * <p>Unless this Spliterator covers an infinite number of elements,
-   * repeated calls to {@code trySplit()} must eventually return {@code null}.
-   * Upon non-null return:
-   * <ul>
-   * <li>the value reported for {@code estimateSize()} before splitting,
-   * must, after splitting, be greater than or equal to {@code estimateSize()}
-   * for this and the returned Spliterator; and</li>
-   * <li>if this Spliterator is {@code SUBSIZED}, then {@code estimateSize()}
-   * for this spliterator before splitting must be equal to the sum of
-   * {@code estimateSize()} for this and the returned Spliterator after
-   * splitting.</li>
-   * </ul>
-   * <p>
-   * <p>This method may return {@code null} for any reason,
-   * including emptiness, inability to split after traversal has
-   * commenced, data structure constraints, and efficiency
-   * considerations.
-   *
-   * @return a {@code Spliterator} covering some portion of the
-   * elements, or {@code null} if this spliterator cannot be split
-   * @apiNote An ideal {@code trySplit} method efficiently (without
-   * traversal) divides its elements exactly in half, allowing
-   * balanced parallel computation.  Many departures from this ideal
-   * remain highly effective; for example, only approximately
-   * splitting an approximately balanced tree, or for a tree in
-   * which leaf nodes may contain either one or two elements,
-   * failing to further split these nodes.  However, large
-   * deviations in balance and/or overly inefficient {@code
-   * trySplit} mechanics typically result in poor parallel
-   * performance.
-   */
   @Override
   public Spliterator<String> trySplit() {
     final ConsumerWithLookback holder = new ConsumerWithLookback();
@@ -150,52 +100,11 @@ public class ReaderSpliterator implements Spliterator<String> {
     return spliterator(batch, 0, j, characteristics() | SIZED);
   }
 
-  /**
-   * Returns an estimate of the number of elements that would be
-   * encountered by a {@link #forEachRemaining} traversal, or returns {@link
-   * Long#MAX_VALUE} if infinite, unknown, or too expensive to compute.
-   * <p>
-   * <p>If this Spliterator is {@link #SIZED} and has not yet been partially
-   * traversed or split, or this Spliterator is {@link #SUBSIZED} and has
-   * not yet been partially traversed, this estimate must be an accurate
-   * count of elements that would be encountered by a complete traversal.
-   * Otherwise, this estimate may be arbitrarily inaccurate, but must decrease
-   * as specified across invocations of {@link #trySplit}.
-   *
-   * @return the estimated size, or {@code Long.MAX_VALUE} if infinite,
-   * unknown, or too expensive to compute.
-   * @apiNote Even an inexact estimate is often useful and inexpensive to compute.
-   * For example, a sub-spliterator of an approximately balanced binary tree
-   * may return a value that estimates the number of elements to be half of
-   * that of its parent; if the root Spliterator does not maintain an
-   * accurate count, it could estimate size to be the power of two
-   * corresponding to its maximum depth.
-   */
   @Override
   public long estimateSize() {
     return Long.MAX_VALUE;
   }
 
-  /**
-   * Returns a set of characteristics of this Spliterator and its
-   * elements. The result is represented as ORed values from {@link
-   * #ORDERED}, {@link #DISTINCT}, {@link #SORTED}, {@link #SIZED},
-   * {@link #NONNULL}, {@link #IMMUTABLE}, {@link #CONCURRENT},
-   * {@link #SUBSIZED}.  Repeated calls to {@code characteristics()} on
-   * a given spliterator, prior to or in-between calls to {@code trySplit},
-   * should always return the same result.
-   * <p>
-   * <p>If a Spliterator reports an inconsistent set of
-   * characteristics (either those returned from a single invocation
-   * or across multiple invocations), no guarantees can be made
-   * about any computation using this Spliterator.
-   *
-   * @return a representation of characteristics
-   * @apiNote The characteristics of a given spliterator before splitting
-   * may differ from the characteristics after splitting.  For specific
-   * examples see the characteristic values {@link #SIZED}, {@link #SUBSIZED}
-   * and {@link #CONCURRENT}.
-   */
   @Override
   public int characteristics() {
     return characteristics;
@@ -203,11 +112,6 @@ public class ReaderSpliterator implements Spliterator<String> {
 
   static class ConsumerWithLookback implements Consumer<String> {
     String value;
-    /**
-     * Performs this operation on the given argument.
-     *
-     * @param string the input argument
-     */
     @Override
     public void accept(String string) {
       this.value = string;


### PR DESCRIPTION
As noted in the ticket, there are 3 options for fixing this

1. Just delete the offending inherited javadoc
2. Explicitly inherit the Javadoc
3. Enable the `@apiNote` tag

This PR just does the first one, but it's easy to change if anybody has a strong preference. I lean pretty heavily towards 1 or 2 (because 3 is apparently more intended towards the Java language, rather than outside usage)

To test, just run mvn javadoc:javadoc.

This also suggests that we should be running this as part of our normal build process (and I'll create a ticket if people agree).
