### PR TITLE
METRON-726: Clean up mvn site generation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,8 +34,7 @@ In order to streamline the review of the contribution we ask you follow these gu
 
   ```
   cd site-book
-  bin/generate-md.sh
-  mvn site:site
+  mvn site
   ```
 
 #### Note:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ before_install:
   - export PATH=$M2_HOME/bin:$PATH
 script:
   - |
-    time mvn -q -T 2C -DskipTests install && time mvn -q -T 2C surefire:test@unit-tests && mvn -q surefire:test@integration-tests  && time mvn -q test --projects metron-interface/metron-config && time build_utils/verify_licenses.sh
-
     time mvn -q -T 2C -DskipTests install && time mvn -q -T 2C jacoco:prepare-agent surefire:test@unit-tests && mvn -q jacoco:prepare-agent surefire:test@integration-tests  && time mvn -q jacoco:prepare-agent test --projects metron-interface/metron-config && time build_utils/verify_licenses.sh
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_install:
 script:
   - |
     time mvn -q -T 2C -DskipTests install && time mvn -q -T 2C surefire:test@unit-tests && mvn -q surefire:test@integration-tests  && time mvn -q test --projects metron-interface/metron-config && time build_utils/verify_licenses.sh
+
+    time mvn -q -T 2C -DskipTests install && time mvn -q -T 2C jacoco:prepare-agent surefire:test@unit-tests && mvn -q jacoco:prepare-agent surefire:test@integration-tests  && time mvn -q jacoco:prepare-agent test --projects metron-interface/metron-config && time build_utils/verify_licenses.sh
 cache:
   directories:
   - $HOME/.m2

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ You can swap "install" for "package" in the commands above if you don't want to 
 
 To build and run reporting with code coverage:
 ```
-$ mvn clean install site site:stage-deploy site:deploy
+$ mvn clean install
+$ mvn site site:stage-deploy site:deploy
 ```
 
 Code coverage can be skipped by skipping tests:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ $ mvn clean install -PHDP-2.5.0.0
 
 You can swap "install" for "package" in the commands above if you don't want to deploy the artifacts to your local .m2 repo.
 
+# Build Metron Reporting
+
+To build and run reporting with code coverage:
+```
+$ mvn clean install site site:stage-deploy site:deploy
+```
+
+Code coverage can be skipped by skipping tests:
+```
+$ mvn clean install -DskipTests site site:stage-deploy site:deploy
+```
+
+The staged site is deployed to /tmp/metron/site/index.html, and can be viewed by opening the file in a browser.
+
 # Navigating the Architecture
 
 Metron is at its core a Kappa architecture with Apache Storm as the processing

--- a/metron-analytics/metron-maas-common/pom.xml
+++ b/metron-analytics/metron-maas-common/pom.xml
@@ -81,6 +81,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>${global_surefire_version}</version>
         <configuration>
           <systemProperties>
             <property>

--- a/metron-analytics/metron-maas-common/pom.xml
+++ b/metron-analytics/metron-maas-common/pom.xml
@@ -21,6 +21,7 @@
     <version>0.4.0</version>
   </parent>
   <artifactId>metron-maas-common</artifactId>
+  <url>https://metron.apache.org/</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-analytics/metron-maas-common/pom.xml
+++ b/metron-analytics/metron-maas-common/pom.xml
@@ -75,24 +75,6 @@
     </dependency>
 
   </dependencies>
-  <reporting>
-    <plugins>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${global_surefire_version}</version>
-        <configuration>
-          <systemProperties>
-            <property>
-              <name>mode</name>
-              <value>global</value>
-            </property>
-          </systemProperties>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
   <build>
     <plugins>
       <plugin>

--- a/metron-analytics/metron-maas-common/pom.xml
+++ b/metron-analytics/metron-maas-common/pom.xml
@@ -92,20 +92,20 @@
       </plugin>
 
       <!-- Normally, dependency report takes time, skip it -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
+      <!--<plugin>-->
+        <!--<groupId>org.apache.maven.plugins</groupId>-->
+        <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+        <!--<version>2.9</version>-->
+        <!--<configuration>-->
+          <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+        <!--</configuration>-->
+      <!--</plugin>-->
 
-        <configuration>
-          <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-        </configuration>
-      </plugin>
-
-      <plugin>
+      <!--plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>emma-maven-plugin</artifactId>
         <version>1.0-alpha-3</version>
-      </plugin>
+      </plugin-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>

--- a/metron-analytics/metron-maas-common/pom.xml
+++ b/metron-analytics/metron-maas-common/pom.xml
@@ -90,29 +90,6 @@
           </systemProperties>
         </configuration>
       </plugin>
-
-      <!-- Normally, dependency report takes time, skip it -->
-      <!--<plugin>-->
-        <!--<groupId>org.apache.maven.plugins</groupId>-->
-        <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-        <!--<version>2.9</version>-->
-        <!--<configuration>-->
-          <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-        <!--</configuration>-->
-      <!--</plugin>-->
-
-      <!--plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>emma-maven-plugin</artifactId>
-        <version>1.0-alpha-3</version>
-      </plugin-->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <configuration>
-          <targetJdk>${global_java_version}</targetJdk>
-        </configuration>
-      </plugin>
     </plugins>
   </reporting>
   <build>

--- a/metron-analytics/metron-maas-service/pom.xml
+++ b/metron-analytics/metron-maas-service/pom.xml
@@ -221,20 +221,20 @@
       </plugin>
 
       <!-- Normally, dependency report takes time, skip it -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
+      <!--<plugin>-->
+        <!--<groupId>org.apache.maven.plugins</groupId>-->
+        <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+        <!--<version>2.9</version>-->
+        <!--<configuration>-->
+          <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+        <!--</configuration>-->
+      <!--</plugin>-->
 
-        <configuration>
-          <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>emma-maven-plugin</artifactId>
-        <version>1.0-alpha-3</version>
-      </plugin>
+      <!--<plugin>-->
+        <!--<groupId>org.codehaus.mojo</groupId>-->
+        <!--<artifactId>emma-maven-plugin</artifactId>-->
+        <!--<version>1.0-alpha-3</version>-->
+      <!--</plugin>-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>

--- a/metron-analytics/metron-maas-service/pom.xml
+++ b/metron-analytics/metron-maas-service/pom.xml
@@ -219,29 +219,6 @@
           </systemProperties>
         </configuration>
       </plugin>
-
-      <!-- Normally, dependency report takes time, skip it -->
-      <!--<plugin>-->
-        <!--<groupId>org.apache.maven.plugins</groupId>-->
-        <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-        <!--<version>2.9</version>-->
-        <!--<configuration>-->
-          <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-        <!--</configuration>-->
-      <!--</plugin>-->
-
-      <!--<plugin>-->
-        <!--<groupId>org.codehaus.mojo</groupId>-->
-        <!--<artifactId>emma-maven-plugin</artifactId>-->
-        <!--<version>1.0-alpha-3</version>-->
-      <!--</plugin>-->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <configuration>
-          <targetJdk>${global_java_version}</targetJdk>
-        </configuration>
-      </plugin>
     </plugins>
   </reporting>
   <build>

--- a/metron-analytics/metron-maas-service/pom.xml
+++ b/metron-analytics/metron-maas-service/pom.xml
@@ -204,24 +204,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <reporting>
-    <plugins>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${global_surefire_version}</version>
-        <configuration>
-          <systemProperties>
-            <property>
-              <name>mode</name>
-              <value>global</value>
-            </property>
-          </systemProperties>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
   <build>
     <plugins>
       <plugin>

--- a/metron-analytics/metron-maas-service/pom.xml
+++ b/metron-analytics/metron-maas-service/pom.xml
@@ -210,6 +210,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>${global_surefire_version}</version>
         <configuration>
           <systemProperties>
             <property>

