### PR TITLE
METRON-857 Ability to completely build project in single Docker Image

### DIFF
--- a/metron-deployment/packaging/docker/ansible-docker/Dockerfile
+++ b/metron-deployment/packaging/docker/ansible-docker/Dockerfile
@@ -21,10 +21,10 @@ RUN yum install -y tar
 RUN yum install -y wget
 RUN yum groupinstall -y "Development tools"
 RUN yum install -y zlib-dev openssl-devel sqlite-devel bzip2-devel libffi-devel
-RUN wget https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz -O /usr/src/Python-2.7.10.tgz
+RUN wget https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz -O /usr/src/Python-2.7.12.tgz
 WORKDIR /usr/src
-RUN tar xvf Python-2.7.10.tgz
-WORKDIR /usr/src/Python-2.7.10
+RUN tar xvf Python-2.7.12.tgz
+WORKDIR /usr/src/Python-2.7.12
 RUN ./configure
 RUN make altinstall
 WORKDIR /usr/src
@@ -45,5 +45,6 @@ RUN wget http://apache.cs.utah.edu/maven/maven-3/3.2.5/binaries/apache-maven-3.2
 RUN tar xzvf apache-maven-3.2.5-bin.tar.gz
 RUN mv apache-maven-3.2.5 /opt/maven
 RUN ln -s /opt/maven/bin/mvn /usr/bin/mvn
+RUN yum -y install asciidoc rpm-build rpm2cpio tar unzip xmlto zip rpmlint && yum clean all
 WORKDIR /root
 

--- a/metron-deployment/packaging/docker/ansible-docker/Dockerfile
+++ b/metron-deployment/packaging/docker/ansible-docker/Dockerfile
@@ -21,10 +21,10 @@ RUN yum install -y tar
 RUN yum install -y wget
 RUN yum groupinstall -y "Development tools"
 RUN yum install -y zlib-dev openssl-devel sqlite-devel bzip2-devel libffi-devel
-RUN wget https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz -O /usr/src/Python-2.7.12.tgz
+RUN wget https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz -O /usr/src/Python-2.7.11.tgz
 WORKDIR /usr/src
-RUN tar xvf Python-2.7.12.tgz
-WORKDIR /usr/src/Python-2.7.12
+RUN tar xvf Python-2.7.11.tgz
+WORKDIR /usr/src/Python-2.7.11
 RUN ./configure
 RUN make altinstall
 WORKDIR /usr/src

--- a/metron-deployment/packaging/docker/ansible-docker/Dockerfile
+++ b/metron-deployment/packaging/docker/ansible-docker/Dockerfile
@@ -41,9 +41,9 @@ RUN yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel
 RUN yum install -y which
 RUN yum install -y nss
 WORKDIR /usr/src
-RUN wget http://apache.cs.utah.edu/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz
-RUN tar xzvf apache-maven-3.2.5-bin.tar.gz
-RUN mv apache-maven-3.2.5 /opt/maven
+RUN wget http://apache.cs.utah.edu/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
+RUN tar xzvf apache-maven-3.3.9-bin.tar.gz
+RUN mv apache-maven-3.3.9 /opt/maven
 RUN ln -s /opt/maven/bin/mvn /usr/bin/mvn
 RUN yum -y install asciidoc rpm-build rpm2cpio tar unzip xmlto zip rpmlint && yum clean all
 WORKDIR /root

--- a/metron-deployment/packaging/docker/ansible-docker/Dockerfile
+++ b/metron-deployment/packaging/docker/ansible-docker/Dockerfile
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-FROM centos:6.6
+FROM centos:centos6
 MAINTAINER Apache Metron
 
 RUN yum install -y tar

--- a/metron-deployment/packaging/docker/rpm-docker/pom.xml
+++ b/metron-deployment/packaging/docker/rpm-docker/pom.xml
@@ -89,50 +89,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.5.0</version>
-                <executions>
-                    <execution>
-                        <id>docker-build</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>docker</executable>
-                            <arguments>
-                                <argument>build</argument>
-                                <argument>-f</argument>
-                                <argument>Dockerfile</argument>
-                                <argument>-t</argument>
-                                <argument>${rpm.docker.tag}</argument>
-                                <argument>.</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>rpm-build</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>docker</executable>
-                            <arguments>
-                                <argument>run</argument>
-                                <argument>-v</argument>
-                                <argument>${project.basedir}:/root</argument>
-                                <argument>${rpm.docker.tag}:latest</argument>
-                                <argument>/bin/bash</argument>
-                                <argument>-c</argument>
-                                <argument>./build.sh ${project.version}</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>
@@ -227,4 +183,97 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>InDocker</id>
+            <activation>
+                <file>
+                    <!-- If this file exists, then we are running in docker already -->
+                    <exists>/.dockerenv</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>rpm-build</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>/bin/bash</executable>
+                                    <arguments>
+                                        <argument>-c</argument>
+                                        <argument>./build.sh ${project.version}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>NeedsDocker</id>
+            <activation>
+                <file>
+                    <!-- if this file doesn't exist, then we need to run docker -->
+                    <missing>/.dockerenv</missing>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>docker-build</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>docker</executable>
+                                    <arguments>
+                                        <argument>build</argument>
+                                        <argument>-f</argument>
+                                        <argument>Dockerfile</argument>
+                                        <argument>-t</argument>
+                                        <argument>${rpm.docker.tag}</argument>
+                                        <argument>.</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>rpm-build</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>docker</executable>
+                                    <arguments>
+                                        <argument>run</argument>
+                                        <argument>-v</argument>
+                                        <argument>${project.basedir}:/root</argument>
+                                        <argument>${rpm.docker.tag}:latest</argument>
+                                        <argument>/bin/bash</argument>
+                                        <argument>-c</argument>
+                                        <argument>./build.sh ${project.version}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Contributor Comments

Before ambari integration, we had the ability to use the ansible docker image to build and deploy metron, and a workflow around that.

With the ambari integration and required rpm-docker build stage that was lost.

This PR makes the necessary changes such that metron can be built either in the ansible docker image ( including building the build-rpms profile ) or as currently documented ( only spawning docker when building -P build-rpms ).

To do this, two profiles, with automatic activation where created, each with the correct maven execute task for the environment.  If we are in docker already, we just execute the script, if we are not, we execute docker.

To test this (docker must be running of course ): 
Build the product normally, and build the rpms 

```
$>cd incubator-metron
$>mvn clean install -D skipTests
$>cd metron-deployment
$> mvn clean package -P build-rpms
```

This should work normally. You should see the RPMS user rpm-docker/RPMS/noarch/

Then
```
$>mvn clean
$>cd ..
$>mvn clean
$>cd metron-deployment/packaging/docker/ansible-docker
$>docker build -t ansible-docker:2.0.0.2 .
$>docker run -it -v {PATH-TO-METRON}/incubator-metron/:/root/incubator-metron ansible-docker:2.0.0.2 bash
$docker>cd incubator-metron
$docker>mvn clean install -DskipTests
$docker>cd metron-deployment
$docker>mvn clean package -P build-rpms
```

As before you should see the rpms. 

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron (Incubating).  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [ x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x ] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x ] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ x] Have you included steps or a guide to how the change may be verified and tested manually?
- [x ] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  bin/generate-md.sh
  mvn site:site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
