### PR TITLE
METRON-823 bro-plugin-kafka/README.md has Markdown usages not compatible with site-book

### DIFF
--- a/metron-sensors/bro-plugin-kafka/README.md
+++ b/metron-sensors/bro-plugin-kafka/README.md
@@ -13,28 +13,34 @@ library for Kafka.  This plugin has been tested against the latest release of
 librdkafka, which at the time of this writing is v0.9.4.  In order to support interacting
 with a kerberized kafka, you will need libsasl2 installed
 
-    # curl -L https://github.com/edenhill/librdkafka/archive/v0.9.4.tar.gz | tar xvz
-    # cd librdkafka-0.9.4/
-    # ./configure --enable-sasl
-    # make
-    # sudo make install
+```
+# curl -L https://github.com/edenhill/librdkafka/archive/v0.9.4.tar.gz | tar xvz
+# cd librdkafka-0.9.4/
+# ./configure --enable-sasl
+# make
+# sudo make install
+```
 
 Then compile this Bro plugin using the following commands.
 
-    # ./configure --bro-dist=$BRO_SRC
-    # make
-    # sudo make install
+```
+# ./configure --bro-dist=$BRO_SRC
+# make
+# sudo make install
+```
 
 Run the following command to ensure that the plugin was installed successfully.
 
-    # bro -N Bro::Kafka
-    Bro::Kafka - Writes logs to Kafka (dynamic, version 0.1)
+```
+# bro -N Bro::Kafka
+Bro::Kafka - Writes logs to Kafka (dynamic, version 0.1)
+```
 
 Activation
 ----------
 
 The easiest way to enable Kafka output is to load the plugin's
-``logs-to-kafka.bro`` script.  If you are using BroControl, the following lines
+`logs-to-kafka.bro` script.  If you are using BroControl, the following lines
 added to local.bro will activate it.
 
 ```
@@ -47,13 +53,13 @@ redef Kafka::kafka_conf = table(
 ```
 
 This example will send all HTTP, DNS, and Conn logs to a Kafka broker running on
-the localhost to a topic called ``bro``. Any configuration value accepted by
-librdkafka can be added to the ``kafka_conf`` configuration table.
+the localhost to a topic called `bro`. Any configuration value accepted by
+librdkafka can be added to the `kafka_conf` configuration table.
 
 Settings
 --------
 
-### ``kafka_conf``
+### `kafka_conf`
 
 The global configuration settings for Kafka.  These values are passed through
 directly to librdkafka.  Any valid librdkafka settings can be defined in this
@@ -67,7 +73,7 @@ redef Kafka::kafka_conf = table(
 );
 ```
 
-### ``topic_name``
+### `topic_name`
 
 The name of the topic in Kafka where all Bro logs will be sent to.
 
@@ -75,7 +81,7 @@ The name of the topic in Kafka where all Bro logs will be sent to.
 redef Kafka::topic_name = "bro";
 ```
 
-### ``max_wait_on_shutdown``
+### `max_wait_on_shutdown`
 
 The maximum number of milliseconds that the plugin will wait for any backlog of
 queued messages to be sent to Kafka before forced shutdown.
@@ -84,16 +90,16 @@ queued messages to be sent to Kafka before forced shutdown.
 redef Kafka::max_wait_on_shutdown = 3000;
 ```
 
-### ``tag_json``
+### `tag_json`
 
 If true, a log stream identifier is appended to each JSON-formatted message. For
-example, a Conn::LOG message will look like ``{ 'conn' : { ... }}``.
+example, a Conn::LOG message will look like `{ 'conn' : { ... }}`.
 
 ```
 redef Kafka::tag_json = T;
 ```
 
-### ``debug``
+### `debug`
 
 A comma separated list of debug contexts in librdkafka which you want to
 enable.  The available contexts are:


### PR DESCRIPTION
Current version of metron-sensors/bro-plugin-kafka/README.md has Markdown usages not compatible with site-book:
1. usages of code blocks by indenting without triple back-ticks.
2. usages of double back-tick, should be single.

It fails to run correctly with site-book/bin/generate-md.sh.

This patched version looks right in both Github-MD and doxia-markdown, and passes successfully through site-book/bin/generate-md.sh.

## Pull Request Checklist
### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

### For code changes: N/A

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  bin/generate-md.sh
  mvn site:site
  ```
