### PR TITLE
METRON-634 Mpack bug fixes and improvements, not impacting Ambari database

### DIFF
--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-site.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-site.xml
@@ -24,7 +24,7 @@
     <property>
         <name>cluster_name</name>
         <value>metron</value>
-        <description>Cluster name identifies your cluster</description>
+        <description>Elasticsearch Cluster Name identifies your Elasticsearch subsystem</description>
     </property>
     <property>
         <name>masters_also_are_datanodes</name>
@@ -37,24 +37,24 @@
     <property>
         <name>zen_discovery_ping_unicast_hosts</name>
         <!--Ideally this gets populated by the list of master eligible nodes (as an acceptable default).  Unsure how to do this.-->
+        <!--Also need to document whether should list masters only, or all ES nodes. I think this one is all nodes, but previous inline comment said Masters.-->
         <value></value>
-        <description>Unicast discovery list of hosts to act as gossip routers, in comma separated format.</description>
+        <description>Unicast discovery list of hosts to act as gossip routers, in comma separated format: eshost1,eshost2</description>
     </property>
     <property>
         <name>index_number_of_shards</name>
         <value>4</value>
-        <description>Set the number of shards (splits) of an index</description>
+        <description>Set the number of shards (splits) of an index.  Changes are not effective after index creation. Usually set to 1 for single-node install.</description>
     </property>
     <property>
         <name>index_number_of_replicas</name>
         <value>2</value>
-        <description>Set the number of replicas (additional copies) of an index</description>
+        <description>Set the number of replicas (copies in addition to the first) of an index. Usually set to 0 for single-node install.</description>
     </property>
-    <!--  Logging Configurations -->
     <property>
         <name>path_data</name>
         <value>"/opt/lmm/es_data"</value>
-        <description>Path to directory where to store index data allocated for this node. e.g. "/mnt/first", "/mnt/second"</description>
+        <description>Comma-separated list of directories where to store index data allocated for each node: "/mnt/first","/mnt/second".  Number of paths should relate to number of shards, and preferably should be on separate physical volumes.</description>
     </property>
     <property>
         <name>http_cors_enabled</name>
@@ -64,22 +64,21 @@
             <type>string</type>
         </value-attributes>
     </property>
-    <!--  Discovery -->
-    <property>
-        <name>transport_tcp_port</name>
-        <value>9300-9400</value>
-        <description>Set a custom port for the node to node communication</description>
-    </property>
     <property>
         <name>http_port</name>
         <value>9200-9300</value>
         <description>Set a custom port to listen for HTTP traffic</description>
     </property>
-    <!--  Discovery -->
+    <property>
+        <name>transport_tcp_port</name>
+        <value>9300-9400</value>
+        <description>Set a custom port for the node to node communication</description>
+    </property>
+    <!--  Multi-node Discovery -->
     <property>
         <name>discovery_zen_ping_multicast_enabled</name>
         <value>false</value>
-        <description>master eligible nodes</description>
+        <description>Whether to use multicast</description>
     </property>
     <property>
         <name>discovery_zen_ping_timeout</name>
@@ -190,7 +189,7 @@
     </property>
     <property>
         <name>network_host</name>
-        <value>_lo_,_eth0_</value>
-        <description>Network interface(s) will bind to. </description>
+        <value>"_lo:ipv4_","_eth0:ipv4_"</value>
+        <description>Network interface(s) ES will bind to within each node. Confirm names via ifconfig.  Should have entries for primary external and loopback interfaces, with :ipv4 annotation and quote marks around each entry: "_lo:ipv4_","_eth0:ipv4_"</description>
     </property>
 </configuration>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-sysconfig.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-sysconfig.xml
@@ -58,7 +58,7 @@
     <!--/etc/sysconfig/elasticsearch-->
     <property>
         <name>content</name>
-        <description>This is the jinja template for elastic-env.sh file</description>
+        <description>This is the jinja template for elastic sysconfig file (/etc/sysconfig/elasticsearch)</description>
         <value>
 # Directory where the Elasticsearch binary distribution resides
 ES_HOME={{elastic_home}}
@@ -88,6 +88,12 @@ CONF_DIR={{conf_dir}}
 # Also make sure, this user can write into the log directories in case you change them
 # This setting only works for the init script, but has to be configured separately for systemd startup
 ES_USER={{elastic_user}}
