### PR TITLE
METRON-770 Unable to Launch Fastcapa Test Environment

### DIFF
--- a/metron-deployment/vagrant/fastcapa-test-platform/vars/main.yml
+++ b/metron-deployment/vagrant/fastcapa-test-platform/vars/main.yml
@@ -36,3 +36,5 @@ kafka_broker_port: dummy
 zookeeper_hosts: dummy
 zookeeper_tag: dummy
 zookeeper_port: dummy
+metron_hosts: dummy
+kibana_hosts: dummy


### PR DESCRIPTION
Unable to launch the Fastcapa test environment.  Errors out during launch with the following error.
```
TASK [ambari_gather_facts : Ask Ambari: metron_hosts] **************************
fatal: [source]: FAILED! => {"failed": true, "msg": "ERROR! 'dict object' has no attribute 'ambari_master'"}

PLAY RECAP *********************************************************************
source                     : ok=20   changed=15   unreachable=0    failed=1

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

Since Ambari is not available in the `fastcapa-test-environment`, it needs to define all of the variables that are retrieved by the `ambari_gather_facts` role.  This prevents it from attempting to reach out to Ambari and thus fail and break.  This was broken by a change in METRON-671.  Simple fix.

To test it all you need to do is launch the `fastcapa-test-environment`.  Before this change it will fail.  After this change, it works.
```
cd metron-deployment/vagrant/fastcapa-test-environment
vagrant up
```

## Pull Request Checklist=
- [x] Is there a JIRA ticket associated with this PR?
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve?
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
