### PR TITLE
METRON-866 Quickdev and Fulldev readme misses Docker as prerequisite

### DIFF
--- a/metron-deployment/vagrant/full-dev-platform/README.md
+++ b/metron-deployment/vagrant/full-dev-platform/README.md
@@ -37,13 +37,6 @@ Any platform that supports these tools is suitable, but the following instructio
 
 ### Deploy Metron
 
-1. Build Metron
-
-    ```
-    cd incubator-metron
-    mvn clean install -DskipTests
-    ```
-
 1. Ensure that the Docker service is running.
 
 1. Deploy Metron

--- a/metron-deployment/vagrant/full-dev-platform/README.md
+++ b/metron-deployment/vagrant/full-dev-platform/README.md
@@ -13,7 +13,9 @@ Getting Started
 The computer used to deploy Apache Metron will need to have the following components installed.
 
  - [Ansible](https://github.com/ansible/ansible) (2.0.0.2 or 2.2.2.0)
+ - [Docker](https://www.docker.com/community-edition)
  - [Vagrant](https://www.vagrantup.com) 1.8.1
+ - [Vagrant Hostmanager Plugin](https://github.com/devopsgroup-io/vagrant-hostmanager) `vagrant plugin install vagrant-hostmanager`
  - [Virtualbox](https://virtualbox.org) 5.0.16
  - Python 2.7.11
  - Maven 3.3.9
@@ -24,35 +26,38 @@ Any platform that supports these tools is suitable, but the following instructio
 
 1. Install Homebrew by following the instructions at [Homebrew](http://brew.sh/).
 
-2. Run the following command in a terminal to install all of the required tools.
+1. Run the following command in a terminal to install all of the required tools.
 
-  ```  
-  brew cask install vagrant virtualbox java
-  brew install maven git
-  ```
+    ```  
+    brew cask install vagrant virtualbox java docker
+    brew install maven git
+    ```
 
-3. Install Ansible by following the instructions [here](http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-pip).
+1. Install Ansible by following the instructions [here](http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-pip).
 
 ### Deploy Metron
 
-1. Install Vagrant Hostmanager.
+1. Build Metron
 
-  ```
-  vagrant plugin install vagrant-hostmanager
-  ```
+    ```
+    cd incubator-metron
+    mvn clean install -DskipTests
+    ```
 
-2. Deploy Metron
+1. Ensure that the Docker service is running.
 
-  ```
-  cd metron-deployment/vagrant/full-dev-platform
-  vagrant up
-  ```
+1. Deploy Metron
 
-  Should the process fail before completing the deployment, the following command will continue the deployment process without re-instantiating the host.
+    ```
+    cd metron-deployment/vagrant/full-dev-platform
+    vagrant up
+    ```
 
-  ```
-  vagrant provision
-  ```
+    Should the process fail before completing the deployment, the following command will continue the deployment process without re-instantiating the host.
+
+    ```
+    vagrant provision
+    ```
 
 ### Explore Metron
 

--- a/metron-deployment/vagrant/quick-dev-platform/README.md
+++ b/metron-deployment/vagrant/quick-dev-platform/README.md
@@ -15,38 +15,51 @@ Getting Started
 As with the Full Development Platform (`metron-deployment/vagrant/full-dev-platform`), the computer used to deploy Apache Metron will need the following components installed.
 
  - [Ansible](https://github.com/ansible/ansible) (2.0.0.2 or 2.2.2.0)
+ - [Docker](https://www.docker.com/community-edition)
  - [Vagrant](https://www.vagrantup.com) 1.8.1
+ - [Vagrant Hostmanager Plugin](https://github.com/devopsgroup-io/vagrant-hostmanager) `vagrant plugin install vagrant-hostmanager`
  - [Virtualbox](https://virtualbox.org) 5.0.16
  - Python 2.7.11
  - Maven 3.3.9
+
+#### macOS
+
+ Any platform that supports these tools is suitable, but the following instructions cover installation on macOS.  The easiest means of installing these tools on a Mac is to use the excellent [Homebrew](http://brew.sh/) project.
+
+ 1. Install Homebrew by following the instructions at [Homebrew](http://brew.sh/).
+
+ 1. Run the following command in a terminal to install all of the required tools.
+
+     ```  
+     brew cask install vagrant virtualbox java docker
+     brew install maven git
+     ```
+
+ 1. Install Ansible by following the instructions [here](http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-pip).
 
 ### Deploy Metron
 
 1. Build Metron
 
-  ```
-  cd incubator-metron
-  mvn clean package -DskipTests
-  ```
+    ```
+    cd incubator-metron
+    mvn clean install -DskipTests
+    ```
 
-2. Install Vagrant Hostmanager.
+1. Ensure that the Docker service is running.
 
-  ```
-  vagrant plugin install vagrant-hostmanager
-  ```
+1. Deploy Metron
 
-3. Deploy Metron
+    ```
+    cd metron-deployment/vagrant/quick-dev-platform
+    vagrant up
+    ```
 
-  ```
-  cd metron-deployment/vagrant/quick-dev-platform
-  vagrant up
-  ```
+    Should the process fail before completing the deployment, the following command will continue the deployment process without re-instantiating the host.
 
-  Should the process fail before completing the deployment, the following command will continue the deployment process without re-instantiating the host.
-
-  ```
-  vagrant provision
-  ```
+    ```
+    vagrant provision
+    ```
 
 ### Explore Metron
 

--- a/metron-deployment/vagrant/quick-dev-platform/README.md
+++ b/metron-deployment/vagrant/quick-dev-platform/README.md
@@ -39,13 +39,6 @@ As with the Full Development Platform (`metron-deployment/vagrant/full-dev-platf
 
 ### Deploy Metron
 
-1. Build Metron
-
-    ```
-    cd incubator-metron
-    mvn clean install -DskipTests
-    ```
-
 1. Ensure that the Docker service is running.
 
 1. Deploy Metron


### PR DESCRIPTION
Updates to the README instructions for both "Quick Dev" and "Full Dev".  This adds "Docker" as a prerequisite, provides simple linkage/instructions, and also prompts the user to ensure that the Docker Service is running before trying to deploy Metron.

## Pull Request Checklist

- [X] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [X] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [X] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  bin/generate-md.sh
  mvn site:site
  ```