+
+# Elasticsearch pid directory
+PID_DIR={{pid_dir}}
+
+# JAVA_HOME must be provided here for OS that use systemd service launch
+JAVA_HOME={{java64_home}}
 
 # Additional Java OPTS
 ES_JAVA_OPTS="-verbose:gc -Xloggc:{{log_dir}}/elasticsearch_gc.log -XX:-CMSConcurrentMTEnabled \

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/metainfo.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/metainfo.xml
@@ -68,6 +68,12 @@
                 <config-type>elastic-sysconfig</config-type>
             </configuration-dependencies>
             <restartRequiredAfterChange>true</restartRequiredAfterChange>
+            <quickLinksConfigurations>
+                <quickLinksConfiguration>
+                    <fileName>quicklinks.json</fileName>
+                    <default>true</default>
+                </quickLinksConfiguration>
+            </quickLinksConfigurations>
         </service>
     </services>
 </metainfo>

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic.py
@@ -33,7 +33,7 @@ def elastic():
     data_path[:] = [x.replace('"', '') for x in data_path]
 
     directories = [params.log_dir, params.pid_dir, params.conf_dir]
-    directories = directories + data_path
+    directories = directories + data_path + ["{0}/scripts".format(params.conf_dir)]
 
     Directory(directories,
               create_parents=True,
@@ -57,11 +57,11 @@ def elastic():
              "elasticsearch.master.yaml.j2",
              configurations=configurations),
          owner=params.elastic_user,
-         group=params.elastic_user
+         group=params.elastic_group
          )
 
     print "Master sysconfig: /etc/sysconfig/elasticsearch"
