### PR TITLE
METRON-764 DST bug in metron-profiler-client Unit Tests

### DIFF
--- a/metron-analytics/metron-profiler-client/README.md
+++ b/metron-analytics/metron-profiler-client/README.md
@@ -253,6 +253,35 @@ The specifiers are a set of fixed specifiers available as part of the language:
     * Countries supported are those supported in [jollyday](https://github.com/svendiedrichsen/jollyday/tree/master/src/main/resources/holidays)
     * Example: `holiday:us:nyc` would be the holidays of New York City, USA
     * Example: `holiday:hu` would be the holidays of Hungary
+    
+**WARNING: Daylight Savings Time effects**
+
+While Universal Time (UTC) is nice and constant, many servers are set to local timezones that enable Daylight Savings Time (DST).
+This means that twice a year, on DST transition weekends, "Sunday" is either 23 or 25 hours long.  However, durations specified
+as "7 days ago" are always interpreted as "7*24 hours ago".  This can lead to some surprising effects when using days of the week
+as inclusion or exclusion specifiers.
+
+For example, the profile window specified by the phrase "30 minute window every 24 hours from 7 days ago"
+will always have 7 thirty-minute intervals, and these will normally occur on 5 weekdays and 2 weekend days.
+However, if you invoke this window at 12:15am any day during the week following the start of DST, you will get
+these intervals (supposing you start early on a Wednesday morning):
+```
+Tuesday 12:15am-12:45am (yesterday)
+Monday 12:15am-12:45am
+Saturday 11:15pm-11:45pm (skipped Sunday!)
+Friday 11:15pm-11:45pm
+Thursday 11:15pm-11:45pm
+Wednesday 11:15pm-11:45pm
+Tuesday 11:15pm-11:45pm
+```
+
+Sunday got skipped over because it was only 23 hours long; that is, there were 24 hours between Saturday 11:15pm and Monday 12:15am.
+So if you specified "excluding weekends", you would get 6 days' intervals instead of the expected 5.  There are multiple variations
+on this theme.
+
+Remember that the underlying time is kept in UTC, so the data is always correct.  It is only when attempting to interpret UTC as
+local time, date, and day, that these confusions may occur.  They may be eliminated by setting your server timezone to UTC, or otherwise
+disabling DST.
      
 **Examples**
 

--- a/metron-analytics/metron-profiler-client/src/test/java/org/apache/metron/profiler/client/window/WindowProcessorTest.java
+++ b/metron-analytics/metron-profiler-client/src/test/java/org/apache/metron/profiler/client/window/WindowProcessorTest.java
@@ -29,6 +29,13 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * On any test case where we explicitly include or exclude days of the week, in 24hr periods,
+ * we need to understand that on Daylight Savings Time (DST) transition weekends,
+ * Sunday is either 23 or 25 hours long.  This leads to surprising correct results,
+ * that may fail the assert criteria, if one starts the hour before or after midnight.
+ * Thus in such test cases, we force now.setHours(6).
+ */
 public class WindowProcessorTest {
 
   @Test
@@ -129,6 +136,7 @@ public class WindowProcessorTest {
     Gotta be 2 tuesdays in 14 days.
      */
       Date now = new Date();
+      now.setHours(6); //avoid DST impacts if near Midnight
       List<Range<Long>> intervals = w.toIntervals(now.getTime());
       Assert.assertEquals(2, intervals.size());
     }
@@ -140,6 +148,7 @@ public class WindowProcessorTest {
     Gotta be 2 days with the same dow in 14 days.
      */
       Date now = new Date();
+      now.setHours(6); //avoid DST impacts if near Midnight
       List<Range<Long>> intervals = w.toIntervals(now.getTime());
       Assert.assertEquals(2, intervals.size());
     }
@@ -162,6 +171,7 @@ public class WindowProcessorTest {
     Window w = WindowProcessor.process("30 minute window every 24 hours from 7 days ago including saturdays excluding weekends");
 
     Date now = new Date();
+    now.setHours(6); //avoid DST impacts if near Midnight
     List<Range<Long>> intervals = w.toIntervals(now.getTime());
     Assert.assertEquals(0, intervals.size());
   }
@@ -171,6 +181,7 @@ public class WindowProcessorTest {
     Window w = WindowProcessor.process("30 minute window every 24 hours from 7 days ago excluding weekends");
 
     Date now = new Date();
+    now.setHours(6); //avoid DST impacts if near Midnight
     List<Range<Long>> intervals = w.toIntervals(now.getTime());
     Assert.assertEquals(5, intervals.size());
   }
@@ -198,6 +209,7 @@ public class WindowProcessorTest {
       Window w = WindowProcessor.process("1 hour window every 24 hours starting from 56 days ago including this day of the week");
 
       Date now = new Date();
+      now.setHours(6); //avoid DST impacts if near Midnight
       List<Range<Long>> intervals = w.toIntervals(now.getTime());
       Assert.assertEquals(8, intervals.size());
     }
@@ -208,6 +220,7 @@ public class WindowProcessorTest {
     Window w = WindowProcessor.process("30 minute window every 24 hours from 7 days ago excluding weekdays");
 
     Date now = new Date();
+    now.setHours(6); //avoid DST impacts if near Midnight
     List<Range<Long>> intervals = w.toIntervals(now.getTime());
     Assert.assertEquals(2, intervals.size());
   }


### PR DESCRIPTION
This is a Unit Test bug.  Please see https://issues.apache.org/jira/browse/METRON-764 for detailed description and how to reproduce the problem.

I only changed a Unit Test file and a docs file, therefore I only tested Unit Tests, which pass as shown by Travis.  I also re-ran the reproduction manually and showed it no longer happens with the fix.

=================
In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [NA] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [NA] Have you written or updated unit tests and or integration tests to verify your changes?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [NA] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? 