--- a/metron-analytics/metron-maas-service/pom.xml
+++ b/metron-analytics/metron-maas-service/pom.xml
@@ -21,6 +21,7 @@
     <version>0.4.0</version>
   </parent>
   <artifactId>metron-maas-service</artifactId>
+  <url>https://metron.apache.org/</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-analytics/metron-profiler-client/pom.xml
+++ b/metron-analytics/metron-profiler-client/pom.xml
@@ -248,31 +248,6 @@
         </dependency>
 
     </dependencies>
-    <reporting>
-        <plugins>
-            <!-- Normally, dependency report takes time, skip it -->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-                <!--<version>2.9</version>-->
-                <!--<configuration>-->
-                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-            <!--<plugin>-->
-                <!--<groupId>org.codehaus.mojo</groupId>-->
-                <!--<artifactId>emma-maven-plugin</artifactId>-->
-                <!--<version>1.0-alpha-3</version>-->
-            <!--</plugin>-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>
-                    <targetJdk>${global_java_version}</targetJdk>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
     <build>
         <plugins>
             <plugin>

--- a/metron-analytics/metron-profiler-client/pom.xml
+++ b/metron-analytics/metron-profiler-client/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-profiler-client</artifactId>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-analytics/metron-profiler-client/pom.xml
+++ b/metron-analytics/metron-profiler-client/pom.xml
@@ -251,20 +251,19 @@
     <reporting>
         <plugins>
             <!-- Normally, dependency report takes time, skip it -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
-
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>1.0-alpha-3</version>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+                <!--<version>2.9</version>-->
+                <!--<configuration>-->
+                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
+            <!--<plugin>-->
+                <!--<groupId>org.codehaus.mojo</groupId>-->
+                <!--<artifactId>emma-maven-plugin</artifactId>-->
+                <!--<version>1.0-alpha-3</version>-->
+            <!--</plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>

--- a/metron-analytics/metron-profiler-common/pom.xml
+++ b/metron-analytics/metron-profiler-common/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-profiler-common</artifactId>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-analytics/metron-profiler/pom.xml
+++ b/metron-analytics/metron-profiler/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-profiler</artifactId>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-analytics/metron-profiler/pom.xml
+++ b/metron-analytics/metron-profiler/pom.xml
@@ -275,20 +275,20 @@
     <reporting>
         <plugins>
             <!-- Normally, dependency report takes time, skip it -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>1.0-alpha-3</version>
-                <inherited>true</inherited>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+                <!--<version>2.9</version>-->
+                <!--<configuration>-->
+                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
+            <!--<plugin>-->
+                <!--<groupId>org.codehaus.mojo</groupId>-->
+                <!--<artifactId>emma-maven-plugin</artifactId>-->
+                <!--<version>1.0-alpha-3</version>-->
+                <!--<inherited>true</inherited>-->
+            <!--</plugin>-->
         </plugins>
     </reporting>
 

--- a/metron-analytics/metron-profiler/pom.xml
+++ b/metron-analytics/metron-profiler/pom.xml
@@ -272,25 +272,6 @@
             </exclusions>
         </dependency>
     </dependencies>
-    <reporting>
-        <plugins>
-            <!-- Normally, dependency report takes time, skip it -->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-                <!--<version>2.9</version>-->
-                <!--<configuration>-->
-                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-            <!--<plugin>-->
-                <!--<groupId>org.codehaus.mojo</groupId>-->
-                <!--<artifactId>emma-maven-plugin</artifactId>-->
-                <!--<version>1.0-alpha-3</version>-->
-                <!--<inherited>true</inherited>-->
-            <!--</plugin>-->
-        </plugins>
-    </reporting>
 
     <build>
         <plugins>

--- a/metron-analytics/metron-profiler/pom.xml
+++ b/metron-analytics/metron-profiler/pom.xml
@@ -279,10 +279,10 @@
                 <!-- Separates the unit tests from the integration tests. -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>${global_surefire_version}</version>
                 <configuration>
                     <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
