### PR TITLE
METRON-829 Use Fastcapa with Kerberos

### DIFF
--- a/metron-sensors/fastcapa/README.md
+++ b/metron-sensors/fastcapa/README.md
@@ -324,21 +324,11 @@ When running the probe some basic counters are output to stdout.  Of course duri
 
 The probe can be used in a Kerberized environment.  Follow these additional steps to use Fastcapa with Kerberos.  The following assumptions have been made.  These may need altered to fit your environment.
 
-* The Kafka broker is at "kafka1:6667"
-* Zookeeper is at "zookeeper1:2181"
-* The Kafka security protocol is "SASL_PLAINTEXT"
+* The Kafka broker is at `kafka1:6667`
+* Zookeeper is at `zookeeper1:2181`
+* The Kafka security protocol is `SASL_PLAINTEXT`
 * The keytab used is located at `/etc/security/keytabs/metron.headless.keytab`
-* The service principal is "metron@EXAMPLE.COM"
-
-1. Install [Cyrus SASL](http://www.cyrusimap.org/sasl/index.html#sasl-index).
-    ```
-    yum install -y cyrus-sasl cyrus-sasl-devel cyrus-sasl-gssapi
-    ```
-
-1. Kerberos is probably already installed.
-    ```
-    yum -y install krb5-server krb5-libs krb5-workstation
-    ```
+* The service principal is `metron@EXAMPLE.COM`
 
 1. Build Librdkafka with SASL support (` --enable-sasl`).
     ```
@@ -349,35 +339,22 @@ The probe can be used in a Kerberized environment.  Follow these additional step
     make install
     ```
 
-1. Validate Librdkafka does indeed support SASL.  Run the following command and ensure that SASL is returned.
+1. Validate Librdkafka does indeed support SASL.  Run the following command and ensure that `sasl` is returned as a built-in feature.
     ```
     $ examples/rdkafka_example -X builtin.features
     builtin.features = gzip,snappy,ssl,sasl,regex
     ```
 
-1. Create a JAAS configuration file at `~/.java.login.config`
+   If it is not, ensure that you have `libsasl` or `libsasl2` installed.  On CentOS, this can be installed with the following command.
     ```
-    $ cat ~/.java.login.config
-    KafkaClient {
-      com.sun.security.auth.module.Krb5LoginModule required
-      useTicketCache=false
-      useKeyTab=true
-      principal="metron@EXAMPLE.COM"
-      keyTab="/etc/security/keytabs/metron.headless.keytab"
-      renewTicket=true
-      debug=true
-      serviceName="kafka"
-      storeKey=true;
-    };
-    ```
-1. Let your Java environment know where it can find the JAAS configuration file.  Edit the file at `$JAVA_HOME/jre/lib/security/java.security` and add the line below.
-    ```
-    login.config.url.1=file:${user.home}/.java.login.config
+    yum install -y cyrus-sasl cyrus-sasl-devel cyrus-sasl-gssapi
     ```
 
-1. Grant access to your Kafka topic.  In this example, it is simply named "pcap".
+1. Grant access to your Kafka topic.  In this example, it is simply named `pcap`.
     ```
-    $KAFKA_HOME/bin/kafka-acls.sh --authorizer kafka.security.auth.SimpleAclAuthorizer --authorizer-properties zookeeper.connect=zookeeper1:2181 --add --allow-principal User:metron --topic pcap
+    $KAFKA_HOME/bin/kafka-acls.sh --authorizer kafka.security.auth.SimpleAclAuthorizer \
+      --authorizer-properties zookeeper.connect=zookeeper1:2181 \
+      --add --allow-principal User:metron --topic pcap
     ```
 
 1. Obtain a Kerberos ticket.

--- a/metron-sensors/fastcapa/README.md
+++ b/metron-sensors/fastcapa/README.md
@@ -322,7 +322,7 @@ When running the probe some basic counters are output to stdout.  Of course duri
 
 ### Kerberos
 
-The probe can be used in a Kerberized environment.  The following additional steps make the following assumptions about the Kerberized environment.  These assumptions may need altered to fit your environment.
+The probe can be used in a Kerberized environment.  Follow these additional steps to use Fastcapa with Kerberos.  The following assumptions have been made.  These may need altered to fit your environment.
 
 * The Kafka broker is at "kafka1:6667"
 * Zookeeper is at "zookeeper1:2181"


### PR DESCRIPTION
Yes, you can use Fastcapa with Kerberos with no code change.  I describe the entire process in the README.  

This PR is dependent on #509 which explains the extra commits that are currently visible.

## Pull Request Checklist
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
- [x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  bin/generate-md.sh
  mvn site:site
  ```



