### PR TITLE
METRON-771 Stellar INDEXING_SET_BATCH incorrectly defaults batchSize to 5

### DIFF
--- a/metron-platform/metron-management/README.md
+++ b/metron-platform/metron-management/README.md
@@ -173,7 +173,7 @@ The functions are split roughly into a few sections:
   * Input:
     * sensorConfig - Sensor config to add transformation to.
     * writer - The writer to update (e.g. elasticsearch, solr or hdfs)
-    * size - batch size (integer)
+    * size - batch size (integer), defaults to 1, meaning batching disabled
   * Returns: The String representation of the config in zookeeper
 * `INDEXING_SET_ENABLED`
   * Description: Enable or disable an indexing writer for a sensor.

--- a/metron-platform/metron-management/src/main/java/org/apache/metron/management/IndexingConfigFunctions.java
+++ b/metron-platform/metron-management/src/main/java/org/apache/metron/management/IndexingConfigFunctions.java
@@ -42,7 +42,7 @@ public class IndexingConfigFunctions {
           ,description = "Set batch size"
           ,params = {"sensorConfig - Sensor config to add transformation to."
                     ,"writer - The writer to update (e.g. elasticsearch, solr or hdfs)"
-                    ,"size - batch size (integer)"
+                    ,"size - batch size (integer), defaults to 1, meaning batching disabled"
                     }
           ,returns = "The String representation of the config in zookeeper"
           )
@@ -69,9 +69,12 @@ public class IndexingConfigFunctions {
       if(writer == null) {
         throw new IllegalStateException("Invalid writer name: " + config);
       }
-      int batchSize = 5;
+      int batchSize = 1;
       if(args.size() > 2) {
         batchSize = ConversionUtils.convert(args.get(i++), Integer.class);
+        if (batchSize < 1) {
+          throw new IllegalArgumentException("Invalid batch size must be >= 1 : " + Integer.toString(batchSize));
+        }
       }
       configObj.put(writer, IndexingConfigurations.setBatchSize((Map<String, Object>) configObj.get(writer), batchSize));
       try {


### PR DESCRIPTION
Simple couple-line fix for the defaulting behavior.  The only non-comment line is changing the default from 5 to 1, and adding a validity check.  Found by inspection, and recommend checking the same.

If one is so inclined, you can do a before-and-after test by invoking
```
INDEXING_SET_BATCH('{}', 'hdfs')
```
in the REPL, leaving out the "size" argument (which is optional, even tho not documented as such).  Observe the returned JSON of the config, and see what the value of batchSize is.  Before this patch, it will be 5, after it will be 1.

BTW, with @cestella 's help, we figured out you can invoke the REPL from the build environment with these steps:
- build the whole project, eg with `mvn clean install -DskipTests`
- cd metron-platform/metron-common
- invoke:
```
java -cp ../metron-enrichment/target/metron-enrichment-0.3.1-uber.jar:../metron-data-management/target/metron-data-management-0.3.1.jar:target/metron-common-0.3.1.jar:../metron-management/target/metron-management-0.3.1.jar:../metron-parsers/target/metron-parsers-0.3.1-uber.jar org.apache.metron.common.stellar.shell.StellarShell
```

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron (Incubating).  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [NA] Have you written or updated unit tests and or integration tests to verify your changes?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [NA] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? 