-                    <argLine>-Xmx2048m</argLine>
+                    <argLine>@{argLine} -Xmx2048m</argLine>
                     <skip>true</skip>
                     <!-- Show 100% of the lines from the stack trace (doesn't work) -->
                     <trimStackTrace>false</trimStackTrace>

--- a/metron-analytics/metron-profiler/pom.xml
+++ b/metron-analytics/metron-profiler/pom.xml
@@ -276,56 +276,6 @@
     <build>
         <plugins>
             <plugin>
-                <!-- Separates the unit tests from the integration tests. -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${global_surefire_version}</version>
-                <configuration>
-                    <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
-                    <argLine>@{argLine} -Xmx2048m</argLine>
-                    <skip>true</skip>
-                    <!-- Show 100% of the lines from the stack trace (doesn't work) -->
-                    <trimStackTrace>false</trimStackTrace>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>unit-tests</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <!-- Never skip running the tests when the test phase is invoked -->
-                            <skip>false</skip>
-                            <includes>
-                                <!-- Include unit tests within integration-test phase. -->
-                                <include>**/*Test.java</include>
-                            </includes>
-                            <excludes>
-                                <!-- Exclude integration tests within (unit) test phase. -->
-                                <exclude>**/*IntegrationTest.java</exclude>
-                            </excludes>
-
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>integration-tests</id>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <!-- Never skip running the tests when the integration-test phase is invoked -->
-                            <skip>false</skip>
-                            <includes>
-                                <!-- Include integration tests within integration-test phase. -->
-                                <include>**/*IntegrationTest.java</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>${global_shade_version}</version>

--- a/metron-analytics/metron-statistics/pom.xml
+++ b/metron-analytics/metron-statistics/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-statistics</artifactId>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-analytics/pom.xml
+++ b/metron-analytics/pom.xml
@@ -80,7 +80,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.18</version>
+				<version>${global_surefire_version}</version>
 				<configuration>
 					<argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
 					<systemProperties>

--- a/metron-analytics/pom.xml
+++ b/metron-analytics/pom.xml
@@ -92,14 +92,15 @@
 				</configuration>
 			</plugin>
 			<!-- Normally, dependency report takes time, skip it -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>2.7</version>
-				<configuration>
-					<dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-				</configuration>
-			</plugin>
+			<!--<plugin>-->
+				<!--<groupId>org.apache.maven.plugins</groupId>-->
+				<!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+				<!--<version>2.9</version>-->
+				<!--<configuration>-->
+					<!--<dependencyDetailsEnabled>false</dependencyDetailsEnabled>-->
+					<!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+				<!--</configuration>-->
+			<!--</plugin>-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
@@ -108,12 +109,12 @@
           <targetJdk>${global_java_version}</targetJdk>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>emma-maven-plugin</artifactId>
-				<version>1.0-alpha-3</version>
-				<inherited>true</inherited>
-			</plugin>
+			<!--<plugin>-->
+				<!--<groupId>org.codehaus.mojo</groupId>-->
+				<!--<artifactId>emma-maven-plugin</artifactId>-->
+				<!--<version>1.0-alpha-3</version>-->
+				<!--<inherited>true</inherited>-->
+			<!--</plugin>-->
 		</plugins>
 	</reporting>
 	<repositories>

--- a/metron-analytics/pom.xml
+++ b/metron-analytics/pom.xml
@@ -91,30 +91,6 @@
 					</systemProperties>
 				</configuration>
 			</plugin>
-			<!-- Normally, dependency report takes time, skip it -->
-			<!--<plugin>-->
-				<!--<groupId>org.apache.maven.plugins</groupId>-->
-				<!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-				<!--<version>2.9</version>-->
-				<!--<configuration>-->
-					<!--<dependencyDetailsEnabled>false</dependencyDetailsEnabled>-->
-					<!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-				<!--</configuration>-->
-			<!--</plugin>-->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.3</version>
-				<configuration>
-          <targetJdk>${global_java_version}</targetJdk>
-				</configuration>
-			</plugin>
-			<!--<plugin>-->
-				<!--<groupId>org.codehaus.mojo</groupId>-->
-				<!--<artifactId>emma-maven-plugin</artifactId>-->
-				<!--<version>1.0-alpha-3</version>-->
-				<!--<inherited>true</inherited>-->
-			<!--</plugin>-->
 		</plugins>
 	</reporting>
 	<repositories>

--- a/metron-analytics/pom.xml
+++ b/metron-analytics/pom.xml
@@ -75,24 +75,6 @@
 		<plugins>
 		</plugins>
 	</build>
-	<reporting>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>${global_surefire_version}</version>
-				<configuration>
-					<argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
-					<systemProperties>
-						<property>
-							<name>mode</name>
-							<value>local</value>
-						</property>
-					</systemProperties>
-				</configuration>
-			</plugin>
-		</plugins>
-	</reporting>
 	<repositories>
 		<repository>
 			<id>clojars.org</id>

--- a/metron-deployment/pom.xml
+++ b/metron-deployment/pom.xml
@@ -24,6 +24,7 @@
         <version>0.4.0</version>
     </parent>
     <description>Building and deploying Metron</description>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-docker/pom.xml
+++ b/metron-docker/pom.xml
@@ -24,6 +24,7 @@
         <version>0.4.0</version>
     </parent>
     <description>Metron Docker</description>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-interface/metron-config/pom.xml
+++ b/metron-interface/metron-config/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-config</artifactId>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-interface/metron-rest-client/pom.xml
+++ b/metron-interface/metron-rest-client/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-rest-client</artifactId>
+    <url>https://metron.apache.org/</url>
     <properties>
     </properties>
     <dependencies>

--- a/metron-interface/metron-rest/pom.xml
+++ b/metron-interface/metron-rest/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-rest</artifactId>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-interface/metron-rest/pom.xml
+++ b/metron-interface/metron-rest/pom.xml
@@ -254,22 +254,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>${emma.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>
-                    <targetJdk>${global_java_version}</targetJdk>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
     <build>
         <plugins>
             <plugin>

--- a/metron-interface/metron-rest/pom.xml
+++ b/metron-interface/metron-rest/pom.xml
@@ -32,7 +32,6 @@
         <spring.kerberos.version>1.0.1.RELEASE</spring.kerberos.version>
         <swagger.version>2.5.0</swagger.version>
         <mysql.client.version>5.1.40</mysql.client.version>
-        <emma.version>1.0-alpha-3</emma.version>
     </properties>
     <dependencies>
         <dependency>

--- a/metron-interface/pom.xml
+++ b/metron-interface/pom.xml
@@ -61,24 +61,6 @@
         <plugins>
         </plugins>
     </build>
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <targetJdk>${global_java_version}</targetJdk>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>1.0-alpha-3</version>
-                <inherited>true</inherited>
-            </plugin>
-        </plugins>
-    </reporting>
     <repositories>
         <repository>
             <id>multiline-release-repo</id>

--- a/metron-platform/elasticsearch-shaded/pom.xml
+++ b/metron-platform/elasticsearch-shaded/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>elasticsearch-shaded</artifactId>
     <name>elasticsearch-shaded</name>
+    <url>https://metron.apache.org/</url>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/metron-platform/elasticsearch-shaded/pom.xml
+++ b/metron-platform/elasticsearch-shaded/pom.xml
@@ -21,6 +21,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>elasticsearch-shaded</artifactId>
+    <name>elasticsearch-shaded</name>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/metron-platform/metron-api/pom.xml
+++ b/metron-platform/metron-api/pom.xml
@@ -22,6 +22,7 @@
 	<artifactId>metron-api</artifactId>
     <name>metron-api</name>
 	<description>Metron API</description>
+    <url>https://metron.apache.org/</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<flume.version>${global_flume_version}</flume.version>

--- a/metron-platform/metron-api/pom.xml
+++ b/metron-platform/metron-api/pom.xml
@@ -20,6 +20,7 @@
 		<version>0.4.0</version>
 	</parent>
 	<artifactId>metron-api</artifactId>
+    <name>metron-api</name>
 	<description>Metron API</description>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/metron-platform/metron-common/pom.xml
+++ b/metron-platform/metron-common/pom.xml
@@ -23,6 +23,7 @@
     <artifactId>metron-common</artifactId>
     <name>metron-common</name>
     <description>Components common to all enrichments</description>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-common/pom.xml
+++ b/metron-platform/metron-common/pom.xml
@@ -360,31 +360,6 @@
         </dependency>
     </dependencies>
 
-    <reporting>
-        <plugins>
-            <!-- Normally, dependency report takes time, skip it -->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-                <!--<version>2.9</version>-->
-                <!--<configuration>-->
-                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-            <!--plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>1.0-alpha-3</version>
-            </plugin-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>
-                  <targetJdk>${global_java_version}</targetJdk>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
     <build>
         <plugins>
             <plugin>

--- a/metron-platform/metron-common/pom.xml
+++ b/metron-platform/metron-common/pom.xml
@@ -363,20 +363,19 @@
     <reporting>
         <plugins>
             <!-- Normally, dependency report takes time, skip it -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
-
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
-            </plugin>
-            <plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+                <!--<version>2.9</version>-->
+                <!--<configuration>-->
+                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
+            <!--plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>emma-maven-plugin</artifactId>
                 <version>1.0-alpha-3</version>
-            </plugin>
+            </plugin-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/transformation/IPProtocolTransformation.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/field/transformation/IPProtocolTransformation.java
@@ -19,7 +19,6 @@
 package org.apache.metron.common.field.transformation;
 
 
-import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.metron.common.dsl.Context;
 import org.apache.metron.common.dsl.ParseException;
 import org.apache.metron.common.dsl.Stellar;
@@ -29,7 +28,6 @@ import org.apache.metron.common.utils.ConversionUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 @Stellar(name="PROTOCOL_TO_NAME"
         , description="Converts the IANA protocol number to the protocol name"

--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/benchmark/StellarMicrobenchmark.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/stellar/benchmark/StellarMicrobenchmark.java
@@ -17,7 +17,6 @@
  */
 package org.apache.metron.common.stellar.benchmark;
 
-import com.clearspring.analytics.util.Lists;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -26,11 +25,9 @@ import org.apache.commons.cli.*;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.apache.metron.common.dsl.Context;
 import org.apache.metron.common.dsl.MapVariableResolver;
-import org.apache.metron.common.dsl.ParseException;
 import org.apache.metron.common.dsl.StellarFunctions;
 import org.apache.metron.common.utils.JSONUtils;
 import org.apache.metron.common.utils.cli.OptionHandler;
-import scala.testing.Benchmark;
 
 import javax.annotation.Nullable;
 import java.io.File;

--- a/metron-platform/metron-data-management/pom.xml
+++ b/metron-platform/metron-data-management/pom.xml
@@ -367,16 +367,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${global_surefire_version}</version>
-                <configuration>
-                    <argLine>@{argLine} -Xmx2048m</argLine>
-                    <skip>true</skip>
-                    <trimStackTrace>false</trimStackTrace>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>${global_shade_version}</version>
                 <executions>

--- a/metron-platform/metron-data-management/pom.xml
+++ b/metron-platform/metron-data-management/pom.xml
@@ -22,6 +22,7 @@
     </parent>
     <artifactId>metron-data-management</artifactId>
     <name>metron-data-management</name>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-data-management/pom.xml
+++ b/metron-platform/metron-data-management/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-data-management</artifactId>
+    <name>metron-data-management</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-data-management/pom.xml
+++ b/metron-platform/metron-data-management/pom.xml
@@ -368,8 +368,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${global_surefire_version}</version>
                 <configuration>
-                    <argLine>-Xmx2048m</argLine>
+                    <argLine>@{argLine} -Xmx2048m</argLine>
                     <skip>true</skip>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/metron-platform/metron-elasticsearch/pom.xml
+++ b/metron-platform/metron-elasticsearch/pom.xml
@@ -198,26 +198,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <reporting>
-        <plugins>
-            <!-- Normally, dependency report takes time, skip it -->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-                <!--<version>2.9</version>-->
-                <!--<configuration>-->
-                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-
-            <!--<plugin>-->
-                <!--<groupId>org.codehaus.mojo</groupId>-->
-                <!--<artifactId>emma-maven-plugin</artifactId>-->
-                <!--<version>1.0-alpha-3</version>-->
-                <!--<inherited>true</inherited>-->
-            <!--</plugin>-->
-        </plugins>
-    </reporting>
 
     <build>
         <plugins>

--- a/metron-platform/metron-elasticsearch/pom.xml
+++ b/metron-platform/metron-elasticsearch/pom.xml
@@ -22,6 +22,7 @@
     </parent>
     <artifactId>metron-elasticsearch</artifactId>
     <name>metron-elasticsearch</name>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-elasticsearch/pom.xml
+++ b/metron-platform/metron-elasticsearch/pom.xml
@@ -205,10 +205,10 @@
                 <!-- Separates the unit tests from the integration tests. -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>${global_surefire_version}</version>
                 <configuration>
                     <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
-                    <argLine>-Xmx2048m</argLine>
+                    <argLine>@{argLine} -Xmx2048m</argLine>
                     <skip>true</skip>
                     <!-- Show 100% of the lines from the stack trace (doesn't work) -->
                     <trimStackTrace>false</trimStackTrace>

--- a/metron-platform/metron-elasticsearch/pom.xml
+++ b/metron-platform/metron-elasticsearch/pom.xml
@@ -202,55 +202,6 @@
     <build>
         <plugins>
             <plugin>
-                <!-- Separates the unit tests from the integration tests. -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${global_surefire_version}</version>
-                <configuration>
-                    <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
-                    <argLine>@{argLine} -Xmx2048m</argLine>
-                    <skip>true</skip>
-                    <!-- Show 100% of the lines from the stack trace (doesn't work) -->
-                    <trimStackTrace>false</trimStackTrace>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>unit-tests</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <!-- Never skip running the tests when the test phase is invoked -->
-                            <skip>false</skip>
-                            <includes>
-                                <!-- Include unit tests within integration-test phase. -->
-                                <include>**/*Test.java</include>
-                            </includes>
-                            <excludes>
-                                <!-- Exclude integration tests within (unit) test phase. -->
-                                <exclude>**/*IntegrationTest.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>integration-tests</id>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <!-- Never skip running the tests when the integration-test phase is invoked -->
-                            <skip>false</skip>
-                            <includes>
-                                <!-- Include integration tests within integration-test phase. -->
-                                <include>**/*IntegrationTest.java</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>${global_shade_version}</version>

--- a/metron-platform/metron-elasticsearch/pom.xml
+++ b/metron-platform/metron-elasticsearch/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-elasticsearch</artifactId>
+    <name>metron-elasticsearch</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -200,22 +201,21 @@
     <reporting>
         <plugins>
             <!-- Normally, dependency report takes time, skip it -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+                <!--<version>2.9</version>-->
+                <!--<configuration>-->
+                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
 
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>1.0-alpha-3</version>
-                <inherited>true</inherited>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.codehaus.mojo</groupId>-->
+                <!--<artifactId>emma-maven-plugin</artifactId>-->
+                <!--<version>1.0-alpha-3</version>-->
+                <!--<inherited>true</inherited>-->
+            <!--</plugin>-->
         </plugins>
     </reporting>
 

--- a/metron-platform/metron-enrichment/pom.xml
+++ b/metron-platform/metron-enrichment/pom.xml
@@ -263,23 +263,6 @@
             <version>${commons-compress.version}</version>
         </dependency>
     </dependencies>
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${global_surefire_version}</version>
-                <configuration>
-                    <systemProperties>
-                        <property>
-                            <name>mode</name>
-                            <value>global</value>
-                        </property>
-                    </systemProperties>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
     <build>
         <plugins>
             <plugin>

--- a/metron-platform/metron-enrichment/pom.xml
+++ b/metron-platform/metron-enrichment/pom.xml
@@ -278,29 +278,6 @@
                     </systemProperties>
                 </configuration>
             </plugin>
-
-            <!-- Normally, dependency report takes time, skip it -->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-                <!--<version>2.9</version>-->
-                <!--<configuration>-->
-                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-
-            <!--<plugin>-->
-                <!--<groupId>org.codehaus.mojo</groupId>-->
-                <!--<artifactId>emma-maven-plugin</artifactId>-->
-                <!--<version>1.0-alpha-3</version>-->
-            <!--</plugin>-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>
-                  <targetJdk>${global_java_version}</targetJdk>
-                </configuration>
-            </plugin>
         </plugins>
     </reporting>
     <build>

--- a/metron-platform/metron-enrichment/pom.xml
+++ b/metron-platform/metron-enrichment/pom.xml
@@ -22,6 +22,7 @@
     </parent>
     <artifactId>metron-enrichment</artifactId>
     <name>metron-enrichment</name>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-enrichment/pom.xml
+++ b/metron-platform/metron-enrichment/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-enrichment</artifactId>
+    <name>metron-enrichment</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -279,21 +280,20 @@
             </plugin>
 
             <!-- Normally, dependency report takes time, skip it -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+                <!--<version>2.9</version>-->
+                <!--<configuration>-->
+                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
 
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>1.0-alpha-3</version>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.codehaus.mojo</groupId>-->
+                <!--<artifactId>emma-maven-plugin</artifactId>-->
+                <!--<version>1.0-alpha-3</version>-->
+            <!--</plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>

--- a/metron-platform/metron-enrichment/pom.xml
+++ b/metron-platform/metron-enrichment/pom.xml
@@ -265,10 +265,10 @@
     </dependencies>
     <reporting>
         <plugins>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${global_surefire_version}</version>
                 <configuration>
                     <systemProperties>
                         <property>

--- a/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/integration/EnrichmentIntegrationTest.java
+++ b/metron-platform/metron-enrichment/src/test/java/org/apache/metron/enrichment/integration/EnrichmentIntegrationTest.java
@@ -198,9 +198,9 @@ public class EnrichmentIntegrationTest extends BaseIntegrationTest {
             .withCustomShutdownOrder(new String[]{"storm","config","kafka","zk"})
             .withNumRetries(10)
             .build();
-    runner.start();
 
     try {
+      runner.start();
       fluxComponent.submitTopology();
 
       kafkaComponent.writeMessages(Constants.ENRICHMENT_TOPIC, inputMessages);

--- a/metron-platform/metron-hbase/pom.xml
+++ b/metron-platform/metron-hbase/pom.xml
@@ -22,6 +22,7 @@
     </parent>
     <artifactId>metron-hbase</artifactId>
     <name>metron-hbase</name>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-hbase/pom.xml
+++ b/metron-platform/metron-hbase/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-hbase</artifactId>
+    <name>metron-hbase</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-indexing/pom.xml
+++ b/metron-platform/metron-indexing/pom.xml
@@ -154,28 +154,6 @@
                     </systemProperties>
                 </configuration>
             </plugin>
-
-            <!-- Normally, dependency report takes time, skip it -->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-                <!--<version>2.9</version>-->
-                <!--<configuration>-->
-                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-            <!--<plugin>-->
-                <!--<groupId>org.codehaus.mojo</groupId>-->
-                <!--<artifactId>emma-maven-plugin</artifactId>-->
-                <!--<version>1.0-alpha-3</version>-->
-            <!--</plugin>-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>
-                  <targetJdk>${global_java_version}</targetJdk>
-                </configuration>
-            </plugin>
         </plugins>
     </reporting>
     <build>

--- a/metron-platform/metron-indexing/pom.xml
+++ b/metron-platform/metron-indexing/pom.xml
@@ -22,6 +22,7 @@
     </parent>
     <artifactId>metron-indexing</artifactId>
     <name>metron-indexing</name>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-indexing/pom.xml
+++ b/metron-platform/metron-indexing/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-indexing</artifactId>
+    <name>metron-indexing</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -155,20 +156,19 @@
             </plugin>
 
             <!-- Normally, dependency report takes time, skip it -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
-
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>1.0-alpha-3</version>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+                <!--<version>2.9</version>-->
+                <!--<configuration>-->
+                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
+            <!--<plugin>-->
+                <!--<groupId>org.codehaus.mojo</groupId>-->
+                <!--<artifactId>emma-maven-plugin</artifactId>-->
+                <!--<version>1.0-alpha-3</version>-->
+            <!--</plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>

--- a/metron-platform/metron-indexing/pom.xml
+++ b/metron-platform/metron-indexing/pom.xml
@@ -145,6 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${global_surefire_version}</version>
                 <configuration>
                     <systemProperties>
                         <property>

--- a/metron-platform/metron-indexing/pom.xml
+++ b/metron-platform/metron-indexing/pom.xml
@@ -140,23 +140,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${global_surefire_version}</version>
-                <configuration>
-                    <systemProperties>
-                        <property>
-                            <name>mode</name>
-                            <value>global</value>
-                        </property>
-                    </systemProperties>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
     <build>
         <plugins>
             <plugin>

--- a/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
+++ b/metron-platform/metron-indexing/src/test/java/org/apache/metron/indexing/integration/IndexingIntegrationTest.java
@@ -182,9 +182,9 @@ public abstract class IndexingIntegrationTest extends BaseIntegrationTest {
             .withMaxTimeMS(150000)
             .withCustomShutdownOrder(new String[] {"search","storm","config","kafka","zk"})
             .build();
-    runner.start();
 
     try {
+      runner.start();
       while(!isLoaded.get()) {
         Thread.sleep(100);
       }

--- a/metron-platform/metron-integration-test/pom.xml
+++ b/metron-platform/metron-integration-test/pom.xml
@@ -269,6 +269,4 @@
       </plugin>
     </plugins>
   </build>
-  <!--<reporting>-->
-  <!--</reporting>-->
 </project>

--- a/metron-platform/metron-integration-test/pom.xml
+++ b/metron-platform/metron-integration-test/pom.xml
@@ -23,6 +23,7 @@
   <artifactId>metron-integration-test</artifactId>
   <name>metron-integration-test</name>
   <description>Metron Integration Test</description>
+  <url>https://metron.apache.org/</url>
   <properties>
   </properties>
   <dependencies>

--- a/metron-platform/metron-integration-test/pom.xml
+++ b/metron-platform/metron-integration-test/pom.xml
@@ -21,6 +21,7 @@
     <version>0.4.0</version>
   </parent>
   <artifactId>metron-integration-test</artifactId>
+  <name>metron-integration-test</name>
   <description>Metron Integration Test</description>
   <properties>
   </properties>
@@ -268,6 +269,6 @@
       </plugin>
     </plugins>
   </build>
-  <reporting>
-  </reporting>
+  <!--<reporting>-->
+  <!--</reporting>-->
 </project>

--- a/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/ComponentRunner.java
+++ b/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/ComponentRunner.java
@@ -121,7 +121,6 @@ public class ComponentRunner {
         }
     }
 
-
     public <T> ProcessorResult<T> process(Processor<T> successState) {
         int retryCount = 0;
         long start = System.currentTimeMillis();

--- a/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/processors/KafkaProcessor.java
+++ b/metron-platform/metron-integration-test/src/main/java/org/apache/metron/integration/processors/KafkaProcessor.java
@@ -58,6 +58,7 @@ public class KafkaProcessor<T> implements Processor<T> {
     private Function<KafkaMessageSet, Boolean> validateReadMessages;
     private Function<KafkaMessageSet,T> provideResult;
 
+    @Override
     public ReadinessState process(ComponentRunner runner){
         KafkaComponent kafkaComponent = runner.getComponent(kafkaComponentName, KafkaComponent.class);
         LinkedList<byte[]> outputMessages = new LinkedList<>(kafkaComponent.readMessages(readTopic));
@@ -79,6 +80,8 @@ public class KafkaProcessor<T> implements Processor<T> {
         }
         return ReadinessState.NOT_READY;
     }
+
+    @Override
     @SuppressWarnings("unchecked")
     public ProcessorResult<T> getResult(){
         ProcessorResult.Builder<T> builder = new ProcessorResult.Builder();

--- a/metron-platform/metron-management/pom.xml
+++ b/metron-platform/metron-management/pom.xml
@@ -23,6 +23,7 @@
     <artifactId>metron-management</artifactId>
     <name>metron-management</name>
     <description>Management Stellar functions</description>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-management/pom.xml
+++ b/metron-platform/metron-management/pom.xml
@@ -181,31 +181,6 @@
         </dependency>
     </dependencies>
 
-    <reporting>
-        <plugins>
-            <!-- Normally, dependency report takes time, skip it -->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-                <!--<version>2.9</version>-->
-                <!--<configuration>-->
-                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-            <!--<plugin>-->
-                <!--<groupId>org.codehaus.mojo</groupId>-->
-                <!--<artifactId>emma-maven-plugin</artifactId>-->
-                <!--<version>1.0-alpha-3</version>-->
-            <!--</plugin>-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>
-                  <targetJdk>${global_java_version}</targetJdk>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
     <build>
         <plugins>
             <plugin>

--- a/metron-platform/metron-management/pom.xml
+++ b/metron-platform/metron-management/pom.xml
@@ -184,20 +184,19 @@
     <reporting>
         <plugins>
             <!-- Normally, dependency report takes time, skip it -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
-
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>1.0-alpha-3</version>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+                <!--<version>2.9</version>-->
+                <!--<configuration>-->
+                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
+            <!--<plugin>-->
+                <!--<groupId>org.codehaus.mojo</groupId>-->
+                <!--<artifactId>emma-maven-plugin</artifactId>-->
+                <!--<version>1.0-alpha-3</version>-->
+            <!--</plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>

--- a/metron-platform/metron-parsers/pom.xml
+++ b/metron-platform/metron-parsers/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-parsers</artifactId>
+    <name>metron-parsers</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -221,20 +222,19 @@
     <reporting>
         <plugins>
             <!-- Normally, dependency report takes time, skip it -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
-
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>1.0-alpha-3</version>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+                <!--<version>2.9</version>-->
+                <!--<configuration>-->
+                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
+            <!--<plugin>-->
+                <!--<groupId>org.codehaus.mojo</groupId>-->
+                <!--<artifactId>emma-maven-plugin</artifactId>-->
+                <!--<version>1.0-alpha-3</version>-->
+            <!--</plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>

--- a/metron-platform/metron-parsers/pom.xml
+++ b/metron-platform/metron-parsers/pom.xml
@@ -22,6 +22,7 @@
     </parent>
     <artifactId>metron-parsers</artifactId>
     <name>metron-parsers</name>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-parsers/pom.xml
+++ b/metron-platform/metron-parsers/pom.xml
@@ -219,32 +219,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <reporting>
-        <plugins>
-            <!-- Normally, dependency report takes time, skip it -->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-                <!--<version>2.9</version>-->
-                <!--<configuration>-->
-                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-            <!--<plugin>-->
-                <!--<groupId>org.codehaus.mojo</groupId>-->
-                <!--<artifactId>emma-maven-plugin</artifactId>-->
-                <!--<version>1.0-alpha-3</version>-->
-            <!--</plugin>-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>
-                    <targetJdk>1.7</targetJdk>
-                </configuration>
-
-            </plugin>
-        </plugins>
-    </reporting>
     <build>
         <plugins>
             <plugin>

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/ParserIntegrationTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/integration/ParserIntegrationTest.java
@@ -74,8 +74,8 @@ public abstract class ParserIntegrationTest extends BaseIntegrationTest {
             .withNumRetries(10)
             .withCustomShutdownOrder(new String[] {"org/apache/storm","config","kafka","zk"})
             .build();
-    runner.start();
     try {
+      runner.start();
       kafkaComponent.writeMessages(sensorType, inputMessages);
       ProcessorResult<List<byte[]>> result = runner.process(getProcessor());
       List<byte[]> outputMessages = result.getResult();

--- a/metron-platform/metron-pcap-backend/pom.xml
+++ b/metron-platform/metron-pcap-backend/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-pcap-backend</artifactId>
+    <name>metron-pcap-backend</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -201,20 +202,19 @@
     <reporting>
         <plugins>
             <!-- Normally, dependency report takes time, skip it -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
-
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>1.0-alpha-3</version>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+                <!--<version>2.9</version>-->
+                <!--<configuration>-->
+                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
+            <!--<plugin>-->
+                <!--<groupId>org.codehaus.mojo</groupId>-->
+                <!--<artifactId>emma-maven-plugin</artifactId>-->
+                <!--<version>1.0-alpha-3</version>-->
+            <!--</plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>

--- a/metron-platform/metron-pcap-backend/pom.xml
+++ b/metron-platform/metron-pcap-backend/pom.xml
@@ -199,31 +199,6 @@
         </dependency>
     </dependencies>
 
-    <reporting>
-        <plugins>
-            <!-- Normally, dependency report takes time, skip it -->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-                <!--<version>2.9</version>-->
-                <!--<configuration>-->
-                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-            <!--<plugin>-->
-                <!--<groupId>org.codehaus.mojo</groupId>-->
-                <!--<artifactId>emma-maven-plugin</artifactId>-->
-                <!--<version>1.0-alpha-3</version>-->
-            <!--</plugin>-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>
-                  <targetJdk>${global_java_version}</targetJdk>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
     <build>
         <plugins>
             <plugin>

--- a/metron-platform/metron-pcap-backend/pom.xml
+++ b/metron-platform/metron-pcap-backend/pom.xml
@@ -22,6 +22,7 @@
     </parent>
     <artifactId>metron-pcap-backend</artifactId>
     <name>metron-pcap-backend</name>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-pcap/pom.xml
+++ b/metron-platform/metron-pcap/pom.xml
@@ -23,6 +23,7 @@
     <artifactId>metron-pcap</artifactId>
     <name>metron-pcap</name>
     <description>Metron Pcap</description>
+    <url>https://metron.apache.org/</url>
     <properties>
     </properties>
     <dependencies>

--- a/metron-platform/metron-pcap/pom.xml
+++ b/metron-platform/metron-pcap/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-pcap</artifactId>
+    <name>metron-pcap</name>
     <description>Metron Pcap</description>
     <properties>
     </properties>

--- a/metron-platform/metron-solr/pom.xml
+++ b/metron-platform/metron-solr/pom.xml
@@ -219,10 +219,10 @@
                 <!-- Separates the unit tests from the integration tests. -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>${global_surefire_version}</version>
                 <configuration>
                     <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
-                    <argLine>-Xmx2048m</argLine>
+                    <argLine>@{argLine} -Xmx2048m</argLine>
                     <skip>true</skip>
                     <!-- Show 100% of the lines from the stack trace (doesn't work) -->
                     <trimStackTrace>false</trimStackTrace>

--- a/metron-platform/metron-solr/pom.xml
+++ b/metron-platform/metron-solr/pom.xml
@@ -22,6 +22,7 @@
     </parent>
     <artifactId>metron-solr</artifactId>
     <name>metron-solr</name>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-solr/pom.xml
+++ b/metron-platform/metron-solr/pom.xml
@@ -21,6 +21,7 @@
         <version>0.4.0</version>
     </parent>
     <artifactId>metron-solr</artifactId>
+    <name>metron-solr</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-solr/pom.xml
+++ b/metron-platform/metron-solr/pom.xml
@@ -216,55 +216,6 @@
     <build>
         <plugins>
             <plugin>
-                <!-- Separates the unit tests from the integration tests. -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${global_surefire_version}</version>
-                <configuration>
-                    <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
-                    <argLine>@{argLine} -Xmx2048m</argLine>
-                    <skip>true</skip>
-                    <!-- Show 100% of the lines from the stack trace (doesn't work) -->
-                    <trimStackTrace>false</trimStackTrace>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>unit-tests</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <!-- Never skip running the tests when the test phase is invoked -->
-                            <skip>false</skip>
-                            <includes>
-                                <!-- Include unit tests within integration-test phase. -->
-                                <include>**/*Test.java</include>
-                            </includes>
-                            <excludes>
-                                <!-- Exclude integration tests within (unit) test phase. -->
-                                <exclude>**/*IntegrationTest.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>integration-tests</id>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <!-- Never skip running the tests when the integration-test phase is invoked -->
-                            <skip>false</skip>
-                            <includes>
-                                <!-- Include integration tests within integration-test phase. -->
-                                <include>**/*IntegrationTest.java</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>${global_shade_version}</version>

--- a/metron-platform/metron-storm-kafka/pom.xml
+++ b/metron-platform/metron-storm-kafka/pom.xml
@@ -23,6 +23,7 @@
     <artifactId>metron-storm-kafka</artifactId>
     <name>metron-storm-kafka</name>
     <description>Components that extend the Storm/Kafka spout</description>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/metron-storm-kafka/pom.xml
+++ b/metron-platform/metron-storm-kafka/pom.xml
@@ -90,35 +90,7 @@
         </dependency>
     </dependencies>
 
-    <reporting>
-        <plugins>
-            <!-- Normally, dependency report takes time, skip it -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
-
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>1.0-alpha-3</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>
-                  <targetJdk>${global_java_version}</targetJdk>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
     <build>
-        <plugins>
-        </plugins>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>

--- a/metron-platform/metron-test-utilities/pom.xml
+++ b/metron-platform/metron-test-utilities/pom.xml
@@ -157,9 +157,4 @@
       <version>0.1.2</version>
     </dependency>
   </dependencies>
-
-  <build>
-  </build>
-  <!--<reporting>-->
-  <!--</reporting>-->
 </project>

--- a/metron-platform/metron-test-utilities/pom.xml
+++ b/metron-platform/metron-test-utilities/pom.xml
@@ -23,6 +23,7 @@
   <artifactId>metron-test-utilities</artifactId>
   <name>metron-test-utilities</name>
   <description>Metron Test Utilities</description>
+  <url>https://metron.apache.org/</url>
   <properties>
   </properties>
   <dependencies>

--- a/metron-platform/metron-test-utilities/pom.xml
+++ b/metron-platform/metron-test-utilities/pom.xml
@@ -21,6 +21,7 @@
     <version>0.4.0</version>
   </parent>
   <artifactId>metron-test-utilities</artifactId>
+  <name>metron-test-utilities</name>
   <description>Metron Test Utilities</description>
   <properties>
   </properties>
@@ -159,6 +160,6 @@
 
   <build>
   </build>
-  <reporting>
-  </reporting>
+  <!--<reporting>-->
+  <!--</reporting>-->
 </project>

--- a/metron-platform/metron-writer/pom.xml
+++ b/metron-platform/metron-writer/pom.xml
@@ -203,20 +203,19 @@
     <reporting>
         <plugins>
             <!-- Normally, dependency report takes time, skip it -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
-
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>emma-maven-plugin</artifactId>
-                <version>1.0-alpha-3</version>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+                <!--<version>2.9</version>-->
+                <!--<configuration>-->
+                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
+            <!--<plugin>-->
+                <!--<groupId>org.codehaus.mojo</groupId>-->
+                <!--<artifactId>emma-maven-plugin</artifactId>-->
+                <!--<version>1.0-alpha-3</version>-->
+            <!--</plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>

--- a/metron-platform/metron-writer/pom.xml
+++ b/metron-platform/metron-writer/pom.xml
@@ -200,31 +200,6 @@
         </dependency>
     </dependencies>
 
-    <reporting>
-        <plugins>
-            <!-- Normally, dependency report takes time, skip it -->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-                <!--<version>2.9</version>-->
-                <!--<configuration>-->
-                    <!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-            <!--<plugin>-->
-                <!--<groupId>org.codehaus.mojo</groupId>-->
-                <!--<artifactId>emma-maven-plugin</artifactId>-->
-                <!--<version>1.0-alpha-3</version>-->
-            <!--</plugin>-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>
-                  <targetJdk>${global_java_version}</targetJdk>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
     <build>
         <plugins>
             <plugin>

--- a/metron-platform/metron-writer/pom.xml
+++ b/metron-platform/metron-writer/pom.xml
@@ -23,6 +23,7 @@
     <artifactId>metron-writer</artifactId>
     <name>metron-writer</name>
     <description>Components common to all enrichments</description>
+    <url>https://metron.apache.org/</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/metron-platform/pom.xml
+++ b/metron-platform/pom.xml
@@ -95,22 +95,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<reporting>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>${global_surefire_version}</version>
-				<configuration>
-					<argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
-					<systemProperties>
-						<property>
-							<name>mode</name>
-							<value>local</value>
-						</property>
-					</systemProperties>
-				</configuration>
-			</plugin>
-		</plugins>
-	</reporting>
 </project>

--- a/metron-platform/pom.xml
+++ b/metron-platform/pom.xml
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.18</version>
+				<version>${global_surefire_version}</version>
 				<configuration>
 					<argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
 					<systemProperties>

--- a/metron-platform/pom.xml
+++ b/metron-platform/pom.xml
@@ -112,14 +112,14 @@
 				</configuration>
 			</plugin>
 			<!-- Normally, dependency report takes time, skip it -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>2.7</version>
-				<configuration>
-					<dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-				</configuration>
-			</plugin>
+			<!--<plugin>-->
+				<!--<groupId>org.apache.maven.plugins</groupId>-->
+				<!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
+				<!--<version>2.9</version>-->
+				<!--<configuration>-->
+					<!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
+				<!--</configuration>-->
+			<!--</plugin>-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
@@ -128,12 +128,12 @@
           <targetJdk>${global_java_version}</targetJdk>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>emma-maven-plugin</artifactId>
-				<version>1.0-alpha-3</version>
-				<inherited>true</inherited>
-			</plugin>
+			<!--<plugin>-->
+				<!--<groupId>org.codehaus.mojo</groupId>-->
+				<!--<artifactId>emma-maven-plugin</artifactId>-->
+				<!--<version>1.0-alpha-3</version>-->
+				<!--<inherited>true</inherited>-->
+			<!--</plugin>-->
 		</plugins>
 	</reporting>
 </project>

--- a/metron-platform/pom.xml
+++ b/metron-platform/pom.xml
@@ -111,29 +111,6 @@
 					</systemProperties>
 				</configuration>
 			</plugin>
-			<!-- Normally, dependency report takes time, skip it -->
-			<!--<plugin>-->
-				<!--<groupId>org.apache.maven.plugins</groupId>-->
-				<!--<artifactId>maven-project-info-reports-plugin</artifactId>-->
-				<!--<version>2.9</version>-->
-				<!--<configuration>-->
-					<!--<dependencyLocationsEnabled>false</dependencyLocationsEnabled>-->
-				<!--</configuration>-->
-			<!--</plugin>-->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.3</version>
-				<configuration>
-          <targetJdk>${global_java_version}</targetJdk>
-				</configuration>
-			</plugin>
-			<!--<plugin>-->
-				<!--<groupId>org.codehaus.mojo</groupId>-->
-				<!--<artifactId>emma-maven-plugin</artifactId>-->
-				<!--<version>1.0-alpha-3</version>-->
-				<!--<inherited>true</inherited>-->
-			<!--</plugin>-->
 		</plugins>
 	</reporting>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
         <global_jackson_version>2.7.4</global_jackson_version>
         <global_errorprone_core_version>2.0.14</global_errorprone_core_version>
         <global_jar_version>3.0.2</global_jar_version>
+        <global_surefire_version>2.19.1</global_surefire_version>
     </properties>
 
     <profiles>
@@ -160,7 +161,7 @@
                     <!-- Separates the unit tests from the integration tests. -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18</version>
+                    <version>${global_surefire_version}</version>
                     <configuration>
                         <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
                         <argLine>@{argLine} -Xmx2048m</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <global_jackson_version>2.7.4</global_jackson_version>
         <global_errorprone_core_version>2.0.14</global_errorprone_core_version>
         <global_jar_version>3.0.2</global_jar_version>
-        <global_surefire_version>2.19.1</global_surefire_version>
+        <global_surefire_version>2.18</global_surefire_version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,6 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-        <repository>
-            <id>Metron-Kraken-Repo</id>
-            <name>Metron Kraken Repository</name>
-            <url>https://raw.github.com/opensoc/kraken/mvn-repo</url>
-        </repository>
     </repositories>
 
     <properties>
@@ -394,6 +389,7 @@
                     <reportSet>
                         <reports>
                             <report>checkstyle</report>
+                            <report>checkstyle-aggregate</report>
                         </reports>
                     </reportSet>
                 </reportSets>
@@ -410,6 +406,14 @@
                         </reports>
                     </reportSet>
                 </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.7</version>
+                <configuration>
+                    <targetJdk>${global_java_version}</targetJdk>
+                </configuration>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
                     <version>${global_surefire_version}</version>
                     <configuration>
                         <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
-                        <argLine>@{argLine} -Xmx2048m -XX:MaxPermSize=256m</argLine>
+                        <argLine>@{argLine} -Xmx2048m</argLine>
                         <skip>true</skip>
                         <!-- Show 100% of the lines from the stack trace (doesn't work) -->
                         <trimStackTrace>false</trimStackTrace>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,10 @@
     <name>Metron</name>
     <description>Metron Top Level Project</description>
     <url>https://metron.apache.org/</url>
+    <organization>
+        <name>The Apache Software Foundation</name>
+        <url>https://www.apache.org</url>
+    </organization>
     <modules>
             <module>metron-analytics</module>
             <module>metron-platform</module>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>Metron-Kraken-Repo</id>
+            <name>Metron Kraken Repository</name>
+            <url>https://raw.github.com/opensoc/kraken/mvn-repo</url>
+        </repository>
     </repositories>
 
     <properties>
@@ -162,7 +167,7 @@
                     <version>2.18</version>
                     <configuration>
                         <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
-                        <argLine>-Xmx2048m</argLine>
+                        <argLine>@{argLine} -Xmx2048m</argLine>
                         <skip>true</skip>
                         <!-- Show 100% of the lines from the stack trace (doesn't work) -->
                         <trimStackTrace>false</trimStackTrace>
@@ -216,6 +221,11 @@
         </pluginManagement>
         <plugins>
             <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-site-plugin</artifactId>
+              <version>3.6</version>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
@@ -253,6 +263,25 @@
                     </formats>
                     <aggregate>true</aggregate>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.9</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.rat</groupId>
@@ -320,4 +349,68 @@
             </plugin>
         </plugins>
     </build>
+
+    <distributionManagement>
+        <site>
+            <id>metron</id>
+            <name>Metron</name>
+            <url>file:///tmp/metron/site/</url>
+        </site>
+    </distributionManagement>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>2.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.9</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <!-- Normally, dependency report takes time, skip it -->
+                            <!--<report>dependencies</report>-->
+                            <report>index</report>
+                            <report>cim</report>
+                            <report>issue-tracking</report>
+                            <report>license</report>
+                            <report>mailing-list</report>
+                            <report>plugins</report>
+                            <report>project-team</report>
+                            <report>scm</report>
+                            <report>summary</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>checkstyle</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.9</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <!-- select non-aggregate reports -->
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
             <module>metron-deployment</module>
             <module>metron-docker</module>
             <module>metron-interface</module>
+            <module>site-book</module>
     </modules>
 
     <repositories>
@@ -358,6 +359,29 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
                 <version>2.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <id>default</id>
+                        <reports>
+                            <report>javadoc</report>
+                            <report>test-javadoc</report>
+                        </reports>
+                    </reportSet>
+                    <reportSet>
+                        <id>aggregate</id>
+                        <reports>
+                            <report>aggregate</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
                     <version>${global_surefire_version}</version>
                     <configuration>
                         <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
-                        <argLine>@{argLine} -Xmx2048m</argLine>
+                        <argLine>@{argLine} -Xmx2048m -XX:MaxPermSize=256m</argLine>
                         <skip>true</skip>
                         <!-- Show 100% of the lines from the stack trace (doesn't work) -->
                         <trimStackTrace>false</trimStackTrace>

--- a/site-book/README.md
+++ b/site-book/README.md
@@ -8,15 +8,15 @@ Metron's Site Book is an attempt at producing documentation that is:
 
 The idea is that a release manager would build the site-book (following the instructions below), then publish it from the public [Metron site](http://metron.apache.org/) as the docs for the new released version. Older site-book versions should remain available for users that need them.
 
+The site-book is also part of the Maven site lifecycle, and will be included by the full site from the top level.  However, the site as a whole takes longer than just the site-book:
 
-To build the book, do the following:
+To build only the book, do the following:
 
 In any git clone of incubator-metron containing the site-book subdirectory,
 
 ```
 cd site-book
-bin/generate-md.sh
-mvn site:site
+mvn site
 ```
 
 It only takes a few seconds. You may now view your copy of the book in a browser by opening 
@@ -31,6 +31,7 @@ On a Mac, you can just type the following on the command line
 open target/site/index.html
 ```
 
+
 ##Key Components:
 
 ###bin/generate-md.sh
@@ -38,6 +39,7 @@ open target/site/index.html
 - Copies all .md files from the code directory tree into the site tree
 - Performs some transformations on them
 - Generates the nav tree structure and labels
+- Happens during the site:pre-site phase of Maven.
 
 ###bin/fix-md-dialect.py
 

--- a/site-book/pom.xml
+++ b/site-book/pom.xml
@@ -73,10 +73,8 @@
 	      <configuration>
                     <generateProjectInfo>false</generateProjectInfo>
                     <generateReports>false</generateReports>
-                    <skip>false</skip>
              </configuration>
             </plugin>
 	  </plugins>
 	</build>
-
 </project>

--- a/site-book/pom.xml
+++ b/site-book/pom.xml
@@ -51,6 +51,22 @@
 
 	<build>
 	  <plugins>
+          <plugin>
+              <artifactId>exec-maven-plugin</artifactId>
+              <groupId>org.codehaus.mojo</groupId>
+              <executions>
+                  <execution>
+                      <id>Generate MD</id>
+                      <phase>pre-site</phase>
+                      <goals>
+                          <goal>exec</goal>
+                      </goals>
+                      <configuration>
+                          <executable>${basedir}/bin/generate-md.sh</executable>
+                      </configuration>
+                  </execution>
+              </executions>
+          </plugin>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-site-plugin</artifactId>


### PR DESCRIPTION
### Summary
An initial attempt to add checkstyle expanded a bit once it turned out that `mvn site` appears to not work right now (and probably hasn't for a long while). More background on some of the issues encountered (and error traces) is in the ticket itself.

A small set of cleanups is included here, and is pretty easy to split out if we want it to be separate PRs (it mostly just got cleaned up while I was trying to fix things one by one, but for example, checkstyle could be included in a separate PR). It's small enough though, that I just left it together since it makes the generated site fairly nice and complete.

### Changes
- The major change is to drop EMMA for JaCoCo. As noted in the ticket, it's unlikely to be worth the erffort to get EMMA working, given that it's not actively developed and it seems likely that EMMA just isn't compatible with Java 8 code (not terribly surprising given how old it is). I put in JaCoCo mostly to keep (make?) code coverage available, but I can easily remove it if we'd rather have a discussion on a different tool, or just a separate PR.
- Added maven-site-plugin to top level pom
- Refactored most reporting (maven-project-info-reports-plugin, maven-pmd-plugin, and code coverage) to go through top level pom, given that most of our reporting is exactly the same throughout the child poms.
- Explicitly setup up maven-project-info-report-plugin reports (neither CLI param nor POM param skipped dependency reports correctly. Unsure why that is. If someone knows, I'd love to just change that)
- Added maven-jxr-plugin to fix warnings in the site build
- Added names to poms to make sure they show up nicely in site
- Deploy set to /tmp/metron/site for now. Should eventually be adjusted to be somewhere useful (I believe other components like Hadoop do something nicer with it within Apache, but I'd need to look into it). I'll create a ticket for it, assuming we're good with this PR (mostly) as-is. Otherwise, I'll wait and see what spins out of discussion here.
- Updated PMD to 3.7

#### Testing
To run everything, including code coverage up:
~`mvn clean install site:site site:deploy site:stage-deploy`~
`mvn clean install && mvn site site:stage-deploy site:deploy`

Open up /tmp/metron/site/index.html in a browser. Everything (other than Javadoc) should be available, and clicking through modules should work because of the `site:stage-deploy`

Skipping tests allows code coverage to be skipped.

I also ran up quick-dev and made sure data passed through topologies. I didn't run up other components, because mostly the reporting section of the poms is touched, so if they built and the reporting built it seemed like enough. I can definitely spin up other components if anybody wants to be more thorough, though.

#### Notes
- Javadocs are currently broken outside of this ticket. Separate Jira/PR is open for that issue.
- Reason for `site:stage-deploy` to is get the parent-child pom links working while testing. Otherwise, you can't navigate through the module structure.
- Currently almost 25k(!) checkstyle issues.
- It's possible to import a check style file in IntelliJ. I could export this for general use (modified it to use two spaces + possibly things like line length). I tested reformatting all Java files like this, and it clears out several thousand checkstyle issues. And makes the code more consistent. Obviously, that's a bit aggressive and touched things like autogenerated files, but it makes it clear we have more issues than trivially solved by code formatting.