-    File(format("/etc/sysconfig/elasticsearch"),
+    File("/etc/sysconfig/elasticsearch",
          owner="root",
          group="root",
          content=InlineTemplate(params.sysconfig_template)

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic_master.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic_master.py
@@ -40,7 +40,7 @@ class Elasticsearch(Script):
     def stop(self, env, upgrade_type=None):
         import params
         env.set_params(params)
-        stop_cmd = format("service elasticsearch stop")
+        stop_cmd = "service elasticsearch stop"
         print 'Stop the Master'
         Execute(stop_cmd)
 
@@ -49,14 +49,14 @@ class Elasticsearch(Script):
         env.set_params(params)
 
         self.configure(env)
-        start_cmd = format("service elasticsearch start")
+        start_cmd = "service elasticsearch start"
         print 'Start the Master'
         Execute(start_cmd)
 
     def status(self, env):
         import params
         env.set_params(params)
-        status_cmd = format("service elasticsearch status")
+        status_cmd = "service elasticsearch status"
         print 'Status of the Master'
         Execute(status_cmd)
 
@@ -64,7 +64,7 @@ class Elasticsearch(Script):
         import params
         env.set_params(params)
         self.configure(env)
-        restart_cmd = format("service elasticsearch restart")
+        restart_cmd = "service elasticsearch restart"
         print 'Restarting the Master'
         Execute(restart_cmd)
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic_slave.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic_slave.py
@@ -39,7 +39,7 @@ class Elasticsearch(Script):
     def stop(self, env, upgrade_type=None):
         import params
         env.set_params(params)
-        stop_cmd = format("service elasticsearch stop")
+        stop_cmd = "service elasticsearch stop"
         print 'Stop the Slave'
         Execute(stop_cmd)
 
@@ -47,14 +47,14 @@ class Elasticsearch(Script):
         import params
         env.set_params(params)
         self.configure(env)
-        start_cmd = format("service elasticsearch start")
+        start_cmd = "service elasticsearch start"
         print 'Start the Slave'
         Execute(start_cmd)
 
     def status(self, env):
         import params
         env.set_params(params)
-        status_cmd = format("service elasticsearch status")
+        status_cmd = "service elasticsearch status"
         print 'Status of the Slave'
         Execute(status_cmd)
 
@@ -62,7 +62,7 @@ class Elasticsearch(Script):
         import params
         env.set_params(params)
         self.configure(env)
-        restart_cmd = format("service elasticsearch restart")
+        restart_cmd = "service elasticsearch restart"
         print 'Restarting the Slave'
         Execute(restart_cmd)
 

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/params.py
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/params.py
@@ -35,8 +35,8 @@ max_map_count = config['configurations']['elastic-sysconfig']['max_map_count']
 elastic_user = config['configurations']['elastic-env']['elastic_user']
 elastic_group = config['configurations']['elastic-env']['elastic_group']
 log_dir = config['configurations']['elastic-env']['elastic_log_dir']
-pid_dir = '/var/run/elasticsearch'
-pid_file = '/var/run/elasticsearch/elasticsearch.pid'
+pid_dir = config['configurations']['elastic-env']['elastic_pid_dir']
+
 hostname = config['hostname']
 java64_home = config['hostLevelParams']['java_home']
 elastic_env_sh_template = config['configurations']['elastic-env']['content']

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/quicklinks/quicklinks.json
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/quicklinks/quicklinks.json
@@ -1,0 +1,43 @@
+{
+  "name": "default",
+  "description": "default quick links configuration",
+  "configuration": {
+    "protocol":
+    {
+      "type":"HTTP_ONLY"
+    },
+
+    "links": [
+      {
+        "name": "es_health_link",
+        "label": "Elasticsearch Health",
+        "requires_user_name": "false",
+        "component_name": "ES_MASTER",
+        "url":"%@://%@:%@/_cat/health?v",
+        "port":{
+          "http_property": "http_port",
+          "http_default_port": "9200",
+          "https_property": "http_port",
+          "https_default_port": "9200",
+          "regex": "^(\\d+)",
+          "site": "elastic-site"
+        }
+      },
+      {
+        "name": "es_indices_link",
+        "label": "Elasticsearch Indexes",
+        "requires_user_name": "false",
+        "component_name": "ES_MASTER",
+        "url":"%@://%@:%@/_cat/indices?v",
+        "port":{
+          "http_property": "http_port",
+          "http_default_port": "9200",
+          "https_property": "http_port",
+          "https_default_port": "9200",
+          "regex": "^(\\d+)",
+          "site": "elastic-site"
+        }
+      }
+    ]
+  }
+}

--- a/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-env.xml
+++ b/metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-env.xml
@@ -97,7 +97,7 @@
     <property require-input="true">
         <name>es_hosts</name>
         <value></value>
-        <description>Comma delimited list of Elasticsearch Hosts. (eshost1,eshost2)</description>
+        <description>Comma delimited list of Elasticsearch Master Hosts: eshost1,eshost2</description>
         <display-name>Elasticsearch Hosts</display-name>
     </property>
     <property>


### PR DESCRIPTION
These changes fix the following significant bugs:
* metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-sysconfig.xml
  * Fixes necessary for Centos7: PID_DIR and JAVA_HOME added for systemd launch
* metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic.py
  * fix permissions on scripts directory
  * fix elastic_group usage (missed one in previous patch)
  * remove incorrect and spurious use of undefined format() method
* metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic_master.py
* metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/elastic_slave.py
  * remove incorrect and spurious uses of undefined format() method
* metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-site.xml
  * Fix default value of "network_host" (ie network binding names), which breaks in some envs

Also the following minor issue corrections and description/comment improvements are made:
* metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/package/scripts/params.py
  * fix incorrect override of pid_dir and pid_file, which are correctly defined in elastic-env.xml and ELASTICSEARCH status_params.py
* metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/metainfo.xml
* metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/quicklinks/quicklinks.json
  * Add quicklinks to Elastic page in Ambari, for ES health status page and indexes list page; very useful for debugging the install.
* metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/ELASTICSEARCH/2.3.3/configuration/elastic-site.xml
* metron-deployment/packaging/ambari/metron-mpack/src/main/resources/common-services/METRON/CURRENT/configuration/metron-env.xml
  * Non-substantive changes to descriptions or comments, meant to improve usability.
  * Also an ordering change and add newline at end of file.

These fixes are only the first half of METRON-634.  The second half cause changes to the Ambari database, and therefore require an update script.  These will be done in a separate PR, when I have time to do it.  The changes here are stand-alone improvements.

## Contributor Comments
These issues were worked out over several weeks of working with Mpack on Centos7, and documented in METRON-634.  @dlyle65535 adopted some into the Ansible work, but most remain to be done.

They have been tested manually, and through a full run of integration test.  If you are running Centos7, you will only notice the bug fixes as smoother startup of Elasticsearch.

The description improvements make it easier for manual users of Mpack Ambari install.

## Pull Request Checklist

In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
  - The issues were not noticed by most users anyway.  Recommend that developers familiar with the guts of Mpack review the changes by inspection.
- [x] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [NA] Have you written or updated unit tests and or integration tests to verify your changes?
- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [NA] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? 
