### PR TITLE
METRON-796: Mpack uses wrong group for owning HDFS directories

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/enrichment_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/enrichment_commands.py
@@ -111,7 +111,7 @@ class EnrichmentCommands:
                                    type="directory",
                                    action="create_on_execute",
                                    owner=self.__params.metron_user,
-                                   group=self.__params.metron_group,
+                                   group=self.__params.hadoop_group,
                                    mode=0775,
                                    )
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/indexing_commands.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/indexing_commands.py
@@ -101,7 +101,7 @@ class IndexingCommands:
                                    type="directory",
                                    action="create_on_execute",
                                    owner=self.__params.metron_user,
-                                   group=self.__params.metron_group,
+                                   group=self.__params.hadoop_group,
                                    mode=0775,
                                    )
         Logger.info('Done creating HDFS indexing directory')

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
@@ -75,6 +75,8 @@ else:
 
 # hadoop params
 stack_root = Script.get_stack_root()
+# This is the cluster group named 'hadoop'. Its membership is the stack process user ids not individual users.
+# The config name 'user_group' out of our control and a bit misleading, so it is renamed to 'hadoop_group'.
 hadoop_group = config['configurations']['cluster-env']['user_group']
 hadoop_home_dir = stack_select.get_hadoop_dir("home")
 hadoop_bin_dir = stack_select.get_hadoop_dir("bin")

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
@@ -39,7 +39,7 @@ config = Script.get_config()
 tmp_dir = Script.get_tmp_dir()
 
 hostname = config['hostname']
-metron_group = config['configurations']['cluster-env']['metron_group']
+hadoop_group = config['configurations']['cluster-env']['user_group']
 metron_home = status_params.metron_home
 parsers = status_params.parsers
 geoip_url = config['configurations']['metron-env']['geoip_url']

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
@@ -76,7 +76,7 @@ else:
 # hadoop params
 stack_root = Script.get_stack_root()
 # This is the cluster group named 'hadoop'. Its membership is the stack process user ids not individual users.
-# The config name 'user_group' out of our control and a bit misleading, so it is renamed to 'hadoop_group'.
+# The config name 'user_group' is out of our control and a bit misleading, so it is renamed to 'hadoop_group'.
 hadoop_group = config['configurations']['cluster-env']['user_group']
 hadoop_home_dir = stack_select.get_hadoop_dir("home")
 hadoop_bin_dir = stack_select.get_hadoop_dir("bin")

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/package/scripts/params/params_linux.py
@@ -39,7 +39,6 @@ config = Script.get_config()
 tmp_dir = Script.get_tmp_dir()
 
 hostname = config['hostname']
-hadoop_group = config['configurations']['cluster-env']['user_group']
 metron_home = status_params.metron_home
 parsers = status_params.parsers
 geoip_url = config['configurations']['metron-env']['geoip_url']
@@ -76,6 +75,7 @@ else:
 
 # hadoop params
 stack_root = Script.get_stack_root()
+hadoop_group = config['configurations']['cluster-env']['user_group']
 hadoop_home_dir = stack_select.get_hadoop_dir("home")
 hadoop_bin_dir = stack_select.get_hadoop_dir("bin")
 hadoop_conf_dir = conf_select.get_hadoop_conf_dir()


### PR DESCRIPTION
## Contributor Comments
Reverts the group owner of a couple HDFS directories to be the hadoop group, rather than the metron group (which is just metron).  Right now, the topologies run as the storm user (which belongs to the hadoop group), and therefore didn't have permission to write to HDFS (including in quick and full dev).  This sets HDFS ownership to metron:hadoop, which lets it be handled appropriately.

Other items, such as configs and installation files, were just left as the metron group.

To test, just run up a dev environment and ensure files are being written and ownership makes sense (/apps/metron/indexing/indexed is metron:hadoop with 755 perms).  The individual sensors will be owned by storm:hadoop (proving that writes work).

For example:
```
[vagrant@node1 ~]$ hdfs dfs -ls /apps/metron/indexing
Found 1 items
drwxrwxr-x   - metron hadoop          0 2017-03-24 12:57 /apps/metron/indexing/indexed
[vagrant@node1 ~]$ hdfs dfs -ls /apps/metron/indexing/indexed
Found 3 items
drwxrwxr-x   - storm hadoop          0 2017-03-24 13:01 /apps/metron/indexing/indexed/bro
drwxrwxr-x   - storm hadoop          0 2017-03-24 13:01 /apps/metron/indexing/indexed/error
drwxrwxr-x   - storm hadoop          0 2017-03-24 13:01 /apps/metron/indexing/indexed/snort
[vagrant@node1 ~]$ hdfs dfs -ls /apps/metron/indexing/indexed/bro
Found 1 items
-rw-r--r--   1 storm hadoop     211393 2017-03-24 13:01 /apps/metron/indexing/indexed/bro/enrichment-null-0-0-1490360489968.json
```

As a note, metron_group existed twice in params_linux.py, so only the first instance is changed to hadoop_group and pulled appropriately.  The second is left as-is.

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron (Incubating).  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommened that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.

