### PR TITLE
METRON-931: Stellar REDUCE incorrectly returns null for fewer than 3 items in list

### DIFF
--- a/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/FunctionalFunctions.java
+++ b/metron-platform/metron-common/src/main/java/org/apache/metron/common/dsl/functions/FunctionalFunctions.java
@@ -94,7 +94,7 @@ public class FunctionalFunctions {
     @Override
     public Object apply(List<Object> args) {
       List<Object> input = (List<Object>) args.get(0);
-      if(input == null || input.size() < 3) {
+      if(input == null || args.size() < 3) {
         return null;
       }
       LambdaExpression expression = (LambdaExpression) args.get(1);

--- a/metron-platform/metron-common/src/test/java/org/apache/metron/common/dsl/functions/FunctionalFunctionsTest.java
+++ b/metron-platform/metron-common/src/test/java/org/apache/metron/common/dsl/functions/FunctionalFunctionsTest.java
@@ -20,6 +20,7 @@ package org.apache.metron.common.dsl.functions;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -205,8 +206,8 @@ public class FunctionalFunctionsTest {
 
   @Test
   public void testReduce() {
-    for (String expr : ImmutableList.of("REDUCE([ 1, 2, 3], (x, y) -> x + y , 0 )"
-                                       ,"REDUCE([ foo, bar, 3], (x, y) -> x + y , 0 )"
+    for (String expr : ImmutableList.of("REDUCE([ 1, 2, 3 ], (x, y) -> x + y , 0 )"
+                                       ,"REDUCE([ foo, bar, 3 ], (x, y) -> x + y , 0 )"
                                        )
         )
     {
@@ -214,6 +215,31 @@ public class FunctionalFunctionsTest {
       Assert.assertTrue(o instanceof Number);
       Number result = (Number) o;
       Assert.assertEquals(6, result.intValue());
+    }
+  }
+
+  @Test
+  public void testReduce_on_various_list_sizes() {
+    {
+      String expr = "REDUCE([ 1, 2, 3, 4 ], (x, y) -> x + y , 0 )";
+      Object o = run(expr, ImmutableMap.of());
+      Assert.assertTrue(o instanceof Number);
+      Number result = (Number) o;
+      Assert.assertEquals(10, result.intValue());
+    }
+    {
+      String expr = "REDUCE([ 1, 2 ], (x, y) -> x + y , 0 )";
+      Object o = run(expr, ImmutableMap.of());
+      Assert.assertTrue(o instanceof Number);
+      Number result = (Number) o;
+      Assert.assertEquals(3, result.intValue());
+    }
+    {
+      String expr = "REDUCE([ 1 ], (x, y) -> x + y , 0 )";
+      Object o = run(expr, ImmutableMap.of());
+      Assert.assertTrue(o instanceof Number);
+      Number result = (Number) o;
+      Assert.assertEquals(1, result.intValue());
     }
   }
 
@@ -232,4 +258,17 @@ public class FunctionalFunctionsTest {
       Assert.assertEquals("grok", result.get(2));
     }
   }
+
+  @Test
+  public void testReduce_returns_null_when_less_than_3_args() {
+    {
+      String expr = "REDUCE([ 1, 2, 3 ], (x, y) -> LIST_ADD(x, y))";
+      Assert.assertThat(run(expr, ImmutableMap.of()), CoreMatchers.equalTo(null));
+    }
+    {
+      String expr = "REDUCE([ 1, 2, 3 ])";
+      Assert.assertThat(run(expr, ImmutableMap.of()), CoreMatchers.equalTo(null));
+    }
+  }
+
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/METRON-931

Reduce was checking input.size() instead of args.size(). The input var is the first arg to the reduce function, so it was returning null if fewer than 3 items existed in the list. I've corrected the function to return null if the number of arguments to the function itself is fewer than the expected 3.

A simple set of unit tests has been added. This can also be manually tested by starting the Stellar REPL and testing that the following calls do not return null:
```
h1 := REDUCE(['foo', 'bar'], (s, x) -> HLLP_ADD(s, x), HLLP_INIT(5, 6))
s1 := REDUCE([1,2], (s, x) -> STATS_ADD(s, x), STATS_INIT())
```

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel). 
- [x] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [x] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [x] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root incubating-metron folder via:
  ```
  mvn -q clean integration-test install && build_utils/verify_licenses.sh 
  ```

- [x] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?
