### PR TITLE
METRON-857 FIX: Full_Dev regression: use the profiles to inject the package phase resource copy

### DIFF
--- a/metron-deployment/packaging/docker/rpm-docker/pom.xml
+++ b/metron-deployment/packaging/docker/rpm-docker/pom.xml
@@ -164,21 +164,6 @@
                             </resources>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>copy-rpms-target</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.basedir}/target/RPMS</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>RPMS</directory>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
         </plugins>
@@ -211,6 +196,27 @@
                                         <argument>-c</argument>
                                         <argument>./build.sh ${project.version}</argument>
                                     </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>copy-rpms-target</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.basedir}/target/RPMS</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>RPMS</directory>
+                                        </resource>
+                                    </resources>
                                 </configuration>
                             </execution>
                         </executions>
@@ -268,6 +274,27 @@
                                         <argument>-c</argument>
                                         <argument>./build.sh ${project.version}</argument>
                                     </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>copy-rpms-target</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.basedir}/target/RPMS</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>RPMS</directory>
+                                        </resource>
+                                    </resources>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
## Contributor Comments
First, I am very sorry to have broken Full_Dev.

I believe the issue is the order of execution within the package phase when using profiles to inject executions.

Simliar to : 
http://stackoverflow.com/questions/22150209/maven-changes-the-order-of-plugins-of-different-profiles
https://issues.apache.org/jira/browse/MNG-2258

To address this, I have injected the copy execution as well as the execute plugin in the profile.  I believe doing this will maintain the correct order, and in my testing spinning up Full Dev a few times it has.

This is building in travis as we speak, but I'm posting the PR to get this tested by someone else and reviewed asap.

###Testing
- spin up full dev
- verify that it installs
- vagrant ssh & ls /localrepo to verify the rpms are deployed

## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [ x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [ x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x ] Have you included steps or a guide to how the change may be verified and tested manually?
- [in progress ] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [NA ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ x] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ x] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  bin/generate-md.sh
  mvn site:site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
